### PR TITLE
Fix project creation on staging

### DIFF
--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -194,8 +194,7 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
         ...state,
         selectedGeounitIds: new Set([...state.selectedGeounitIds, ...action.payload])
       };
-    case getType(removeSelectedGeounitIds):
-      // eslint-disable-next-line
+    case getType(removeSelectedGeounitIds): {
       const mutableSelected = new Set([...state.selectedGeounitIds]);
       [...action.payload].forEach(function(v) {
         mutableSelected.delete(v);
@@ -204,6 +203,7 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
         ...state,
         selectedGeounitIds: mutableSelected
       };
+    }
     case getType(clearSelectedGeounitIds):
       return {
         ...state,

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -87,9 +87,9 @@ export class ProjectsController implements CrudController<Project> {
     @ParsedBody() dto: CreateProjectDto
   ): Promise<Project> {
     try {
-      const regionConfig = await this.regionConfigService.findOne(dto.regionConfig);
+      const regionConfig = await this.regionConfigService.findOne({ id: dto.regionConfig.id });
       if (!regionConfig) {
-        throw new NotFoundException(`Unable to find region config: ${dto.regionConfig}`);
+        throw new NotFoundException(`Unable to find region config: ${dto.regionConfig.id}`);
       }
 
       const geoCollection = await this.topologyService.get(regionConfig.s3URI);


### PR DESCRIPTION
## Overview

When fetching the region config during project creation, all columns of the region config were being used in the query. This wasn't obvious from the types, since `dto.regionConfig` is a `RegionConfigIdDto`, which only has an `id` field defined, but the JavaScript object itself contains the additional info at runtime. This works fine in development, but in staging, the formatted `version` column wasn't exactly matching up with the parameter being passed along in the `SELECT` query. The fix implemented here is to explicitly only use the `id` parameter. 

### Notes

Snuck in one unrelated, and very small change to properly address an ignored `no-case-declarations` eslint error.

## Testing Instructions

This is a trivial change, and the error is only present on staging, so I think simply merging it and verifying it works in staging is the best approach.

