### PR TITLE
Move district drawing out of projectData

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -5,16 +5,19 @@ import * as projectDataActions from "./actions/projectData";
 import * as projectsActions from "./actions/projects";
 import * as regionConfigActions from "./actions/regionConfig";
 import * as userActions from "./actions/user";
+import * as districtDrawingActions from "./actions/districtDrawing";
 
 export type AuthAction = ActionType<typeof authActions>;
 export type ProjectDataAction = ActionType<typeof projectDataActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
 export type RegionConfigAction = ActionType<typeof regionConfigActions>;
 export type UserAction = ActionType<typeof userActions>;
+export type DistrictDrawingAction = ActionType<typeof districtDrawingActions>;
 
 export type Action =
   | AuthAction
   | UserAction
   | RegionConfigAction
   | ProjectDataAction
-  | ProjectsAction;
+  | ProjectsAction
+  | DistrictDrawingAction;

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,0 +1,21 @@
+import { createAction } from "typesafe-actions";
+import { IProject } from "../../shared/entities";
+
+export const setSelectedDistrictId = createAction("Set selected district id")<number>();
+
+export const addSelectedGeounitIds = createAction("Add selected geounit ids")<
+  ReadonlySet<number>
+>();
+export const removeSelectedGeounitIds = createAction("Remove selected geounit ids")<
+  ReadonlySet<number>
+>();
+export const clearSelectedGeounitIds = createAction("Clear selected geounit ids")();
+
+export const saveDistrictsDefinition = createAction("Save districts definition")<IProject>();
+
+export const patchDistrictsDefinitionSuccess = createAction("Patch districts definition success")<
+  IProject
+>();
+export const patchDistrictsDefinitionFailure = createAction("Patch districts definition failure")<
+  string
+>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -29,22 +29,3 @@ export const staticDemographicsFetchSuccess = createAction("Static demographics 
 export const staticDemographicsFetchFailure = createAction("Static demographics fetch failure")<
   string
 >();
-
-export const setSelectedDistrictId = createAction("Set selected district id")<number>();
-
-export const addSelectedGeounitIds = createAction("Add selected geounit ids")<
-  ReadonlySet<number>
->();
-export const removeSelectedGeounitIds = createAction("Remove selected geounit ids")<
-  ReadonlySet<number>
->();
-export const clearSelectedGeounitIds = createAction("Clear selected geounit ids")();
-
-export const saveDistrictsDefinition = createAction("Save districts definition")();
-
-export const patchDistrictsDefinitionSuccess = createAction("Patch districts definition success")<
-  IProject
->();
-export const patchDistrictsDefinitionFailure = createAction("Patch districts definition failure")<
-  string
->();

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef, useState } from "react";
 import MapboxGL from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 
-import { addSelectedGeounitIds, removeSelectedGeounitIds } from "../actions/projectData";
+import { addSelectedGeounitIds, removeSelectedGeounitIds } from "../actions/districtDrawing";
 import { getDistrictColor } from "../constants/colors";
 import { DistrictProperties, IProject, IStaticMetadata } from "../../shared/entities";
 import { getAllIndices, getDemographics } from "../../shared/functions";

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -9,7 +9,7 @@ import {
   clearSelectedGeounitIds,
   saveDistrictsDefinition,
   setSelectedDistrictId
-} from "../actions/projectData";
+} from "../actions/districtDrawing";
 import store from "../store";
 
 // TODO (#185): need to make it so the sidebar doesn't fully re-render when new information is fetched
@@ -37,7 +37,7 @@ const ProjectSidebar = ({
       minWidth: "300px"
     }}
   >
-    <SidebarHeader selectedGeounitIds={selectedGeounitIds} />
+    {project && <SidebarHeader selectedGeounitIds={selectedGeounitIds} project={project} />}
     <Styled.table>
       <thead>
         <Styled.tr>
