### PR TITLE
Fix converting S3 URIs to HTTP URIs

### DIFF
--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
-import { join } from "path";
-import { parse } from "url";
+import { parse, resolve } from "url";
 
 import { HttpsURI, IStaticFile, IStaticMetadata, S3URI } from "../shared/entities";
 
@@ -8,11 +7,11 @@ const s3Axios = axios.create();
 
 export function s3ToHttps(path: S3URI): HttpsURI {
   const uri = parse(path);
-  return join("https://", `${uri.host}.s3.amazonaws.com`, uri.path || "");
+  return resolve(`https://${uri.host}.s3.amazonaws.com`, uri.path || "");
 }
 
 export function staticDataUri(path: S3URI, fileName: string): HttpsURI {
-  return join(s3ToHttps(path), fileName);
+  return resolve(s3ToHttps(path), fileName);
 }
 
 export async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata> {


### PR DESCRIPTION
This was actually generating strings starting like https:/s3-buck-name/...
which worked when hosting from localhost but not when from staging

Switching from path.join which is meant for filepaths to url.resolve which
is designed for URIs fixed the issue

## Overview

Brief description of what this PR does, and why it is needed.

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

Closes #XXX
