### PR TITLE
Fix performance of GeoUnitHierarchy group function

### DIFF
--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -48,6 +48,7 @@ export class TopologyService {
       this.s3.getObject({ Bucket: bucket, Key: staticMetadataKey }).promise()
     ])
       .then(([topojsonResponse, staticMetadataResponse]) => {
+        this.logger.debug(`downloaded data for s3URI ${s3URI}`);
         const staticMetadataBody = staticMetadataResponse.Body?.toString("utf8");
         const topojsonBody = topojsonResponse.Body?.toString("utf8");
         if (staticMetadataBody && topojsonBody) {


### PR DESCRIPTION
## Overview

This function was scaling in overhead in a greater than linear fashion, making it take an unacceptably long time for larger states and seemingly never complete for PA.

### Demo
```
$ ./scripts/dbshell
districtbuilder_database_1 is up-to-date
Recreating districtbuilder_server_1 ... done
psql (11.5 (Debian 11.5-3.pgdg90+1))
Type "help" for help.

districtbuilder=# UPDATE project SET districts_definition = '[1,1,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]' WHERE id = '697ab0b7-eb76-4afa-ab92-9d7913ad2ce9';
UPDATE 1
districtbuilder=# \q
$ http :3003/api/projects/697ab0b7-eb76-4afa-ab92-9d7913ad2ce9/export/geojson "Authorization:Bearer $TOKEN" > output.geojson
```

## Testing Instructions

- Using the data file `smb://fileshare.internal.azavea.com/projects/Azavea_DistrictBuilder/clients/Sloan-DistrictBuilder2/data/block-demographic/PA.geojson`, ingest it using `./scripts/manage process-geojson` and publish it to S3 using `./scripts/manage publish-geojson`
- `scripts/server`
- Sign in to the application
- Create a new project using the newly created `RegionConfig`
- Using `./scripts/dbshell`, set your project district definition as in the demo above
- Get a copy of your JWT token from the browser dev tools, and use it to hit the project export endpoint:
   `http :3003/api/projects/<project id>/export/geojson "Authorization:Bearer $TOKEN" > output.geojson`
- Double check the output w/ a tool like mapshaper.org or QGIS

Closes #152