@@ -55,9 +55,11 @@ const ProjectSidebar = ({
 );
 
 const SidebarHeader = ({
-  selectedGeounitIds
+  selectedGeounitIds,
+  project
 }: {
   readonly selectedGeounitIds: ReadonlySet<number>;
+  readonly project: IProject;
 }) => {
   return (
     <Flex sx={{ variant: "header.app" }}>
@@ -81,7 +83,7 @@ const SidebarHeader = ({
             variant="circular"
             sx={{ cursor: "pointer" }}
             onClick={() => {
-              store.dispatch(saveDistrictsDefinition());
+              store.dispatch(saveDistrictsDefinition(project));
             }}
           >
             Approve

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -1,5 +1,9 @@
 import { combineReducers } from "redux-loop";
 import authReducer, { AuthState, initialState as initialAuthState } from "./reducers/auth";
+import districtDrawingReducer, {
+  initialState as initialDistrictDrawingState,
+  DistrictDrawingState
+} from "./reducers/districtDrawing";
 import projectDataReducer, {
   initialState as initialProjectDataState,
   ProjectDataState
@@ -20,6 +24,7 @@ export interface State {
   readonly regionConfig: RegionConfigState;
   readonly projectData: ProjectDataState;
   readonly projects: ProjectsState;
+  readonly districtDrawing: DistrictDrawingState;
 }
 
 export const initialState: State = {
@@ -27,7 +32,8 @@ export const initialState: State = {
   user: initialUserState,
   regionConfig: initialRegionConfigState,
   projectData: initialProjectDataState,
-  projects: initialProjectsState
+  projects: initialProjectsState,
+  districtDrawing: initialDistrictDrawingState
 };
 
 export default combineReducers({
@@ -35,5 +41,6 @@ export default combineReducers({
   user: userReducer,
   regionConfig: regionConfigReducer,
   projectData: projectDataReducer,
-  projects: projectsReducer
+  projects: projectsReducer,
+  districtDrawing: districtDrawingReducer
 });

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -1,0 +1,97 @@
+import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
+
+import { Action } from "../actions";
+import {
+  addSelectedGeounitIds,
+  clearSelectedGeounitIds,
+  patchDistrictsDefinitionSuccess,
+  patchDistrictsDefinitionFailure,
+  removeSelectedGeounitIds,
+  saveDistrictsDefinition,
+  setSelectedDistrictId
+} from "../actions/districtDrawing";
+import { projectFetchGeoJson } from "../actions/projectData";
+
+import { patchDistrictsDefinition } from "../api";
+
+export interface DistrictDrawingState {
+  readonly selectedDistrictId: number;
+  readonly selectedGeounitIds: ReadonlySet<number>;
+}
+
+export const initialState = {
+  selectedDistrictId: 1,
+  selectedGeounitIds: new Set([])
+};
+
+const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
+  state: DistrictDrawingState = initialState,
+  action: Action
+): DistrictDrawingState | Loop<DistrictDrawingState, Action> => {
+  switch (action.type) {
+    case getType(setSelectedDistrictId):
+      return {
+        ...state,
+        selectedDistrictId: action.payload
+      };
+    case getType(addSelectedGeounitIds):
+      return {
+        ...state,
+        selectedGeounitIds: new Set([...state.selectedGeounitIds, ...action.payload])
+      };
+    case getType(removeSelectedGeounitIds): {
+      const mutableSelected = new Set([...state.selectedGeounitIds]);
+      [...action.payload].forEach(function(v) {
+        mutableSelected.delete(v);
+      });
+      return {
+        ...state,
+        selectedGeounitIds: mutableSelected
+      };
+    }
+    case getType(clearSelectedGeounitIds):
+      return {
+        ...state,
+        selectedGeounitIds: new Set([])
+      };
+    case getType(saveDistrictsDefinition):
+      return loop(
+        state,
+        Cmd.run(patchDistrictsDefinition, {
+          successActionCreator: patchDistrictsDefinitionSuccess,
+          failActionCreator: patchDistrictsDefinitionFailure,
+          args: [
+            action.payload.id,
+            // TODO (#113): we are only dealing with the top-most geolevel at the moment, so this
+            // will need to be modified when we support all geolevels.
+            [...state.selectedGeounitIds].reduce((newDistrictsDefinition, geounitId) => {
+              // @ts-ignore
+              // eslint-disable-next-line
+              newDistrictsDefinition[geounitId] = state.selectedDistrictId;
+              return newDistrictsDefinition;
+            }, action.payload.districtsDefinition)
+          ] as Parameters<typeof patchDistrictsDefinition>
+        })
+      );
+    case getType(patchDistrictsDefinitionSuccess):
+      return loop(
+        {
+          ...state,
+          project: { resource: action.payload },
+          selectedGeounitIds: new Set([])
+        },
+        Cmd.action(projectFetchGeoJson(action.payload.id))
+      );
+    case getType(patchDistrictsDefinitionFailure):
+      // TODO (#188): implement a status area to display errors for this and other things
+      // eslint-disable-next-line
+      console.log("Error patching districts definition: ", action.payload);
+      return state;
+
+    default:
+      return state as never;
+  }
+};
+
+export default districtDrawingReducer;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -13,6 +13,7 @@ import Map from "../components/Map";
 import ProjectHeader from "../components/ProjectHeader";
 import ProjectSidebar from "../components/ProjectSidebar";
 import { State } from "../reducers";
+import { DistrictDrawingState } from "../reducers/districtDrawing";
 import { ProjectDataState } from "../reducers/projectData";
 import { Resource } from "../resource";
 import store from "../store";
@@ -20,6 +21,7 @@ import store from "../store";
 interface StateProps {
   readonly projectData: ProjectDataState;
   readonly user: Resource<IUser>;
+  readonly districtDrawing: DistrictDrawingState;
 }
 
 const FullScreenApp = ({ children }: { readonly children: React.ReactNode }) => {
@@ -38,7 +40,7 @@ const MapHeader = () => {
   return <Box sx={{ variant: "header.app", backgroundColor: "burlywood" }}>MapHeader</Box>;
 };
 
-const ProjectScreen = ({ projectData, user }: StateProps) => {
+const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const { projectId } = useParams();
   const project = "resource" in projectData.project ? projectData.project.resource : undefined;
   const geojson = "resource" in projectData.geojson ? projectData.geojson.resource : undefined;
@@ -59,8 +61,8 @@ const ProjectScreen = ({ projectData, user }: StateProps) => {
         <ProjectSidebar
           project={project}
           geojson={geojson}
-          selectedDistrictId={projectData.selectedDistrictId}
-          selectedGeounitIds={projectData.selectedGeounitIds}
+          selectedDistrictId={districtDrawing.selectedDistrictId}
+          selectedGeounitIds={districtDrawing.selectedGeounitIds}
         />
         <MapContainer>
           <MapHeader />
@@ -75,7 +77,7 @@ const ProjectScreen = ({ projectData, user }: StateProps) => {
               staticMetadata={projectData.staticMetadata.resource}
               staticGeoLevels={projectData.staticGeoLevels.resource}
               staticDemographics={projectData.staticDemographics.resource}
-              selectedGeounitIds={projectData.selectedGeounitIds}
+              selectedGeounitIds={districtDrawing.selectedGeounitIds}
             />
           ) : null}
         </MapContainer>
@@ -87,7 +89,8 @@ const ProjectScreen = ({ projectData, user }: StateProps) => {
 function mapStateToProps(state: State): StateProps {
   return {
     projectData: state.projectData,
-    user: state.user
+    user: state.user,
+    districtDrawing: state.districtDrawing
   };
 }
 


### PR DESCRIPTION
## Overview

This is a straightforward refactor to create a new `districtDrawing` reducer/actions to contain functionality related to drawing districts (they've been moved over from `projectData`).

## Testing Instructions

Follow testing instructions in #183 and ensure all district drawing capabilities are still functional.

Closes #187 
