### PR TITLE
Display intermediate changes to population in sidebar

### DIFF
--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -210,9 +210,11 @@ const Map = ({
       (selectedDistrictId === 0
         ? removeSelectedFeatures(map)
         : // When adding or changing the district to which a geounit is
-          // assigned, wait until districts GeoJSON is updated before removing
-          // selected state.
-          map.once("idle", () => removeSelectedFeatures(map)));
+        // assigned, wait until districts GeoJSON is updated before removing
+        // selected state.
+        map.isStyleLoaded()
+        ? removeSelectedFeatures(map)
+        : map.once("idle", () => removeSelectedFeatures(map)));
     // We don't want to tigger this effect when `selectedDistrictId` changes
     // eslint-disable-next-line
   }, [map, selectedGeounitIds, topGeoLevel]);

--- a/src/client/components/Map.tsx
+++ b/src/client/components/Map.tsx
@@ -212,7 +212,7 @@ const Map = ({
         : // When adding or changing the district to which a geounit is
         // assigned, wait until districts GeoJSON is updated before removing
         // selected state.
-        map.isStyleLoaded()
+        map.isStyleLoaded() && map.isSourceLoaded("districts")
         ? removeSelectedFeatures(map)
         : map.once("idle", () => removeSelectedFeatures(map)));
     // We don't want to tigger this effect when `selectedDistrictId` changes

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -98,3 +98,7 @@ export const getDistrictColor = (id?: string | number) => {
   // Cycle through the list in case there are a very large number of districts
   return districtColors[index % districtColors.length];
 };
+
+export const positiveChangeColor = "#2dbeae";
+export const negativeChangeColor = "#f5677a";
+export const selectedDistrictColor = "#efefef";

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -44,6 +44,14 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const { projectId } = useParams();
   const project = "resource" in projectData.project ? projectData.project.resource : undefined;
   const geojson = "resource" in projectData.geojson ? projectData.geojson.resource : undefined;
+  const staticMetadata =
+    "resource" in projectData.staticMetadata ? projectData.staticMetadata.resource : undefined;
+  const staticGeoLevels =
+    "resource" in projectData.staticGeoLevels ? projectData.staticGeoLevels.resource : undefined;
+  const staticDemographics =
+    "resource" in projectData.staticDemographics
+      ? projectData.staticDemographics.resource
+      : undefined;
   const isLoading =
     ("isPending" in projectData.project && projectData.project.isPending) ||
     ("isPending" in projectData.geojson && projectData.geojson.isPending);
@@ -65,6 +73,9 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
           project={project}
           geojson={geojson}
           isLoading={isLoading}
+          staticMetadata={staticMetadata}
+          staticGeoLevels={staticGeoLevels}
+          staticDemographics={staticDemographics}
           selectedDistrictId={districtDrawing.selectedDistrictId}
           selectedGeounitIds={districtDrawing.selectedGeounitIds}
         />


### PR DESCRIPTION
## Overview

This displays in-progress population changes in the district sidebar as geounits are being selected. The selected district shows increases in population, while any districts that geounits are being pulled from (including the unassigned district) show decreases in population. These increases and decreases are color coded accordingly (green/red).

### Demo

![screenshot_13](https://user-images.githubusercontent.com/6386/86797209-651a9380-c03d-11ea-883d-ae2e404fb635.png)

### Notes

 * Also fixed a problem with the unassigned district being counted as a normal district when calculating population deviations
 * Also fixed a problem with cancel button not clearing selection
 * This is only currently working for the top-most geolevel, which is the only one we can currently select. I spent a lot of time attempting to get it to work with districts comprised of other geolevels too (via manually POSTing district definitions), but ran into a road block, since we don't currently have enough information on the front-end to determine the full composition of base geounits for a given district. I've added some comments explaining the problem, and had a chat with developers. In order to get this working with multiple geolevels, it looks like we are going to have to generate a slimmed-down version of the hierarchy (with no shapes) and ship it over to the front-end.

## Testing Instructions

- `./scripts/server`
- View a project page
- Interact with the map, selecting various geounits and districts, and verify that the numbers are adjusting accordingly

Closes #186 
Closes #197 
