### PR TITLE
Fix rectangle selection tool bug with multiple selections

### DIFF
--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -54,7 +54,7 @@ const RectangleSelectionTool: ISelectionTool = {
       document.addEventListener("mouseup", onMouseUp);
 
       setOfInitiallySelectedFeatures = featuresToSet(
-        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(feature) === true)
+        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(feature))
       );
 
       // Capture the first xy coordinates
@@ -93,7 +93,7 @@ const RectangleSelectionTool: ISelectionTool = {
       const features = getFeaturesInBoundingBox([start, current]);
 
       // Set any newly selected features on the map within the bounding box to selected state
-      const newFeatures = features.filter(feature => isFeatureSelected(feature) === false);
+      const newFeatures = features.filter(feature => !isFeatureSelected(feature));
       newFeatures.forEach(feature => {
         map.setFeatureState(featureStateExpression(feature.id), { selected: true });
       });

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -53,7 +53,9 @@ const RectangleSelectionTool: ISelectionTool = {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
 
-      setOfInitiallySelectedFeatures = featuresToSet(getAllSelectedFeatures());
+      setOfInitiallySelectedFeatures = featuresToSet(
+        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(feature) === true)
+      );
 
       // Capture the first xy coordinates
       start = mousePos(e);
@@ -61,7 +63,7 @@ const RectangleSelectionTool: ISelectionTool = {
 
     function onMouseMove(e: MouseEvent) {
       // Find selected features before updating `current` to tell if any features were deselected
-      const prevSelectedFeatures = current && getAllSelectedFeatures([start, current]);
+      const prevFeatures = current && getFeaturesInBoundingBox([start, current]);
 
       // Capture the ongoing xy coordinates
       current = mousePos(e);
@@ -88,23 +90,21 @@ const RectangleSelectionTool: ISelectionTool = {
       box.style.height = maxY - minY + "px";
       /* eslint-enable */
 
-      const selectedFeatures = getAllSelectedFeatures([start, current]);
+      const features = getFeaturesInBoundingBox([start, current]);
 
       // Set any newly selected features on the map within the bounding box to selected state
-      const newlySelectedFeatures = selectedFeatures.filter(
-        feature => isFeatureSelected(feature) === false
-      );
-      newlySelectedFeatures.forEach(feature => {
+      const newFeatures = features.filter(feature => isFeatureSelected(feature) === false);
+      newFeatures.forEach(feature => {
         map.setFeatureState(featureStateExpression(feature.id), { selected: true });
       });
 
       // Set any features that were previously selected and just became unselected to unselected
       // eslint-disable-next-line
-      if (prevSelectedFeatures) {
-        const setOfPrevSelectedFeatures = featuresToSet(prevSelectedFeatures);
-        const setOfSelectedFeatures = featuresToSet(selectedFeatures);
-        [...setOfPrevSelectedFeatures]
-          .filter(id => !setOfInitiallySelectedFeatures.has(id) && !setOfSelectedFeatures.has(id))
+      if (prevFeatures) {
+        const setOfPrevFeatures = featuresToSet(prevFeatures);
+        const setOfFeatures = featuresToSet(features);
+        [...setOfPrevFeatures]
+          .filter(id => !setOfInitiallySelectedFeatures.has(id) && !setOfFeatures.has(id))
           .forEach(id => {
             map.setFeatureState(featureStateExpression(id), { selected: false });
           });
@@ -140,7 +140,7 @@ const RectangleSelectionTool: ISelectionTool = {
     }
 
     // eslint-disable-next-line
-    function getAllSelectedFeatures(bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]) {
+    function getFeaturesInBoundingBox(bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]) {
       return map.queryRenderedFeatures(bbox, {
         layers: [levelToSelectionLayerId(topGeoLevel)]
       });
@@ -161,7 +161,7 @@ const RectangleSelectionTool: ISelectionTool = {
       // If bbox exists. use this value as the argument for `queryRenderedFeatures`
       // eslint-disable-next-line
       if (bbox) {
-        const selectedFeatures = getAllSelectedFeatures(bbox);
+        const selectedFeatures = getFeaturesInBoundingBox(bbox);
         selectedFeatures.length &&
           store.dispatch(addSelectedGeounitIds(featuresToSet(selectedFeatures)));
       }

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -37,7 +37,7 @@ const RectangleSelectionTool: ISelectionTool = {
     // Save mouseDown for removal upon disabling
     this.mouseDown = mouseDown; // eslint-disable-line
 
-    let setOfInitiallySelectedFeatures: ReadonlySet<number>;
+    let setOfInitiallySelectedFeatures: ReadonlySet<number>; // eslint-disable-line
 
     // Return the xy coordinates of the mouse position
     function mousePos(e: MouseEvent) {

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -37,6 +37,8 @@ const RectangleSelectionTool: ISelectionTool = {
     // Save mouseDown for removal upon disabling
     this.mouseDown = mouseDown; // eslint-disable-line
 
+    let setOfInitiallySelectedFeatures: ReadonlySet<number>;
+
     // Return the xy coordinates of the mouse position
     function mousePos(e: MouseEvent) {
       const rect = canvas.getBoundingClientRect();
@@ -50,6 +52,8 @@ const RectangleSelectionTool: ISelectionTool = {
       // Call functions for the following events
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
+
+      setOfInitiallySelectedFeatures = featuresToSet(getAllSelectedFeatures());
 
       // Capture the first xy coordinates
       start = mousePos(e);
@@ -100,7 +104,7 @@ const RectangleSelectionTool: ISelectionTool = {
         const setOfPrevSelectedFeatures = featuresToSet(prevSelectedFeatures);
         const setOfSelectedFeatures = featuresToSet(selectedFeatures);
         [...setOfPrevSelectedFeatures]
-          .filter(id => !setOfSelectedFeatures.has(id))
+          .filter(id => !setOfInitiallySelectedFeatures.has(id) && !setOfSelectedFeatures.has(id))
           .forEach(id => {
             map.setFeatureState(featureStateExpression(id), { selected: false });
           });
@@ -136,7 +140,7 @@ const RectangleSelectionTool: ISelectionTool = {
     }
 
     // eslint-disable-next-line
-    function getAllSelectedFeatures(bbox: [MapboxGL.PointLike, MapboxGL.PointLike]) {
+    function getAllSelectedFeatures(bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]) {
       return map.queryRenderedFeatures(bbox, {
         layers: [levelToSelectionLayerId(topGeoLevel)]
       });


### PR DESCRIPTION
## Overview

Small bug fix that @kshepard noticed related to the newly-implemented rectangle selection tool when making multiple, separate selections.

This fix should make the rectangle selection tool work the same as the prototype.

Bug fix is in 63a5616

### Demo

**Before**
![db_rectangle_selection_bug_before](https://user-images.githubusercontent.com/2926237/87601501-39458080-c6c3-11ea-8f2c-e0c85442dc7d.gif)

**After**
![db_rectangle_selection_bug_after](https://user-images.githubusercontent.com/2926237/87601503-39458080-c6c3-11ea-96b6-149590157ead.gif)

## Testing Instructions
* Make a selection using the rectangle tool, making sure to select at least one feature (mousing over the not yet selected feature should deselect it)
* Make a separate selection, mousing over and off the originally selected feature and newly selected features (original should stay selected, new features should be selected/unselected as per prototype)
