### PR TITLE
Fix cancel not deselecting geounits

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -121,9 +121,11 @@ const Map = ({
       (selectedDistrictId === 0
         ? removeSelectedFeatures(map)
         : // When adding or changing the district to which a geounit is
-          // assigned, wait until districts GeoJSON is updated before removing
-          // selected state.
-          map.once("idle", () => removeSelectedFeatures(map)));
+        // assigned, wait until districts GeoJSON is updated before removing
+        // selected state.
+        map.isStyleLoaded() && map.isSourceLoaded(DISTRICTS_SOURCE_ID)
+        ? removeSelectedFeatures(map)
+        : map.once("idle", () => removeSelectedFeatures(map)));
     // We don't want to tigger this effect when `selectedDistrictId` changes
     // eslint-disable-next-line
   }, [map, selectedGeounitIds, topGeoLevel]);


### PR DESCRIPTION
## Overview

The cancel button wasn't deselecting geounits. This was fixed in #196, but it looks like it must have accidentally been rebased out in a subsequent PR. This PR is simply reapplying that one change (and making use of the new constant).

## Testing Instructions

- Select some geounits on the map
- Click the cancel button and verify that the geounits on the map are deselected (without the change in this PR, the selection hangs out on the map).
