### PR TITLE
Add zoom geolevel restrictions and auto-saving when switching geolevels

### DIFF
--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -16,6 +16,6 @@ export const setSelectionTool = createAction("Set selection tool")<SelectionTool
 
 export const setGeoLevelIndex = createAction("Set geoLevel index")<number>();
 
-export const setBaseGeoUnitVisible = createAction("Set base geounit visible")<boolean>();
+export const setGeoLevelVisibility = createAction("Set geolevel visibility")<readonly boolean[]>();
 
 export const saveDistrictsDefinition = createAction("Save districts definition")();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,5 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { GeoUnits, GeoUnitHierarchy, IProject } from "../../shared/entities";
+import { GeoUnits } from "../../shared/entities";
 
 export enum SelectionTool {
   Default = "DEFAULT",
@@ -12,20 +12,10 @@ export const addSelectedGeounitIds = createAction("Add selected geounit ids")<Ge
 export const removeSelectedGeounitIds = createAction("Remove selected geounit ids")<GeoUnits>();
 export const clearSelectedGeounitIds = createAction("Clear selected geounit ids")();
 
-export const saveDistrictsDefinition = createAction("Save districts definition")<{
-  readonly project: IProject;
-  readonly geoUnitHierarchy: GeoUnitHierarchy;
-}>();
-
-export const patchDistrictsDefinitionSuccess = createAction("Patch districts definition success")<
-  IProject
->();
-export const patchDistrictsDefinitionFailure = createAction("Patch districts definition failure")<
-  string
->();
-
 export const setSelectionTool = createAction("Set selection tool")<SelectionTool>();
 
 export const setGeoLevelIndex = createAction("Set geoLevel index")<number>();
 
 export const setBaseGeoUnitVisible = createAction("Set base geounit visible")<boolean>();
+
+export const saveDistrictsDefinition = createAction("Save districts definition")();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -27,3 +27,5 @@ export const patchDistrictsDefinitionFailure = createAction("Patch districts def
 export const setSelectionTool = createAction("Set selection tool")<SelectionTool>();
 
 export const setGeoLevelIndex = createAction("Set geoLevel index")<number>();
+
+export const setBaseGeoUnitVisible = createAction("Set base geounit visible")<boolean>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -3,6 +3,7 @@ import { FeatureCollection, MultiPolygon } from "geojson";
 import {
   DistrictProperties,
   GeoUnitHierarchy,
+  GeoUnits,
   IProject,
   IStaticMetadata,
   ProjectId
@@ -42,3 +43,15 @@ export const staticGeounitHierarchyFetchSuccess = createAction(
 export const staticGeounitHierarchyFetchFailure = createAction(
   "Static geounit hierarchy fetch failure"
 )<string>();
+
+export const updateDistrictsDefinition = createAction("Update districts definition")<{
+  readonly selectedGeounits: GeoUnits;
+  readonly selectedDistrictId: number;
+}>();
+
+export const updateDistrictsDefinitionSuccess = createAction("Update districts definition success")<
+  IProject
+>();
+export const updateDistrictsDefinitionFailure = createAction("Update districts definition failure")<
+  string
+>();

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -17,7 +17,7 @@ const geoLevelLabel = (id: string) => {
     case "county":
       return "Counties";
     default:
-      return "";
+      return id;
   }
 };
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -11,13 +11,15 @@ const MapHeader = ({
   setMapLabel,
   metadata,
   selectionTool,
-  geoLevelIndex
+  geoLevelIndex,
+  isBaseGeoUnitVisible
 }: {
   readonly label?: string;
   readonly setMapLabel: (label?: string) => void;
   readonly metadata?: IStaticMetadata;
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number;
+  readonly isBaseGeoUnitVisible: boolean;
 }) => {
   const labelOptions = metadata
     ? metadata.demographics.map(val => <option key={val.id}>{val.id}</option>)
@@ -27,15 +29,22 @@ const MapHeader = ({
     ? metadata.geoLevelHierarchy
         .slice()
         .reverse()
-        .map((val, index) => (
-          <button
-            key={index}
-            className={buttonClassName(geoLevelIndex === index)}
-            onClick={() => store.dispatch(setGeoLevelIndex(index))}
-          >
-            {val.id}
-          </button>
-        ))
+        .map((val, index) => {
+          const isButtonDisabled =
+            index === metadata.geoLevelHierarchy.length - 1 && !isBaseGeoUnitVisible;
+          const otherProps = isButtonDisabled ? { title: "Zoom in to see blocks" } : {};
+          return (
+            <button
+              key={index}
+              className={buttonClassName(geoLevelIndex === index)}
+              onClick={() => store.dispatch(setGeoLevelIndex(index))}
+              disabled={isButtonDisabled}
+              {...otherProps}
+            >
+              {val.id}
+            </button>
+          );
+        })
     : [];
   return (
     <Box sx={{ variant: "header.app", backgroundColor: "white" }} className="map-actions">

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -6,6 +6,21 @@ import Icon from "./Icon";
 import { setGeoLevelIndex, setSelectionTool, SelectionTool } from "../actions/districtDrawing";
 import store from "../store";
 
+const geoLevelLabel = (id: string) => {
+  switch (id) {
+    case "block":
+      return "Blocks";
+    case "tract":
+      return "Tracts";
+    case "blockgroup":
+      return "Blockgroups";
+    case "county":
+      return "Counties";
+    default:
+      return "";
+  }
+};
+
 const MapHeader = ({
   label,
   setMapLabel,
@@ -31,7 +46,9 @@ const MapHeader = ({
         .reverse()
         .map((val, index) => {
           const isButtonDisabled = geoLevelVisibility[index] === false;
-          const otherProps = isButtonDisabled ? { title: "Zoom in to see blocks" } : {};
+          const otherProps = isButtonDisabled
+            ? { title: `Zoom in to see ${geoLevelLabel(val.id).toLowerCase()}` }
+            : {};
           return (
             <button
               key={index}
@@ -40,7 +57,7 @@ const MapHeader = ({
               disabled={isButtonDisabled}
               {...otherProps}
             >
-              {val.id}
+              {geoLevelLabel(val.id)}
             </button>
           );
         })

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -12,14 +12,14 @@ const MapHeader = ({
   metadata,
   selectionTool,
   geoLevelIndex,
-  isBaseGeoUnitVisible
+  geoLevelVisibility
 }: {
   readonly label?: string;
   readonly setMapLabel: (label?: string) => void;
   readonly metadata?: IStaticMetadata;
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number;
-  readonly isBaseGeoUnitVisible: boolean;
+  readonly geoLevelVisibility: readonly boolean[];
 }) => {
   const labelOptions = metadata
     ? metadata.demographics.map(val => <option key={val.id}>{val.id}</option>)
@@ -30,8 +30,7 @@ const MapHeader = ({
         .slice()
         .reverse()
         .map((val, index) => {
-          const isButtonDisabled =
-            index === metadata.geoLevelHierarchy.length - 1 && !isBaseGeoUnitVisible;
+          const isButtonDisabled = geoLevelVisibility[index] === false;
           const otherProps = isButtonDisabled ? { title: "Zoom in to see blocks" } : {};
           return (
             <button

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -143,7 +143,7 @@ const SidebarHeader = ({
             variant="circular"
             sx={{ cursor: "pointer" }}
             onClick={() => {
-              store.dispatch(saveDistrictsDefinition({ project, geoUnitHierarchy }));
+              store.dispatch(saveDistrictsDefinition());
             }}
           >
             Approve

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -69,12 +69,7 @@ const ProjectSidebar = ({
       }}
     >
       {project && geoUnitHierarchy && (
-        <SidebarHeader
-          selectedGeounits={selectedGeounits}
-          geoUnitHierarchy={geoUnitHierarchy}
-          project={project}
-          isLoading={isLoading}
-        />
+        <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       )}
       <Styled.table>
         <thead>
@@ -111,13 +106,9 @@ const ProjectSidebar = ({
 
 const SidebarHeader = ({
   selectedGeounits,
-  geoUnitHierarchy,
-  project,
   isLoading
 }: {
   readonly selectedGeounits: GeoUnits;
-  readonly geoUnitHierarchy: GeoUnitHierarchy;
-  readonly project: IProject;
 } & LoadingProps) => {
   return (
     <Flex sx={{ variant: "header.app" }}>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -181,7 +181,7 @@ const Map = ({
         map.off("zoomstart", restrictZoom);
       };
     }
-  }, [map, selectedGeolevel, staticMetadata, selectedGeounits]);
+  }, [map, selectedGeolevel, staticMetadata, selectedGeounits, minZoom]);
 
   useEffect(() => {
     /* eslint-disable */

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -121,8 +121,15 @@ const Map = ({
     districtsSource && districtsSource.type === "geojson" && districtsSource.setData(geojson);
   }, [map, geojson]);
 
-  const removeSelectedFeatures = (map: MapboxGL.Map) => {
-    map.removeFeatureState({ source: GEOLEVELS_SOURCE_ID, sourceLayer: selectedGeolevel.id });
+  const removeSelectedFeatures = (map: MapboxGL.Map, staticMetadata: IStaticMetadata) => {
+    staticMetadata.geoLevelHierarchy
+      .map(geoLevel => geoLevel.id)
+      .forEach(sourceLayer =>
+        map.removeFeatureState({
+          source: GEOLEVELS_SOURCE_ID,
+          sourceLayer
+        })
+      );
   };
 
   // Remove selected features from map when selected geounit ids has been emptied
@@ -130,16 +137,16 @@ const Map = ({
     map &&
       selectedGeounits.size === 0 &&
       (selectedDistrictId === 0
-        ? removeSelectedFeatures(map)
+        ? removeSelectedFeatures(map, staticMetadata)
         : // When adding or changing the district to which a geounit is
         // assigned, wait until districts GeoJSON is updated before removing
         // selected state.
         map.isStyleLoaded() && map.isSourceLoaded(DISTRICTS_SOURCE_ID)
-        ? removeSelectedFeatures(map)
-        : map.once("idle", () => removeSelectedFeatures(map)));
+        ? removeSelectedFeatures(map, staticMetadata)
+        : map.once("idle", () => removeSelectedFeatures(map, staticMetadata)));
     // We don't want to tigger this effect when `selectedDistrictId` changes
     // eslint-disable-next-line
-  }, [map, selectedGeounits]);
+  }, [map, selectedGeounits, staticMetadata]);
 
   // Update districts source when geojson is fetched
   useEffect(() => {

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import MapboxGL from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 
-import { SelectionTool } from "../../actions/districtDrawing";
+import { setBaseGeoUnitVisible, SelectionTool } from "../../actions/districtDrawing";
 import { getDistrictColor } from "../../constants/colors";
 import { DistrictProperties, GeoUnits, IProject, IStaticMetadata } from "../../../shared/entities";
 import {
@@ -15,6 +15,7 @@ import {
 } from "./index";
 import DefaultSelectionTool from "./DefaultSelectionTool";
 import RectangleSelectionTool from "./RectangleSelectionTool";
+import store from "../../store";
 
 const styles = {
   width: "100%",
@@ -97,6 +98,12 @@ const Map = ({
         });
 
         map.resize();
+      });
+
+      map.on("zoomend", () => {
+        const baseGeoUnit = staticMetadata.geoLevelHierarchy[0];
+        const baseGeoUnitMinZoom = baseGeoUnit.minZoom;
+        store.dispatch(setBaseGeoUnitVisible(map.getZoom() >= baseGeoUnitMinZoom));
       });
     };
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -12,8 +12,7 @@ import {
   DISTRICTS_SOURCE_ID,
   DISTRICTS_LAYER_ID,
   getMapboxStyle,
-  isBaseGeoUnitVisible,
-  areFeaturesSelected
+  isBaseGeoUnitVisible
 } from "./index";
 import DefaultSelectionTool from "./DefaultSelectionTool";
 import RectangleSelectionTool from "./RectangleSelectionTool";
@@ -164,7 +163,7 @@ const Map = ({
       // layers are shown at each zoom level.
       const restrictZoom = () => {
         // eslint-disable-next-line
-        if (areFeaturesSelected(map, staticMetadata)) {
+        if (selectedGeounits.size > 0) {
           map.setMinZoom(selectedGeolevel.minZoom);
           map.setMaxZoom(selectedGeolevel.maxZoom);
         }
@@ -174,7 +173,7 @@ const Map = ({
         map.off("zoomstart", restrictZoom);
       };
     }
-  }, [map, selectedGeolevel, staticMetadata]);
+  }, [map, selectedGeolevel, staticMetadata, selectedGeounits]);
 
   useEffect(() => {
     /* eslint-disable */

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -8,6 +8,8 @@ import { setBaseGeoUnitVisible, SelectionTool } from "../../actions/districtDraw
 import { getDistrictColor } from "../../constants/colors";
 import { DistrictProperties, GeoUnits, IProject, IStaticMetadata } from "../../../shared/entities";
 import {
+  DEFAULT_MIN_ZOOM,
+  DEFAULT_MAX_ZOOM,
   GEOLEVELS_SOURCE_ID,
   DISTRICTS_SOURCE_ID,
   DISTRICTS_LAYER_ID,
@@ -71,8 +73,8 @@ const Map = ({
         style: getMapboxStyle(project.regionConfig.s3URI, staticMetadata.geoLevelHierarchy),
         bounds: [b0, b1, b2, b3],
         fitBoundsOptions: { padding: 20 },
-        minZoom: 5,
-        maxZoom: 15
+        minZoom: DEFAULT_MIN_ZOOM,
+        maxZoom: DEFAULT_MAX_ZOOM
       });
 
       map.dragRotate.disable();
@@ -162,11 +164,7 @@ const Map = ({
       // selection could make the user's selection disappear since not all
       // layers are shown at each zoom level.
       const restrictZoom = () => {
-        // eslint-disable-next-line
-        if (selectedGeounits.size > 0) {
-          map.setMinZoom(selectedGeolevel.minZoom);
-          map.setMaxZoom(selectedGeolevel.maxZoom);
-        }
+        map.setMinZoom(selectedGeounits.size > 0 ? selectedGeolevel.minZoom : DEFAULT_MIN_ZOOM);
       };
       map.on("zoomstart", restrictZoom);
       return () => {

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -4,6 +4,7 @@ import { addSelectedGeounitIds } from "../../actions/districtDrawing";
 import {
   featuresToSet,
   GEOLEVELS_SOURCE_ID,
+  isFeatureSelected,
   levelToSelectionLayerId,
   ISelectionTool
 } from "./index";
@@ -21,7 +22,7 @@ import { GeoUnits, IStaticMetadata } from "../../../shared/entities";
  * https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/
  */
 const RectangleSelectionTool: ISelectionTool = {
-  enable: function(map: MapboxGL.Map, geoLevel: string, staticMetadata: IStaticMetadata) {
+  enable: function(map: MapboxGL.Map, geoLevelId: string, staticMetadata: IStaticMetadata) {
     map.boxZoom.disable();
     map.dragPan.disable();
     map.getCanvas().style.cursor = "crosshair"; // eslint-disable-line
@@ -60,7 +61,7 @@ const RectangleSelectionTool: ISelectionTool = {
       document.addEventListener("mouseup", onMouseUp);
 
       setOfInitiallySelectedFeatures = featuresToSet(
-        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(feature)),
+        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(map, feature)),
         staticMetadata.geoLevelHierarchy
       );
 
@@ -100,7 +101,7 @@ const RectangleSelectionTool: ISelectionTool = {
       const features = getFeaturesInBoundingBox([start, current]);
 
       // Set any newly selected features on the map within the bounding box to selected state
-      const newFeatures = features.filter(feature => !isFeatureSelected(feature));
+      const newFeatures = features.filter(feature => !isFeatureSelected(map, feature));
       newFeatures.forEach(feature => {
         map.setFeatureState(featureStateExpression(feature.id), { selected: true });
       });
@@ -127,13 +128,8 @@ const RectangleSelectionTool: ISelectionTool = {
       return {
         source: GEOLEVELS_SOURCE_ID,
         id,
-        sourceLayer: geoLevel
+        sourceLayer: geoLevelId
       };
-    }
-
-    function isFeatureSelected(feature: MapboxGL.MapboxGeoJSONFeature): boolean {
-      const featureState = map.getFeatureState(featureStateExpression(feature.id));
-      return featureState.selected === true;
     }
 
     function getFeaturesInBoundingBox(
@@ -141,7 +137,7 @@ const RectangleSelectionTool: ISelectionTool = {
       bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]
     ): readonly MapboxGL.MapboxGeoJSONFeature[] {
       return map.queryRenderedFeatures(bbox, {
-        layers: [levelToSelectionLayerId(geoLevel)]
+        layers: [levelToSelectionLayerId(geoLevelId)]
       });
     }
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -4,9 +4,6 @@ import { s3ToHttps } from "../../s3";
 
 import { FeatureId, GeoLevelInfo, GeoUnits, IStaticMetadata } from "../../../shared/entities";
 
-export const DEFAULT_MIN_ZOOM = 5;
-export const DEFAULT_MAX_ZOOM = 15;
-
 // Vector tiles with geolevel data for this geography
 export const GEOLEVELS_SOURCE_ID = "db";
 // GeoJSON district data for district as currently drawn
@@ -109,10 +106,15 @@ export function isFeatureSelected(
   return featureState.selected === true;
 }
 
-export function isBaseGeoUnitVisible(map: MapboxGL.Map, staticMetadata: IStaticMetadata): boolean {
-  const baseGeoUnit = staticMetadata.geoLevelHierarchy[0];
-  const baseGeoUnitMinZoom = baseGeoUnit.minZoom;
-  return map.getZoom() >= baseGeoUnitMinZoom;
+export function getGeoLevelVisibility(
+  map: MapboxGL.Map,
+  staticMetadata: IStaticMetadata
+): readonly boolean[] {
+  const mapZoom = map.getZoom();
+  return staticMetadata.geoLevelHierarchy
+    .slice()
+    .reverse()
+    .map(geoLevel => mapZoom <= geoLevel.maxZoom && mapZoom >= geoLevel.minZoom);
 }
 
 /* eslint-disable */

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -87,6 +87,25 @@ export function levelToSelectionLayerId(geoLevel: string) {
   return `${geoLevel}-selected`;
 }
 
+/*
+ * Used for getting/setting feature state.
+ */
+export function featureStateExpression(feature: MapboxGL.MapboxGeoJSONFeature) {
+  return {
+    source: GEOLEVELS_SOURCE_ID,
+    id: feature.id,
+    sourceLayer: feature.sourceLayer
+  };
+}
+
+export function isFeatureSelected(
+  map: MapboxGL.Map,
+  feature: MapboxGL.MapboxGeoJSONFeature
+): boolean {
+  const featureState = map.getFeatureState(featureStateExpression(feature));
+  return featureState.selected === true;
+}
+
 /* eslint-disable */
 export interface ISelectionTool {
   enable: (map: MapboxGL.Map, ...args: any) => void;

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -4,6 +4,9 @@ import { s3ToHttps } from "../../s3";
 
 import { GeoLevelInfo, GeoUnits, IStaticMetadata } from "../../../shared/entities";
 
+export const DEFAULT_MIN_ZOOM = 5;
+export const DEFAULT_MAX_ZOOM = 15;
+
 // Vector tiles with geolevel data for this geography
 export const GEOLEVELS_SOURCE_ID = "db";
 // GeoJSON district data for district as currently drawn

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -112,18 +112,6 @@ export function isBaseGeoUnitVisible(map: MapboxGL.Map, staticMetadata: IStaticM
   return map.getZoom() >= baseGeoUnitMinZoom;
 }
 
-export function areFeaturesSelected(map: MapboxGL.Map, staticMetadata: IStaticMetadata): boolean {
-  const allGeoLevelIds = staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.id);
-  const geoLevelIds = isBaseGeoUnitVisible(map, staticMetadata)
-    ? allGeoLevelIds
-    : allGeoLevelIds.slice(1);
-  const layers = geoLevelIds.map(levelToSelectionLayerId);
-  const allSelectedFeatures = map
-    .queryRenderedFeatures(undefined, { layers })
-    .filter(feature => isFeatureSelected(map, feature));
-  return allSelectedFeatures.length > 0;
-}
-
 /* eslint-disable */
 export interface ISelectionTool {
   enable: (map: MapboxGL.Map, ...args: any) => void;

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -2,7 +2,7 @@ import MapboxGL, { MapboxGeoJSONFeature } from "mapbox-gl";
 import { join } from "path";
 import { s3ToHttps } from "../../s3";
 
-import { GeoLevelInfo, GeoUnits, IStaticMetadata } from "../../../shared/entities";
+import { FeatureId, GeoLevelInfo, GeoUnits, IStaticMetadata } from "../../../shared/entities";
 
 export const DEFAULT_MIN_ZOOM = 5;
 export const DEFAULT_MAX_ZOOM = 15;
@@ -135,7 +135,7 @@ export function featuresToSet(
   // value set last will be used (thus achieving the uniqueness of sets).
   return new Map(
     features.map((feature: MapboxGeoJSONFeature) => [
-      feature.id as number,
+      feature.id as FeatureId,
       geoLevelHierarchyKeys.reduce(
         (geounitData, key) => {
           const geounitId = feature.properties && feature.properties[key];

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -12,7 +12,8 @@ import {
   SelectionTool,
   setSelectionTool,
   setSelectedDistrictId,
-  setGeoLevelIndex
+  setGeoLevelIndex,
+  setBaseGeoUnitVisible
 } from "../actions/districtDrawing";
 import { projectFetchGeoJson } from "../actions/projectData";
 import { assignGeounitsToDistrict } from "../../shared/functions";
@@ -25,13 +26,15 @@ export interface DistrictDrawingState {
   readonly selectedGeounits: GeoUnits;
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number; // Index is based off of reversed geoLevelHierarchy in static metadata
+  readonly isBaseGeoUnitVisible: boolean;
 }
 
 export const initialState = {
   selectedDistrictId: 1,
   selectedGeounits: new Map(),
   selectionTool: SelectionTool.Default,
-  geoLevelIndex: 0
+  geoLevelIndex: 0,
+  isBaseGeoUnitVisible: false
 };
 
 const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
@@ -103,6 +106,11 @@ const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
       return {
         ...state,
         geoLevelIndex: action.payload
+      };
+    case getType(setBaseGeoUnitVisible):
+      return {
+        ...state,
+        isBaseGeoUnitVisible: action.payload
       };
     default:
       return state as never;

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -11,7 +11,7 @@ import {
   setSelectionTool,
   setSelectedDistrictId,
   setGeoLevelIndex,
-  setBaseGeoUnitVisible
+  setGeoLevelVisibility
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition } from "../actions/projectData";
 import { GeoUnits } from "../../shared/entities";
@@ -21,7 +21,7 @@ export interface DistrictDrawingState {
   readonly selectedGeounits: GeoUnits;
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number; // Index is based off of reversed geoLevelHierarchy in static metadata
-  readonly isBaseGeoUnitVisible: boolean;
+  readonly geoLevelVisibility: ReadonlyArray<boolean>; // Visibility values at indices corresponding to `geoLevelIndex`
 }
 
 export const initialState = {
@@ -29,7 +29,7 @@ export const initialState = {
   selectedGeounits: new Map(),
   selectionTool: SelectionTool.Default,
   geoLevelIndex: 0,
-  isBaseGeoUnitVisible: false
+  geoLevelVisibility: []
 };
 
 const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
@@ -85,10 +85,10 @@ const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
           })
         )
       );
-    case getType(setBaseGeoUnitVisible):
+    case getType(setGeoLevelVisibility):
       return {
         ...state,
-        isBaseGeoUnitVisible: action.payload
+        geoLevelVisibility: action.payload
       };
     default:
       return state as never;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -88,6 +88,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
             metadata={staticMetadata}
             selectionTool={districtDrawing.selectionTool}
             geoLevelIndex={districtDrawing.geoLevelIndex}
+            isBaseGeoUnitVisible={districtDrawing.isBaseGeoUnitVisible}
           />
           {"resource" in projectData.project &&
           "resource" in projectData.staticMetadata &&

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -88,7 +88,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
             metadata={staticMetadata}
             selectionTool={districtDrawing.selectionTool}
             geoLevelIndex={districtDrawing.geoLevelIndex}
-            isBaseGeoUnitVisible={districtDrawing.isBaseGeoUnitVisible}
+            geoLevelVisibility={districtDrawing.geoLevelVisibility}
           />
           {"resource" in projectData.project &&
           "resource" in projectData.staticMetadata &&

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -117,4 +117,6 @@ export interface IChamber {
 // a county may have indices [0] where 0 = county
 export type GeoUnitIndices = readonly number[];
 
-export type GeoUnits = ReadonlyMap<number, GeoUnitIndices>;
+export type FeatureId = number;
+
+export type GeoUnits = ReadonlyMap<FeatureId, GeoUnitIndices>;


### PR DESCRIPTION
## Overview
Add zoom geolevel restrictions and auto-saving when switching geolevels

### Demo
![db_selector_constraints](https://user-images.githubusercontent.com/2926237/88334111-3ec44b80-ccff-11ea-9ff0-320a8363e98d.gif)

### Notes
There is a small amount of weirdness introduced in `reducers/districtDrawing.ts` where we need state held in `reducers/projectData.ts` to call the API function to save the updated district definition, so instead we kick off an action, passing the missing data along to the reducer that has the rest of the data to make the API call (previously we were getting around this by having the necessary data where the action is dispatched at the call site but now it needs to be called in two places to accommodate the auto-saving). I suppose this is the price we pay for encapsulation, but it does add complexity. The other alternative is to recombine the two reducers into one.

FWIW I still think the auto-saving is confusing and would rather just not let the user switch geolevels with some messaging if they have a selection instead of auto-saving for them.

## Testing Instructions
* Make sure you can only select the block level after zooming in enough to see blocks
* Make sure once you select a block, you can't zoom out so far as to no longer be able to see blocks
* Switch geolevels and make sure your select was saved

Closes #201 
