### PR TITLE
Refactor logging for sent emails

### DIFF
--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -69,6 +69,19 @@ export class AuthService {
     return this.jwtService.sign(payload);
   }
 
+  // The @nestjs-modules/mailer MailerService.sendMail method returns a Promise for a
+  // SentMessageInfo object, which @types/nodemailer defines as an any type object. This object
+  // could have a raw or message property defined. We're checking that here to be more explicit
+  // about logging errors vs. informational output.
+  private logSentEmail(info: any): void {
+    const body = info.raw || info.message;
+    if (body) {
+      this.logger.debug(info.envelope, body.toString());
+    } else {
+      this.logger.error("Email body is undefined", info);
+    }
+  }
+
   async sendInitialVerificationEmail(user: User): Promise<void> {
     const emailToken = await this.sendEmailVerification(user, VerificationType.INITIAL);
 
@@ -83,8 +96,7 @@ export class AuthService {
       template: "verify"
     });
 
-    const infoBody = info.raw || info.message;
-    this.logger.debug(info.envelope, infoBody.toString());
+    this.logSentEmail(info);
 
     return;
   }
@@ -103,8 +115,7 @@ export class AuthService {
       template: "passwordreset"
     });
 
-    const infoBody = info.raw || info.message;
-    this.logger.debug(info.envelope, infoBody.toString());
+    this.logSentEmail(info);
 
     return;
   }


### PR DESCRIPTION
## Overview

This DRYs up property checking and logging for sent emails in the auth service.

### Notes

The upstream `@types/nodemailer` module [uses an `any` type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b0cce3cd2cbc053400175af3ea84007076c2a775/types/nodemailer/index.d.ts#L22) for the email object that is returned from `sendEmail` in `@nestjs/mailer`. That doesn't give us much to work with and leaves us with the options of either wrapping the `EmailService` defined by the module and defining our own types, or refactoring the email logging to make its expected types and error checking more explicit.

Given that we're only reading the returned email object in the auth service, defining our own types felt like overkill in this situation. We opted to increase the visibility of how we're handling the various properties that the `any` type `info` object could have.

## Testing Instructions

- Start up the application locally with `scripts/server` and go to http://localhost:3005
- Register a new user and verify that the debug console outputs the `envelope` and body of the email that would have been sent.

Closes #165 
