### PR TITLE
Add missing static data needed for constructing districts

### DIFF
--- a/src/manage/tsconfig.json
+++ b/src/manage/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDirs": ["src", "../"],
     "strict": true,
     "strictPropertyInitialization": false,
-    "target": "es2017"
+    "target": "es2019"
   },
   "include": [
     "src/**/*"

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -8,17 +8,13 @@ import {
   Topology
 } from "topojson-specification";
 
-import { GeoUnitCollection, IStaticMetadata } from "../../../../shared/entities";
+import { GeoUnitCollection, GeoUnitDefinition, IStaticMetadata } from "../../../../shared/entities";
 import { getAllIndices, getDemographics } from "../../../../shared/functions";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
 
 interface GeoUnitHierarchy {
   geom: Polygon | MultiPolygon;
   children: ReadonlyArray<GeoUnitHierarchy>;
-}
-
-export interface GeoUnitDefinition {
-  groups: ReadonlyArray<string>;
 }
 
 // Creates a list of trees for the nested geometries of the geounits

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -9,7 +9,13 @@ export interface IUser {
 
 export type GeoUnitCollection = number | readonly GeoUnitCollection[];
 
+export interface GeoUnitDefinition {
+  readonly groups: ReadonlyArray<string>;
+}
+
 export type DistrictsDefinition = readonly GeoUnitCollection[];
+
+export type HierarchyDefinition = readonly GeoUnitCollection[];
 
 export interface IDistrictsDefinition {
   readonly districts: DistrictsDefinition;


### PR DESCRIPTION
## Overview

There were two more pieces of information needed in order to properly be able to draw and save districts:
 1) We need a slimmed-down geounit hierarchy, so when we're operating with district definitions, we are able to properly find all base geounits for a given entity. This is needed when performing sidebar calculations, and is also needed for determining how many child geounits belong to a given geounit (for use during generation of district definitions when a geounit item needs to be exploded).
 2) We need information about all parent geounit hierarchical ids on the vector tiles. For example, when a user selects a block, we need to know the parent blockgroup and county indices, so we can set them properly in the district definition.

To accomplish these, a new file has been generated: `geounit-hierarchy.json`, which has a similar structure to the district definition (nested array with leaves of integers). Here, the leaves are always at the base geolevel, and the values are base geounit indices. The vector tiles have also been updated with new properties for parent geounit indices. These properties are named by the geolevel key suffixed with "Idx". For example, blocks will have properties for "blockgroupIdx" and "countyIdx", blockgroups will have a property for "countyIdx", and counties won't have any properties (since there are no parents).

### Demo

![screenshot_idx_props](https://user-images.githubusercontent.com/6386/87682035-5f176780-c74d-11ea-826a-9a9a980497fa.png)

![screenshot_geounit-hierarchy](https://user-images.githubusercontent.com/6386/87682723-2e83fd80-c74e-11ea-9cd9-2ba63538f3f6.png)

### Notes

 * I've processed and published both DE and PA data. Here are some DB parameters in case anyone wants to try these region configs out without needing to process:
```
["Delaware","US","DE","s3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-07-16T13:43:57.706Z/","2020-07-16T13:43:57.706Z"]
["Pennsylvania","US","PA","s3://global-districtbuilder-dev-us-east-1/regions/US/PA/2020-07-16T13:50:38.570Z/","2020-07-16T13:50:38.570Z"]
```
 * Compiler target has been updated to `es2019` to be in-line with the server (as well as to be able to use `Object.fromEntries`)
 * The new hierarchy generation is very similar to the code on the server-side for when we generate geojson from a district definition. I've copied over the `group` and `getNode` functions from this and modified them accordingly (it's very similar, but different enough that trying to abstract it out into something reusable wasn't practical).
 * I explored several ways to add the indices to the vector tiles (including trying to bolt pieces of it on to the above hierarchy generation, but it didn't end up fitting in very nicely anywhere. So I ended up just writing a separate imperative, mutation-heavy function that does the trick in the interest of time, though I don't love the approach.
 * The new `geounit-hierarchy.json` is a little on the large size (a couple megs for PA), but will be much easier to work with than the array buffers. If we end up having any problems due to the large size, I know of a way to optimize this by making modifications to our array buffers in a way that better expresses the hierarchy. Having information in that form will allow us to reconstruct this hierarchy on the front-end if needed. The reason I didn't go with that approach is because it would result in more changes, and would be more difficult to work with, so it felt like a premature optimization. However, the option is open if we need it.

## Testing Instructions

- Process GeoJSON for your state of choice. E.g. for Deleware (your dirs may vary): `./scripts/manage process-geojson data/input/DE.geojson -o data/output-de -n 12,4,4 -x 12,12,12 -l block,tract,county`
- Take a look at the new `geounit-hierarchy.json` file and ensure it has contents that line up with the expected structure
- Take a look at the intermediate geojson files for each geolevel, and verify each file has the appropriate `xxxIdx` property keys for the geolevel. These files are used to generate the vector tiles, so it's safe to assume if they made it to this file, they're also on the vector tiles. However I also included a screenshot above to show that it does indeed make it's way onto the vector tile.

Closes #198
