### PR TITLE
Forgot password workflow

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -10,6 +10,7 @@ import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
 import ProjectScreen from "./screens/ProjectScreen";
 import RegistrationScreen from "./screens/RegistrationScreen";
+import ResetPasswordScreen from "./screens/ResetPasswordScreen";
 import theme from "./theme";
 
 import "./App.css";
@@ -34,6 +35,7 @@ const App = () => (
           <Route path="/register" exact={true} component={RegistrationScreen} />
           <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
           <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />
+          <Route path="/password-reset/:token" exact={true} component={ResetPasswordScreen} />
           <PrivateRoute path="/create-project" exact={true} component={CreateProjectScreen} />
         </Switch>
       </Router>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -5,6 +5,7 @@ import { Flex, ThemeProvider } from "theme-ui";
 import { getJWT, jwtIsExpired } from "./jwt";
 import ActivateAccountScreen from "./screens/ActivateAccountScreen";
 import CreateProjectScreen from "./screens/CreateProjectScreen";
+import ForgotPasswordScreen from "./screens/ForgotPasswordScreen";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
 import ProjectScreen from "./screens/ProjectScreen";
@@ -31,6 +32,7 @@ const App = () => (
           <PrivateRoute path="/projects/:projectId" exact={true} component={ProjectScreen} />
           <Route path="/login" exact={true} component={LoginScreen} />
           <Route path="/register" exact={true} component={RegistrationScreen} />
+          <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
           <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />
           <PrivateRoute path="/create-project" exact={true} component={CreateProjectScreen} />
         </Switch>

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1,13 +1,20 @@
 import { ActionType } from "typesafe-actions";
 
+import * as authActions from "./actions/auth";
 import * as projectDataActions from "./actions/projectData";
 import * as projectsActions from "./actions/projects";
 import * as regionConfigActions from "./actions/regionConfig";
 import * as userActions from "./actions/user";
 
+export type AuthAction = ActionType<typeof authActions>;
 export type ProjectDataAction = ActionType<typeof projectDataActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
 export type RegionConfigAction = ActionType<typeof regionConfigActions>;
 export type UserAction = ActionType<typeof userActions>;
 
-export type Action = UserAction | RegionConfigAction | ProjectDataAction | ProjectsAction;
+export type Action =
+  | AuthAction
+  | UserAction
+  | RegionConfigAction
+  | ProjectDataAction
+  | ProjectsAction;

--- a/src/client/actions/auth.ts
+++ b/src/client/actions/auth.ts
@@ -1,0 +1,3 @@
+import { createAction } from "typesafe-actions";
+
+export const showPasswordResetNotice = createAction("Show password reset notice")<boolean>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -59,6 +59,15 @@ export async function registerUser(name: string, email: string, password: string
   });
 }
 
