### PR TITLE
Document running RDS migrations using ECS Fargate

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -83,7 +83,7 @@ This will attempt to apply the plan assembled in the previous step using Amazon'
 
 ## RDS Migrations
 
-Migrations on RDS should be run through ECS using the app task definition.
+Migrations on RDS should be run through ECS using the [StagingApp](https://console.aws.amazon.com/ecs/home?region=us-east-1#/taskDefinitions/StagingApp) task definition.
 
 To run migrations on the staging environment, run a new task using the following parameters:
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,6 +3,7 @@
 - [AWS Credentials](#aws-credentials)
 - [Publish Container Images](#publish-container-images)
 - [Terraform](#terraform)
+- [RDS Migrations](#rds-migrations)
 
 ## AWS Credentials
 
@@ -79,3 +80,25 @@ $ ./scripts/infra apply
 ```
 
 This will attempt to apply the plan assembled in the previous step using Amazon's APIs.
+
+## RDS Migrations
+
+Migrations on RDS should be run through ECS using the app task definition.
+
+To run migrations on the staging environment, run a new task using the following parameters:
+
+| Setting               | Value                               |
+|-----------------------|-------------------------------------|
+| Launch type           | `FARGATE`                           |
+| Task definition       | `StagingApp:<most recent revision>` |
+| Platform version      | `LATEST`                            |
+| Cluster               | `ecsStagingCluster`                 |
+| Number of tasks       | `1`                                 |
+| Cluster VPC           | select `vpcDistrictBuilderStaging`  |
+| Subnets               | select both `PrivateSubnet` entries |
+| Security groups       | select `sgStagingAppEcsService`     |
+| Auto-assign public IP | `DISABLED`                          |
+
+Under Advanced Options: Container Overrides, set the `app` command override to `run,migration:run`
+
+Once the task leaves `PENDING` state and enters `RUNNING` state, you can view the migration progress in the task logs.


### PR DESCRIPTION
## Overview

Documents the process for running migrations as ECS Fargate tasks. Instructions are currently for the `Staging` environment, but a similar approach can be used for the `Production` environment once it exists.

### Notes

I made a fair bit of progress with both shell scripting using AWS CLI commands, and with adapting https://github.com/azavea/django-ecsmanage to run as a standalone script.

The shell script approach quickly ran into a lot of edge cases around parsing quotes, JSON, and token separators. It became clear that I was in the process of writing a parser so I abandoned that approach.

The `django-ecsmanage` approach was more successful but also ran into problems around parsing out arguments to `ecsmanage` vs. passing them along to ECS. I think this is a viable approach, but it required more adaptation than I expected to remove it from Django. By this point the task was running well over estimate and was starting to block development. I think we should revisit a similar approach if we need to run management commands more frequently but it should be estimated for more time.

## Testing Instructions

- Verify documentation by running a task in the DistrictBuilder AWS ECS console.

Closes #46 
