### PR TITLE
Add zoom level metadata

### DIFF
--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -56,7 +56,7 @@ export class TopologyService {
       const topojsonBody = topojsonResponse.Body?.toString("utf8");
       if (staticMetadataBody && topojsonBody) {
         const staticMetadata = JSON.parse(staticMetadataBody) as IStaticMetadata;
-        const geoLevelHierarchy = staticMetadata.geoLevelHierarchy;
+        const geoLevelHierarchy = staticMetadata.geoLevelHierarchy.map(gl => gl.id);
         if (!geoLevelHierarchy) {
           this.logger.error(`geoLevelHierarchy missing from static metadata for ${s3URI}`);
         }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -23,11 +23,17 @@ export interface IStaticFile {
   readonly bytesPerElement: number;
 }
 
+export interface GeoLevelInfo {
+  readonly id: string;
+  readonly maxZoom: number;
+  readonly minZoom: number;
+}
+
 export interface IStaticMetadata {
   readonly demographics: readonly IStaticFile[];
   readonly geoLevels: readonly IStaticFile[];
   readonly bbox: readonly [number, number, number, number];
-  readonly geoLevelHierarchy: readonly string[];
+  readonly geoLevelHierarchy: readonly GeoLevelInfo[];
 }
 
 export interface Login {


### PR DESCRIPTION
## Overview

We need min and max zoom level information on the client-side in order to perform zoom level restrictions. This PR extracts that information from the metadata that `tippecanoe` produces, and adds it to our static metadata.

## Testing Instructions
- Because the format of the static metadata is changing, your current projects/regions will be invalid, delete them:
  - `./scripts/dbshell`
  - `truncate table region_config cascade;`
- Run `process-geojson` for a region, and then run `publish-region` for the output
- Verify that the `static-metadata.json` file contains new min/max zoom level information for each geolevel
- `./scripts/server`
- Create a new project with the newly published region config
- Verify that things behave as normal (the interface for `IStaticMetadata` changed, so I need to update a few places on the front-end, but didn't make another other front-end changes)

Closes #199