+export async function initiateForgotPassword(email: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/auth/email/forgot-password/${email}`)
+      .then(() => resolve())
+      .catch(error => reject(error.response.data));
+  });
+}
+
 export async function activateAccount(token: string): Promise<JWT> {
   return new Promise((resolve, reject) => {
     apiAxios

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -81,6 +81,15 @@ export async function activateAccount(token: string): Promise<JWT> {
   });
 }
 
+export async function resetPassword(token: string, password: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/auth/email/reset-password/${token}`, { password })
+      .then(() => resolve())
+      .catch(error => reject(error.response.data));
+  });
+}
+
 export async function createProject({
   name,
   numberOfDistricts,

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from "redux-loop";
+import authReducer, { AuthState, initialState as initialAuthState } from "./reducers/auth";
 import projectDataReducer, {
   initialState as initialProjectDataState,
   ProjectDataState
@@ -14,6 +15,7 @@ import regionConfigReducer, {
 import userReducer, { initialState as initialUserState, UserState } from "./reducers/user";
 
 export interface State {
+  readonly auth: AuthState;
   readonly user: UserState;
   readonly regionConfig: RegionConfigState;
   readonly projectData: ProjectDataState;
@@ -21,6 +23,7 @@ export interface State {
 }
 
 export const initialState: State = {
+  auth: initialAuthState,
   user: initialUserState,
   regionConfig: initialRegionConfigState,
   projectData: initialProjectDataState,
@@ -28,6 +31,7 @@ export const initialState: State = {
 };
 
 export default combineReducers({
+  auth: authReducer,
   user: userReducer,
   regionConfig: regionConfigReducer,
   projectData: projectDataReducer,

--- a/src/client/reducers/auth.ts
+++ b/src/client/reducers/auth.ts
@@ -1,0 +1,17 @@
+import { createReducer } from "typesafe-actions";
+
+import { Action } from "../actions";
+import { showPasswordResetNotice } from "../actions/auth";
+
+export interface AuthState {
+  readonly passwordResetNoticeShown: boolean;
+}
+
+export const initialState: AuthState = { passwordResetNoticeShown: false };
+
+const authReducer = createReducer<AuthState, Action>(initialState).handleAction(
+  showPasswordResetNotice,
+  (state, action) => ({ passwordResetNoticeShown: action.payload })
+);
+
+export default authReducer;

--- a/src/client/screens/ForgotPasswordScreen.tsx
+++ b/src/client/screens/ForgotPasswordScreen.tsx
@@ -1,0 +1,106 @@
+/** @jsx jsx */
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { Box, Button, Card, Flex, Heading, jsx, Styled } from "theme-ui";
+
+import { initiateForgotPassword } from "../api";
+import CenteredContent from "../components/CenteredContent";
+import { InputField } from "../components/Field";
+import FormError from "../components/FormError";
+import { WriteResource } from "../resource";
+
+const isFormInvalid = (form: ForgotPasswordForm): boolean =>
+  Object.values(form).some(value => value.trim() === "") || !form.email.includes("@");
+
+interface ForgotPasswordForm {
+  readonly email: string;
+}
+
+const ForgotPasswordScreen = () => {
+  const [emailResource, setEmailResource] = useState<WriteResource<ForgotPasswordForm, void>>({
+    data: {
+      email: ""
+    }
+  });
+  const { data } = emailResource;
+
+  return (
+    <CenteredContent>
+      <Heading as="h1">DistrictBuilder</Heading>
+      <Card sx={{ backgroundColor: "muted", my: 4, p: 4 }}>
+        <Flex
+          as="form"
+          sx={{ flexDirection: "column", textAlign: "left" }}
+          onSubmit={(e: React.FormEvent) => {
+            e.preventDefault();
+            setEmailResource({ data, isPending: true });
+            initiateForgotPassword(data.email)
+              .then(() => setEmailResource({ data, resource: void 0 }))
+              .catch(errors => {
+                setEmailResource({ data, errors });
+              });
+          }}
+        >
+          <Heading as="h2" sx={{ textAlign: "left" }}>
+            Reset your password
+          </Heading>
+          {"resource" in emailResource ? (
+            <React.Fragment>
+              <p>
+                Password reset email sent to <b>{data.email}</b>
+              </p>
+              <p>
+                Used the wrong email address?{" "}
+                <Styled.a
+                  as={Link}
+                  to="/forgot-password"
+                  onClick={(e: React.MouseEvent<HTMLAnchorElement>): void => {
+                    e.preventDefault();
+                    setEmailResource({ data: { email: "" } });
+                  }}
+                  sx={{ color: "primary" }}
+                >
+                  Reset your password again
+                </Styled.a>
+              </p>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <FormError resource={emailResource} />
+              <InputField
+                field="email"
+                label="Email"
+                resource={emailResource}
+                inputProps={{
+                  required: true,
+                  type: "email",
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                    setEmailResource({
+                      data: { ...data, email: e.currentTarget.value }
+                    })
+                }}
+              />
+              <Button type="submit" disabled={isFormInvalid(data)}>
+                Reset password
+              </Button>
+            </React.Fragment>
+          )}
+        </Flex>
+      </Card>
+      <Box>
+        Know your password?{" "}
+        <Styled.a as={Link} to="/login" sx={{ color: "primary" }}>
+          Log in
+        </Styled.a>
+      </Box>
+      <Box>
+        Need an account?{" "}
+        <Styled.a as={Link} to="/register" sx={{ color: "primary" }}>
+          Sign up for free
+        </Styled.a>
+      </Box>
+    </CenteredContent>
+  );
+};
+
+export default ForgotPasswordScreen;

--- a/src/client/screens/LoginScreen.tsx
+++ b/src/client/screens/LoginScreen.tsx
@@ -75,6 +75,12 @@ const LoginScreen = () => {
           Sign up for free
         </Styled.a>
       </Box>
+      <Box>
+        Forgot password?{" "}
+        <Styled.a as={Link} to="/forgot-password" sx={{ color: "primary" }}>
+          Password reset
+        </Styled.a>
+      </Box>
     </CenteredContent>
   );
 };

--- a/src/client/screens/LoginScreen.tsx
+++ b/src/client/screens/LoginScreen.tsx
@@ -1,17 +1,25 @@
 /** @jsx jsx */
 import React, { useState } from "react";
+import { connect } from "react-redux";
 import { Link, Redirect } from "react-router-dom";
-import { Box, Button, Card, Flex, Heading, jsx, Styled } from "theme-ui";
+import { Alert, Box, Button, Card, Close, Flex, Heading, jsx, Styled } from "theme-ui";
 
 import { JWT, Login } from "../../shared/entities";
+import { showPasswordResetNotice } from "../actions/auth";
 import { authenticateUser } from "../api";
 import CenteredContent from "../components/CenteredContent";
 import { InputField } from "../components/Field";
 import FormError from "../components/FormError";
 import { jwtIsExpired } from "../jwt";
+import { State } from "../reducers";
 import { WriteResource } from "../resource";
+import store from "../store";
 
-const LoginScreen = () => {
+interface StateProps {
+  readonly passwordResetNoticeShown: boolean;
+}
+
+const LoginScreen = ({ passwordResetNoticeShown }: StateProps) => {
   const [loginResource, setLoginResource] = useState<WriteResource<Login, JWT>>({
     data: {
       email: "",
@@ -42,6 +50,16 @@ const LoginScreen = () => {
           <Heading as="h2" sx={{ textAlign: "left" }}>
             Log in
           </Heading>
+          {passwordResetNoticeShown && (
+            <Alert>
+              Your password has been reset
+              <Close
+                as="a"
+                onClick={() => store.dispatch(showPasswordResetNotice(false))}
+                sx={{ ml: "auto", p: 0 }}
+              />
+            </Alert>
+          )}
           <FormError resource={loginResource} />
           <InputField
             field="email"
@@ -85,4 +103,10 @@ const LoginScreen = () => {
   );
 };
 
-export default LoginScreen;
+function mapStateToProps(state: State): StateProps {
+  return {
+    passwordResetNoticeShown: state.auth.passwordResetNoticeShown
+  };
+}
+
+export default connect(mapStateToProps)(LoginScreen);

--- a/src/client/screens/ResetPasswordScreen.tsx
+++ b/src/client/screens/ResetPasswordScreen.tsx
@@ -4,11 +4,13 @@ import { useParams } from "react-router-dom";
 import { Link, Redirect } from "react-router-dom";
 import { Box, Button, Card, Flex, Heading, jsx, Styled } from "theme-ui";
 
+import { showPasswordResetNotice } from "../actions/auth";
 import { resetPassword } from "../api";
 import CenteredContent from "../components/CenteredContent";
 import { InputField } from "../components/Field";
 import FormError from "../components/FormError";
 import { WriteResource } from "../resource";
+import store from "../store";
 
 const isFormInvalid = (form: ResetPasswordForm): boolean =>
   Object.values(form).some(value => value.trim() === "") || form.password !== form.confirmPassword;
@@ -45,7 +47,10 @@ const ResetPasswordScreen = () => {
             e.preventDefault();
             setPasswordResource({ data, isPending: true });
             resetPassword(token, data.password)
-              .then(() => setPasswordResource({ data, resource: void 0 }))
+              .then(() => {
+                setPasswordResource({ data, resource: void 0 });
+                store.dispatch(showPasswordResetNotice(true));
+              })
               .catch(errors => {
                 setPasswordResource({ data, errors });
               });

--- a/src/client/screens/ResetPasswordScreen.tsx
+++ b/src/client/screens/ResetPasswordScreen.tsx
@@ -1,0 +1,105 @@
+/** @jsx jsx */
+import React, { useState } from "react";
+import { useParams } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
+import { Box, Button, Card, Flex, Heading, jsx, Styled } from "theme-ui";
+
+import { resetPassword } from "../api";
+import CenteredContent from "../components/CenteredContent";
+import { InputField } from "../components/Field";
+import FormError from "../components/FormError";
+import { WriteResource } from "../resource";
+
+const isFormInvalid = (form: ResetPasswordForm): boolean =>
+  Object.values(form).some(value => value.trim() === "") || form.password !== form.confirmPassword;
+
+interface ResetPasswordForm {
+  readonly password: string;
+  readonly confirmPassword: string;
+}
+
+interface ResetPasswordScreenParams {
+  readonly token: string;
+}
+
+const ResetPasswordScreen = () => {
+  const { token } = useParams<ResetPasswordScreenParams>();
+  const [passwordResource, setPasswordResource] = useState<WriteResource<ResetPasswordForm, void>>({
+    data: {
+      password: "",
+      confirmPassword: ""
+    }
+  });
+  const { data } = passwordResource;
+
+  return "resource" in passwordResource ? (
+    <Redirect to="/login" />
+  ) : (
+    <CenteredContent>
+      <Heading as="h1">DistrictBuilder</Heading>
+      <Card sx={{ backgroundColor: "muted", my: 4, p: 4 }}>
+        <Flex
+          as="form"
+          sx={{ flexDirection: "column", textAlign: "left" }}
+          onSubmit={(e: React.FormEvent) => {
+            e.preventDefault();
+            setPasswordResource({ data, isPending: true });
+            resetPassword(token, data.password)
+              .then(() => setPasswordResource({ data, resource: void 0 }))
+              .catch(errors => {
+                setPasswordResource({ data, errors });
+              });
+          }}
+        >
+          <Heading as="h2" sx={{ textAlign: "left" }}>
+            Reset your password
+          </Heading>
+          <FormError resource={passwordResource} />
+          <InputField
+            field="password"
+            label="Password"
+            resource={passwordResource}
+            inputProps={{
+              required: true,
+              type: "password",
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setPasswordResource({
+                  data: { ...data, password: e.currentTarget.value }
+                })
+            }}
+          />
+          <InputField
+            field="confirmPassword"
+            label="Confirm password"
+            resource={passwordResource}
+            inputProps={{
+              required: true,
+              type: "password",
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setPasswordResource({
+                  data: { ...data, confirmPassword: e.currentTarget.value }
+                })
+            }}
+          />
+          <Button type="submit" disabled={isFormInvalid(data)}>
+            Reset password
+          </Button>
+        </Flex>
+      </Card>
+      <Box>
+        Know your password?{" "}
+        <Styled.a as={Link} to="/login" sx={{ color: "primary" }}>
+          Log in
+        </Styled.a>
+      </Box>
+      <Box>
+        Need an account?{" "}
+        <Styled.a as={Link} to="/register" sx={{ color: "primary" }}>
+          Sign up for free
+        </Styled.a>
+      </Box>
+    </CenteredContent>
+  );
+};
+
+export default ResetPasswordScreen;

--- a/src/server/migrations/1590169690909-ForgotPasswordTypes.ts
+++ b/src/server/migrations/1590169690909-ForgotPasswordTypes.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ForgotPasswordTypes1590169690909 implements MigrationInterface {
+  name = "ForgotPasswordTypes1590169690909";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `CREATE TYPE "email_verification_type_enum" AS ENUM('forgot password', 'initial')`,
+      undefined
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_verification" ADD "type" "email_verification_type_enum" NOT NULL`,
+      undefined
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_verification" DROP CONSTRAINT "UQ_3ffc9210f041753e837b29d9e5b"`,
+      undefined
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_verification" ADD CONSTRAINT "UQ_40aa9efaef98ed03b98dfcd87f1" UNIQUE ("email", "type")`,
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `ALTER TABLE "email_verification" DROP CONSTRAINT "UQ_40aa9efaef98ed03b98dfcd87f1"`,
+      undefined
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_verification" ADD CONSTRAINT "UQ_3ffc9210f041753e837b29d9e5b" UNIQUE ("email")`,
+      undefined
+    );
+    await queryRunner.query(`ALTER TABLE "email_verification" DROP COLUMN "type"`, undefined);
+    await queryRunner.query(`DROP TYPE "email_verification_type_enum"`, undefined);
+  }
+}

--- a/src/server/src/auth/entities/email-verification.entity.ts
+++ b/src/server/src/auth/entities/email-verification.entity.ts
@@ -1,13 +1,24 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, PrimaryGeneratedColumn, Unique } from "typeorm";
+
+export enum VerificationType {
+  FORGOT_PASSWORD = "forgot password",
+  INITIAL = "initial"
+}
 
 @Entity()
+@Unique(["email", "type"])
 export class EmailVerification {
   @PrimaryGeneratedColumn()
   id: string;
-  @Column({ unique: true })
+  @Column()
   email: string;
   @Column()
   emailToken: string;
   @Column()
   timestamp: Date;
+  @Column({
+    type: "enum",
+    enum: VerificationType
+  })
+  type: VerificationType;
 }

--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -11,7 +11,7 @@ import { IUser, JWT, UserId } from "../../../../shared/entities";
 import { EMAIL_VERIFICATION_TOKEN_LENGTH, FROM_EMAIL } from "../../common/constants";
 import { User } from "../../users/entities/user.entity";
 import { UsersService } from "../../users/services/users.service";
-import { EmailVerification } from "../entities/email-verification.entity";
+import { EmailVerification, VerificationType } from "../entities/email-verification.entity";
 
 function generateEmailToken(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -24,6 +24,8 @@ function generateEmailToken(): Promise<string> {
     });
   });
 }
+
+const EMAIL_EXPIRATION_IN_MS = 60 * 60 * 24 * 1000;
 
 @Injectable()
 export class AuthService {
@@ -67,22 +69,8 @@ export class AuthService {
     return this.jwtService.sign(payload);
   }
 
-  async sendVerificationEmail(user: User): Promise<void> {
-    const emailToken = await generateEmailToken();
-    const data = {
-      email: user.email,
-      emailToken,
-      timestamp: new Date()
-    };
-
-    await this.emailVerificationRepo
-      .createQueryBuilder()
-      .insert()
-      .into(EmailVerification)
-      .values(data)
-      .onConflict(`("email") DO UPDATE SET "emailToken" = :emailToken, "timestamp" = :timestamp`)
-      .setParameters(data)
-      .execute();
+  async sendInitialVerificationEmail(user: User): Promise<void> {
+    const emailToken = this.sendEmailVerification(user, VerificationType.INITIAL);
 
     const info = await this.mailerService.sendMail({
       to: user.email,
@@ -100,24 +88,87 @@ export class AuthService {
     return;
   }
 
-  async verifyEmail(token: string): Promise<User | undefined> {
-    const emailVerif = await this.emailVerificationRepo.findOne({
-      emailToken: token
+  async sendPasswordResetEmail(user: User): Promise<void> {
+    const emailToken = await this.sendEmailVerification(user, VerificationType.FORGOT_PASSWORD);
+
+    const info = await this.mailerService.sendMail({
+      to: user.email,
+      from: FROM_EMAIL,
+      subject: "Reset your DistrictBuilder password",
+      context: {
+        user,
+        url: `${process.env.CLIENT_URL}/password-reset/${emailToken}`
+      },
+      template: "passwordreset"
     });
-    if (emailVerif) {
+
+    this.logger.debug(info.envelope, info.message.toString());
+
+    return;
+  }
+
+  async verifyInitialEmail(token: string): Promise<User | undefined> {
+    return this.verifyEmail(token, VerificationType.INITIAL, user => {
+      /* tslint:disable:no-object-mutation */
+      user.isEmailVerified = true;
+      /* tslint:enable */
+    });
+  }
+
+  async resetPassword(token: string, password: string): Promise<User | undefined> {
+    return this.verifyEmail(token, VerificationType.FORGOT_PASSWORD, user => {
+      /* tslint:disable:no-object-mutation */
+      // Token-based password reset goes through email and so will verify email
+      // address if that hasn't happened yet
+      user.isEmailVerified = true;
+      return user.setPassword(password);
+      /* tslint:enable */
+    });
+  }
+
+  private async sendEmailVerification(user: User, type: VerificationType): Promise<string> {
+    const emailToken = await generateEmailToken();
+    const data = {
+      email: user.email,
+      emailToken,
+      timestamp: new Date(),
+      type
+    };
+
+    await this.emailVerificationRepo
+      .createQueryBuilder()
+      .insert()
+      .into(EmailVerification)
+      .values(data)
+      .onConflict(
+        `("email", "type") DO UPDATE SET "emailToken" = :emailToken, "timestamp" = :timestamp`
+      )
+      .setParameters(data)
+      .execute();
+
+    return emailToken;
+  }
+
+  private async verifyEmail(
+    emailToken: string,
+    type: VerificationType,
+    updateUser: (user: User) => void | Promise<void>
+  ): Promise<User | undefined> {
+    const emailVerif = await this.emailVerificationRepo.findOne({ emailToken, type });
+    const now = new Date();
+    const lastValidTimestamp = new Date(now.getTime() - EMAIL_EXPIRATION_IN_MS);
+    if (emailVerif && emailVerif.timestamp > lastValidTimestamp) {
       const userFromDb = await this.usersService.findOne({
         email: emailVerif.email
       });
       if (userFromDb) {
-        /* tslint:disable:no-object-mutation */
-        userFromDb.isEmailVerified = true;
+        await updateUser(userFromDb);
         let savedUser;
         await getManager().transaction(async transactionalEntityManager => {
           savedUser = await transactionalEntityManager.save(userFromDb);
           await transactionalEntityManager.remove(emailVerif);
         });
         return savedUser;
-        /* tslint:enable */
       }
     }
   }

--- a/src/server/src/templates/passwordreset.hbs
+++ b/src/server/src/templates/passwordreset.hbs
@@ -1,0 +1,11 @@
+<p>
+  Hi <b>{{ user.name }}</b>!
+</p>
+
+<p>
+Click the link below to reset your password. The link expires in 24 hours.
+</p>
+
+<p>
+<a href="{{ url }}">{{ url }}</a>
+</p>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,3 +1,8 @@
+export enum ForgotPasswordResponse {
+  SUCCESS = "SUCCESS",
+  NOT_FOUND = "NOT_FOUND"
+}
+
 export enum LoginErrors {
   NOT_FOUND = "NOT_FOUND",
   INVALID_PASSWORD = "INVALID_PASSWORD"
@@ -15,6 +20,11 @@ export enum RegisterResponse {
 }
 
 export enum ResendResponse {
+  SUCCESS = "SUCCESS",
+  NOT_FOUND = "NOT_FOUND"
+}
+
+export enum ResetPasswordResponse {
   SUCCESS = "SUCCESS",
   NOT_FOUND = "NOT_FOUND"
 }


### PR DESCRIPTION
## Overview

Adds an email-based system for resetting a forgottten password.

### Demo

![localhost_3003_ (14)](https://user-images.githubusercontent.com/4432106/82921752-b9aef700-9f46-11ea-90d8-09e6ed25ae48.png)
![localhost_3003_password-reset_CRC8s3CGOeaZlTlOK5oXVQ_3Epw](https://user-images.githubusercontent.com/4432106/82921749-b9aef700-9f46-11ea-9fef-425561b2791e.png)
![localhost_3003_ (15)](https://user-images.githubusercontent.com/4432106/82921750-b9aef700-9f46-11ea-9fbb-dfb45f2d451e.png)
![localhost_3003_password-reset_CRC8s3CGOeaZlTlOK5oXVQ_3Epw (2)](https://user-images.githubusercontent.com/4432106/82921748-b9166080-9f46-11ea-82c1-dbcc7b952755.png)


### Notes

 - I combined the models for email verification & password registration into 1 model with a type column that differentiates them, which seemed more DRY but is different from how the sample repo I looked at for #74 did things.
 - We weren't checking email verification links for expiration (:astonished:) so I added a 1 day expiration for both the password reset email & the initial verification email

## Testing Instructions

- http://localhost:3003/forgot-password

Closes #76 