### PR TITLE
Seamlessly rerender the map after editing districts

### DIFF
--- a/src/client/components/Loading.tsx
+++ b/src/client/components/Loading.tsx
@@ -1,0 +1,7 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui";
+
+// TODO: Make this into a nice-looking spinner
+const Loading = () => <span>Loading...</span>;
+
+export default Loading;

--- a/src/client/components/Loading.tsx
+++ b/src/client/components/Loading.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui";
 
-// TODO: Make this into a nice-looking spinner
+// TODO (#194): Make this into a nice-looking spinner
 const Loading = () => <span>Loading...</span>;
 
 export default Loading;

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -76,7 +76,6 @@ function getMapboxStyle(path: string, geoLevels: readonly string[]): MapboxGL.St
   };
 }
 
-// TODO (#185): need to make it so the map doesn't fully re-render when new information is fetched
 const Map = ({
   project,
   geojson,
@@ -193,6 +192,18 @@ const Map = ({
     // eslint complains that this useEffect should depend on map, but we're using this to call setMap so that wouldn't make sense
     // eslint-disable-next-line
   }, []);
+
+  // Update districts source when geojson is fetched
+  useEffect(() => {
+    const districtsSource = map && map.getSource("districts");
+    // Add a color property to the geojson, so it can be used for styling
+    geojson.features.forEach((feature, id) => {
+      // @ts-ignore
+      // eslint-disable-next-line
+      feature.properties.color = getDistrictColor(id);
+    });
+    districtsSource && districtsSource.type === "geojson" && districtsSource.setData(geojson);
+  }, [map, geojson]);
 
   // Remove selected features from map when selected geounit ids has been emptied
   useEffect(() => {

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -93,6 +93,13 @@ const Map = ({
   // At the moment, we are only interacting with the top geolevel (e.g. County)
   const topGeoLevel = staticMetadata.geoLevelHierarchy[staticMetadata.geoLevelHierarchy.length - 1];
 
+  // Add a color property to the geojson, so it can be used for styling
+  geojson.features.forEach((feature, id) => {
+    // @ts-ignore
+    // eslint-disable-next-line
+    feature.properties.color = getDistrictColor(id);
+  });
+
   useEffect(() => {
     const initializeMap = (setMap: (map: MapboxGL.Map) => void, mapContainer: HTMLDivElement) => {
       const map = new MapboxGL.Map({
@@ -110,13 +117,6 @@ const Map = ({
 
       map.on("load", () => {
         setMap(map);
-
-        // Add a color property to the geojson, so it can be used for styling
-        geojson.features.forEach((feature, id) => {
-          // @ts-ignore
-          // eslint-disable-next-line
-          feature.properties.color = getDistrictColor(id);
-        });
 
         map.addSource("districts", {
           type: "geojson",
@@ -196,12 +196,6 @@ const Map = ({
   // Update districts source when geojson is fetched
   useEffect(() => {
     const districtsSource = map && map.getSource("districts");
-    // Add a color property to the geojson, so it can be used for styling
-    geojson.features.forEach((feature, id) => {
-      // @ts-ignore
-      // eslint-disable-next-line
-      feature.properties.color = getDistrictColor(id);
-    });
     districtsSource && districtsSource.type === "geojson" && districtsSource.setData(geojson);
   }, [map, geojson]);
 

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -213,6 +213,8 @@ const Map = ({
           // assigned, wait until districts GeoJSON is updated before removing
           // selected state.
           map.once("idle", () => removeSelectedFeatures(map)));
+    // We don't want to tigger this effect when `selectedDistrictId` changes
+    // eslint-disable-next-line
   }, [map, selectedGeounitIds, topGeoLevel]);
 
   return <div ref={mapRef} style={styles} />;

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -213,7 +213,7 @@ const Map = ({
           // assigned, wait until districts GeoJSON is updated before removing
           // selected state.
           map.once("idle", () => removeSelectedFeatures(map)));
-  }, [map, selectedDistrictId, selectedGeounitIds, topGeoLevel]);
+  }, [map, selectedGeounitIds, topGeoLevel]);
 
   return <div ref={mapRef} style={styles} />;
 };

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -12,7 +12,6 @@ import {
 } from "../actions/districtDrawing";
 import store from "../store";
 
-// TODO (#185): need to make it so the sidebar doesn't fully re-render when new information is fetched
 const ProjectSidebar = ({
   project,
   geojson,

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -4,6 +4,7 @@ import { Button, Flex, Heading, jsx, Styled } from "theme-ui";
 
 import { DistrictProperties, IProject } from "../../shared/entities";
 import { getDistrictColor } from "../constants/colors";
+import Loading from "./Loading";
 
 import {
   clearSelectedGeounitIds,
@@ -12,9 +13,14 @@ import {
 } from "../actions/districtDrawing";
 import store from "../store";
 
+interface LoadingProps {
+  readonly isLoading: boolean;
+}
+
 const ProjectSidebar = ({
   project,
   geojson,
+  isLoading,
   selectedDistrictId,
   selectedGeounitIds
 }: {
@@ -22,7 +28,7 @@ const ProjectSidebar = ({
   readonly geojson?: FeatureCollection<MultiPolygon, DistrictProperties>;
   readonly selectedDistrictId: number;
   readonly selectedGeounitIds: ReadonlySet<number>;
-}) => (
+} & LoadingProps) => (
   <Flex
     sx={{
       background: "#fff",
@@ -36,7 +42,13 @@ const ProjectSidebar = ({
       minWidth: "300px"
     }}
   >
-    {project && <SidebarHeader selectedGeounitIds={selectedGeounitIds} project={project} />}
+    {project && (
+      <SidebarHeader
+        selectedGeounitIds={selectedGeounitIds}
+        project={project}
+        isLoading={isLoading}
+      />
+    )}
     <Styled.table>
       <thead>
         <Styled.tr>
@@ -55,11 +67,12 @@ const ProjectSidebar = ({
 
 const SidebarHeader = ({
   selectedGeounitIds,
-  project
+  project,
+  isLoading
 }: {
   readonly selectedGeounitIds: ReadonlySet<number>;
   readonly project: IProject;
-}) => {
+} & LoadingProps) => {
   return (
     <Flex sx={{ variant: "header.app" }}>
       <Flex sx={{ variant: "header.left" }}>
@@ -67,7 +80,9 @@ const SidebarHeader = ({
           Districts
         </Heading>
       </Flex>
-      {selectedGeounitIds.size ? (
+      {isLoading ? (
+        <Loading />
+      ) : selectedGeounitIds.size ? (
         <Flex sx={{ variant: "header.right" }}>
           <Button
             variant="circularSubtle"

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -78,8 +78,7 @@ const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
       return loop(
         {
           ...state,
-          project: { resource: action.payload },
-          selectedGeounitIds: new Set([])
+          project: { resource: action.payload }
         },
         Cmd.action(projectFetchGeoJson(action.payload.id))
       );

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -45,7 +45,6 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
   state: ProjectDataState = initialState,
   action: Action
 ): ProjectDataState | Loop<ProjectDataState, Action> => {
-  console.log(action, state);
   switch (action.type) {
     case getType(projectDataFetch):
       return loop(state, Cmd.action(projectFetch(action.payload)));

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -44,6 +44,7 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
   state: ProjectDataState = initialState,
   action: Action
 ): ProjectDataState | Loop<ProjectDataState, Action> => {
+  console.log(action, state);
   switch (action.type) {
     case getType(projectDataFetch):
       return loop(state, Cmd.action(projectFetch(action.payload)));
@@ -88,7 +89,10 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
       return loop(
         {
           ...state,
-          geojson: { errorMessage: action.payload }
+          geojson: {
+            ...state.geojson,
+            isPending: true
+          }
         },
         Cmd.run(fetchProjectGeoJson, {
           successActionCreator: projectFetchGeoJsonSuccess,

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -18,6 +18,7 @@ import {
   staticMetadataFetchFailure,
   staticMetadataFetchSuccess
 } from "../actions/projectData";
+import { clearSelectedGeounitIds } from "../actions/districtDrawing";
 
 import { DistrictProperties, IProject, IStaticMetadata } from "../../shared/entities";
 import { fetchProject, fetchProjectGeoJson } from "../api";
@@ -81,10 +82,13 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
         project: { errorMessage: action.payload }
       };
     case getType(projectFetchGeoJsonSuccess):
-      return {
-        ...state,
-        geojson: { resource: action.payload }
-      };
+      return loop(
+        {
+          ...state,
+          geojson: { resource: action.payload }
+        },
+        Cmd.action(clearSelectedGeounitIds())
+      );
     case getType(projectFetchGeoJson):
       return loop(
         {

--- a/src/client/resource.ts
+++ b/src/client/resource.ts
@@ -12,6 +12,10 @@ export interface ResourceSuccess<T> {
 export interface ResourceFailure {
   readonly errorMessage: string;
 }
+export interface ResourceRefreshing<T> {
+  readonly isPending: true;
+  readonly resource: T;
+}
 export interface ResourceWritePending<D> {
   readonly data: D;
   readonly isPending: true;
@@ -25,7 +29,11 @@ export interface ResourceWriteFailure<D> {
   readonly errors: Errors<D>;
 }
 
-export type Resource<T> = ResourcePending | ResourceSuccess<T> | ResourceFailure;
+export type Resource<T> =
+  | ResourcePending
+  | ResourceSuccess<T>
+  | ResourceFailure
+  | ResourceRefreshing<T>;
 
 export type WriteResource<D, T> =
   | ResourceEditing<D>

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -44,6 +44,9 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const { projectId } = useParams();
   const project = "resource" in projectData.project ? projectData.project.resource : undefined;
   const geojson = "resource" in projectData.geojson ? projectData.geojson.resource : undefined;
+  const isLoading =
+    ("isPending" in projectData.project && projectData.project.isPending) ||
+    ("isPending" in projectData.geojson && projectData.geojson.isPending);
 
   useEffect(() => {
     store.dispatch(userFetch());
@@ -61,6 +64,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
         <ProjectSidebar
           project={project}
           geojson={geojson}
+          isLoading={isLoading}
           selectedDistrictId={districtDrawing.selectedDistrictId}
           selectedGeounitIds={districtDrawing.selectedGeounitIds}
         />

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -82,6 +82,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
               staticGeoLevels={projectData.staticGeoLevels.resource}
               staticDemographics={projectData.staticDemographics.resource}
               selectedGeounitIds={districtDrawing.selectedGeounitIds}
+              selectedDistrictId={districtDrawing.selectedDistrictId}
             />
           ) : null}
         </MapContainer>


### PR DESCRIPTION
## Overview

Seamlessly rerender the map after editing districts

### Demo

![district_builder_seamless_districts2](https://user-images.githubusercontent.com/2926237/86380169-ca474100-bc59-11ea-8d54-19f7fce58140.gif)

### Notes

This PR is kind of a grab bag of changes to achieve the desired effect (how this should work was informed by discussions with @jfrankl )

It includes a change to the loading state (now "Loading..." is shown while waiting for district definition saving and loading new GeoJSON, though that was broken out into a separate `Loading.tsx` component so it can easily be improved later; see https://github.com/PublicMapping/districtbuilder/issues/194)

Part of making the seamless refresh functionality work required a reducer state change to both persist the current GeoJSON and show a loading state during the refresh (see change to `resource.ts`).

I added f562a11 to try to mitigate flicker (see that commit description). It's still slightly flickery and could be improved but I think it's a lot better than showing the white map underneath for a second (much worse flicker). (You may want to revert f562a11 to see the difference.)

## Testing Instructions
Test:
* Adding an unassigned geounit
* Changing the district for an assigned geounit
* Removing a geounit from district
* Test selecting multiple geounits and performing the above operations
* Test for flicker (see f562a11) 

Closes #185 
