### PR TITLE
Add Terraform configuration for staging CLI

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -31,7 +31,7 @@ $ export DB_AWS_ECR_ENDPOINT=123456789012.dkr.ecr.us-east-1.amazonaws.com
 $ ./scripts/cibuild
 ...
 Successfully built 20dcf93f6907
-Successfully tagged district-builder-server:a476b78
+Successfully tagged districtbuilder:a476b78
 $ ./scripts/cipublish
 ...
 ```

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -1,0 +1,64 @@
+#
+# Security Group Resources
+#
+resource "aws_security_group" "app" {
+  name   = "sg${var.environment}AppEcsService"
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sg${var.environment}AppEcsService",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+#
+# ECS Resources
+#
+resource "aws_ecs_cluster" "app" {
+  name = "ecs${var.environment}Cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_task_definition" "app_cli" {
+  family                   = "${var.environment}AppCLI"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_app_cli_cpu
+  memory                   = var.fargate_app_cli_memory
+
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = templatefile("${path.module}/task-definitions/app_cli.json.tmpl", {
+    image = "${module.ecr_cli.repository_url}:${var.image_tag}"
+
+    postgres_host     = aws_route53_record.database.name
+    postgres_port     = module.database.port
+    postgres_user     = var.rds_database_username
+    postgres_password = var.rds_database_password
+    postgres_db       = var.rds_database_name
+
+    project     = var.project
+    environment = var.environment
+    aws_region  = var.aws_region
+  })
+
+  tags = {
+    Name        = "${var.environment}AppCLI",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+#
+# CloudWatch Resources
+#
+resource "aws_cloudwatch_log_group" "app_cli" {
+  name              = "log${var.environment}AppCLI"
+  retention_in_days = 30
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -33,3 +33,36 @@ resource "aws_security_group_rule" "rds_bastion_ingress" {
   security_group_id        = module.database.database_security_group_id
   source_security_group_id = module.vpc.bastion_security_group_id
 }
+
+resource "aws_security_group_rule" "rds_ecs_ingress" {
+  type      = "ingress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.database.database_security_group_id
+  source_security_group_id = aws_security_group.app.id
+}
+
+#
+# ECS security group resources
+#
+resource "aws_security_group_rule" "ecs_https_egress" {
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.app.id
+}
+
+resource "aws_security_group_rule" "ecs_rds_egress" {
+  type      = "egress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.app.id
+  source_security_group_id = module.database.database_security_group_id
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -1,0 +1,32 @@
+#
+# ECS IAM resources
+#
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "ecs${var.environment}TaskExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "ecs${var.environment}TaskRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = var.aws_ecs_task_execution_role_policy_arn
+}

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,13 @@
+module "ecr" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=1.0.0"
+
+  repository_name         = lower(var.project)
+  attach_lifecycle_policy = true
+}
+
+module "ecr_cli" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=1.0.0"
+
+  repository_name         = "${lower(var.project)}-manage"
+  attach_lifecycle_policy = true
+}

--- a/deployment/terraform/task-definitions/app_cli.json.tmpl
+++ b/deployment/terraform/task-definitions/app_cli.json.tmpl
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "app-cli",
+    "image": "${image}",
+    "cpu": 0,
+    "essential": true,
+    "entryPoint": [
+      "./bin/run"
+    ],
+    "environment": [
+      {
+        "name": "POSTGRES_HOST",
+        "value": "${postgres_host}"
+      },
+      {
+        "name": "POSTGRES_PORT",
+        "value": "${postgres_port}"
+      },
+      {
+        "name": "POSTGRES_USER",
+        "value": "${postgres_user}"
+      },
+      {
+        "name": "POSTGRES_PASSWORD",
+        "value": "${postgres_password}"
+      },
+      {
+        "name": "POSTGRES_DB",
+        "value": "${postgres_db}"
+      }
+    ],
+    "mountPoints": [],
+    "portMappings": [],
+    "volumesFrom": [],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "log${environment}AppCLI",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "${lower(project)}-app-cli"
+      }
+    }
+  }
+]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -214,3 +214,21 @@ variable "rds_cpu_credit_balance_threshold" {
   default = "30"
   type    = string
 }
+
+variable "image_tag" {
+   type = string
+ }
+
+ variable "fargate_app_cli_cpu" {
+   type = number
+ }
+
+ variable "fargate_app_cli_memory" {
+   type = number
+ }
+
+ variable "aws_ecs_task_execution_role_policy_arn" {
+   default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+   type    = string
+ }
+ 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   server:
-    image: "district-builder-server:${GIT_COMMIT:-latest}"
+    image: "districtbuilder:${GIT_COMMIT:-latest}"
 
   shellcheck:
     image: koalaman/shellcheck:stable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       retries: 3
 
   server:
-    image: district-builder-server
+    image: districtbuilder
     environment:
       - POSTGRES_HOST=database
       - POSTGRES_PORT=5432
@@ -53,7 +53,7 @@ services:
     command: yarn start
 
   manage:
-    image: district-builder-manage
+    image: districtbuilder-manage
     environment:
       - POSTGRES_HOST=database
       - POSTGRES_PORT=5432

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -29,7 +29,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f docker-compose.yml \
             -f docker-compose.ci.yml \
-            build server
+            build server manage
 
         CI=1 GIT_COMMIT="${GIT_COMMIT}" \
             ./scripts/test

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -28,9 +28,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             # is a docker login command with temporarily ECR credentials.
             eval "$(aws ecr get-login --no-include-email)"
 
-            docker tag "district-builder-server:${GIT_COMMIT}" \
-                "${DB_AWS_ECR_ENDPOINT}/district-builder-server:${GIT_COMMIT}"
-            docker push "${DB_AWS_ECR_ENDPOINT}/district-builder-server:${GIT_COMMIT}"
+            docker tag "districtbuilder:${GIT_COMMIT}" \
+                "${DB_AWS_ECR_ENDPOINT}/districtbuilder:${GIT_COMMIT}"
+            docker push "${DB_AWS_ECR_ENDPOINT}/districtbuilder:${GIT_COMMIT}"
+
+            docker tag "districtbuilder-manage:${GIT_COMMIT}" \
+                "${DB_AWS_ECR_ENDPOINT}/districtbuilder-manage:${GIT_COMMIT}"
+            docker push "${DB_AWS_ECR_ENDPOINT}/districtbuilder-manage:${GIT_COMMIT}"
         else
             echo "ERROR: No DB_AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/scripts/infra
+++ b/scripts/infra
@@ -44,6 +44,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 -backend-config="key=terraform/state"
 
             terraform plan \
+                -var="image_tag=${GIT_COMMIT}" \
                 -var-file="${DB_SETTINGS_BUCKET}.tfvars" \
                 -out="${DB_SETTINGS_BUCKET}.tfplan"
             ;;

--- a/src/manage/.dockerignore
+++ b/src/manage/.dockerignore
@@ -1,0 +1,5 @@
+*
+!bin
+!lib
+!package.json
+!yarn.lock

--- a/src/manage/Dockerfile
+++ b/src/manage/Dockerfile
@@ -40,7 +40,6 @@ RUN set -ex \
 COPY --from=tippecanoe /usr/local/bin/tippecanoe /usr/local/bin/tippecanoe
 COPY --from=tippecanoe /usr/local/bin/tile-join /usr/local/bin/tile-join
 
-COPY bin /home/node/app/manage/bin
-COPY lib /home/node/app/manage/lib
+COPY . /home/node/app/manage
 
 CMD ["/home/node/app/manage/bin/run"]

--- a/src/manage/Dockerfile
+++ b/src/manage/Dockerfile
@@ -40,4 +40,7 @@ RUN set -ex \
 COPY --from=tippecanoe /usr/local/bin/tippecanoe /usr/local/bin/tippecanoe
 COPY --from=tippecanoe /usr/local/bin/tile-join /usr/local/bin/tile-join
 
+COPY bin /home/node/app/manage/bin
+COPY lib /home/node/app/manage/lib
+
 CMD ["/home/node/app/manage/bin/run"]


### PR DESCRIPTION
## Overview

The following changes were made to support the staging CLI on AWS:

- Add TypeScript build output to `districtbuilder-manage` container image
- Create new ECR repositories
- ECS with Fargate
  - Pass environment secrets to the ECS task definition
- Include log aggregation with CloudWatch Logs

Resolves #72 

## Testing Instructions

- Verify that the Terraform plan output is clean

```bash
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-5.0# ./scripts/infra plan
. . .
```

- Build and publish the container images

```bash
$ ./scripts/cibuild
. . .

$ ./scripts/cipublish
. . .
```

- See the output of the ECS task that I invoked out-of-band:
https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/ecsStagingCluster/tasks/8943a75f-e053-4ea8-9e0a-a04e5cee840c/details

![image](https://user-images.githubusercontent.com/1774125/82088112-2a405300-96bf-11ea-933c-79d6a9b0e60a.png)


