### PR TITLE
Set server image entrypoint to yarn

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-180') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-180') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -4,8 +4,6 @@
     "image": "${image}",
     "cpu": 0,
     "essential": true,
-    "entryPoint": ["yarn"],
-    "command": ["run", "start:prod"],
     "environment": [
       {
         "name": "POSTGRES_HOST",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       database:
         condition: service_healthy
-    command: run start:dev
+    command: start:dev
 
   client:
     image: node:12-slim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       database:
         condition: service_healthy
-    command: yarn start:dev
+    command: run start:dev
 
   client:
     image: node:12-slim

--- a/scripts/migration
+++ b/scripts/migration
@@ -19,10 +19,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     elif [[ -z "${1}" ]]; then
         docker-compose \
             run --rm server \
-            yarn run migration:run
+            run migration:run
     else
         docker-compose \
             run --rm server \
-            bash -c "yarn run migration:${1} ${*:2}"
+            "run migration:${1} ${*:2}"
     fi
 fi

--- a/scripts/migration
+++ b/scripts/migration
@@ -19,10 +19,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     elif [[ -z "${1}" ]]; then
         docker-compose \
             run --rm server \
-            run migration:run
+            migration:run
     else
         docker-compose \
             run --rm server \
-            "run migration:${1} ${*:2}"
+            "migration:${1} ${*:2}"
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -52,7 +52,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 run --rm --no-deps \
                 -e "CI=${CI}" \
                 server \
-                yarn test --watchAll=false --passWithNoTests
+                test --watchAll=false --passWithNoTests
         else
             echo "Executing server test suite"
             ./scripts/yarn server \

--- a/scripts/update
+++ b/scripts/update
@@ -23,7 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Clean dist directory
         docker-compose \
             run --rm --no-deps server \
-            bash -c "yarn clean"
+            clean
 
         # Update frontend, Yarn dependencies and build static asset bundle
         docker-compose \
@@ -32,8 +32,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         # Update backend, Yarn dependencies and build server
         docker-compose \
-            run --rm --no-deps server \
-            bash -c "yarn install && yarn build"
+            run --rm --no-deps --entrypoint "bash -c" server \
+            "yarn install && yarn build"
 
         # Update manage, Yarn dependencies and build
         docker-compose \

--- a/scripts/yarn
+++ b/scripts/yarn
@@ -19,7 +19,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     elif [[ "${1}" == "server" ]]; then
         docker-compose \
             run --rm --no-deps "${1}" \
-            "${*:2}"
+            "${@:2}"
     else
         docker-compose \
             run --rm --no-deps "${1}" \

--- a/scripts/yarn
+++ b/scripts/yarn
@@ -16,6 +16,10 @@ Execute Yarn CLI commands.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [[ "${1:-}" == "--help" ]] || [[ ! "${1}" == "client" && ! "${1}" == "server" && ! "${1}" == "manage" ]]; then
         usage
+    elif [[ "${1}" == "server" ]]; then
+        docker-compose \
+            run --rm --no-deps "${1}" \
+            "${*:2}"
     else
         docker-compose \
             run --rm --no-deps "${1}" \

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -17,4 +17,4 @@ RUN set -ex \
 COPY . /home/node/app/server
 
 ENTRYPOINT ["yarn"]
-CMD ["run", "start:prod"]
+CMD ["start:prod"]

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -16,4 +16,5 @@ RUN set -ex \
 
 COPY . /home/node/app/server
 
-CMD ["node", "dist/server/src/main"]
+ENTRYPOINT ["yarn"]
+CMD ["run", "start:prod"]


### PR DESCRIPTION
## Overview

Updates the Docker `ENTRYPOINT` for the `server` image to `yarn`, allowing us to start the container in production with the command `run start:prod`. We no longer need to override the entrypoint in the Fargate task definition.

### Notes

This was mentioned in #142 when overriding the entrypoint to run `yarn` instead of the parent image `node` entrypoint.

## Testing Instructions

- Confirm that the [Jenkins build](http://urbanappsci.internal.azavea.com/job/PublicMapping/job/districtbuilder/job/PR-180/3/) passes.
- Run `scripts/update` locally and confirm that all updates succeed.
- Run `scripts/test` locally and confirm that all tests run and continue to pass.
- Run `scripts/server` locally and confirm that all application containers come up, that the application is running in development mode, and that the application is available at http://localhost:3005.
- Confirm that the staging site at https://staging.districtbuilder.azavea.com is up and accessible.

Closes #148 
