### PR TITLE
Document using server in AWS staging with local proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ While `server` is running, the [Create React App](https://github.com/facebook/cr
 If you want to develop the `client` locally against a `server` running in the AWS staging environment, you can configure a local proxy using the `BASE_URL` environment variable:
 
 ```#bash
-BASE_URL=https://staging.districtbuilder.azavea.com ./scripts/server
+BASE_URL=https://staging.districtbuilder.azavea.com docker-compose up client
 ```
 
 This will proxy local AJAX requests to `https://staging.districtbuilder.azavea.com`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you want to develop the `client` locally against a `server` running in the AW
 BASE_URL=https://staging.districtbuilder.azavea.com docker-compose up client
 ```
 
-This will proxy local AJAX requests to `https://staging.districtbuilder.azavea.com`.
+This will proxy local all requests directed at `/api` to `https://staging.districtbuilder.azavea.com`.
 
 ### Project Organization
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ DistrictBuilder is web-based, open source software for collaborative redistricti
 - [Requirements](#requirements)
 - [Development](#development)
   - [Hot Reloading 🔥](#hot-reloading-)
+  - [Remote Server Proxy](#remote-server-proxy)
   - [Project Organization](#project-organization)
   - [Stack](#stack)
   - [Ports](#ports)
@@ -44,6 +45,16 @@ Run `scripts/setup` to prepare the development environment:
 ### Hot Reloading 🔥
 
 While `server` is running, the [Create React App](https://github.com/facebook/create-react-app/) frontend will automatically [reload](https://github.com/facebook/create-react-app/#whats-included) when changes are made. Additionally, the [NestJS](https://nestjs.com/) backend will [restart](https://docs.nestjs.com/cli/usages#nest-start) when changes are made.
+
+### Remote Server Proxy
+
+If you want to develop the `client` locally against a `server` running in the AWS staging environment, you can configure a local proxy using the `BASE_URL` environment variable:
+
+```#bash
+BASE_URL=https://staging.districtbuilder.azavea.com ./scripts/server
+```
+
+This will proxy local AJAX requests to `https://staging.districtbuilder.azavea.com`.
 
 ### Project Organization
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   client:
     image: node:12-slim
     environment:
-      - BASE_URL=http://server:3005
+      - BASE_URL=${BASE_URL:-http://server:3005}
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=250
       - PORT=3003


### PR DESCRIPTION
## Overview

This provides documentation on how to configure a local `client` development server to use the `server` instance running in the staging environment on AWS.

### Demo

![Screen Shot 2020-06-02 at 5 12 28 PM](https://user-images.githubusercontent.com/3892845/83570652-6e6f8800-a4f4-11ea-9693-99e8a3808383.png)

![Screen Shot 2020-06-02 at 5 13 37 PM](https://user-images.githubusercontent.com/3892845/83570663-72030f00-a4f4-11ea-8a6c-3125bdc46f28.png)

### Notes

This is currently difficult to test end-to-end due to stability issues with the `staging.districtbuilder.azavea.com` server on AWS, as mentioned in #155.

## Testing Instructions

- Start up a development server and set `BASE_URL`:
```#bash
BASE_URL=https://staging.districtbuilder.azavea.com ./scripts/server
```
- Confirm in the script output that the remote server is being used for the development proxy.
- Open the client at http://localhost:3003/
- Attempt to login and verify that the POST request is going to CloudFront by checking the `via` HTTP response header.

Closes #55 
