### PR TITLE
Fix displaying map labels when option is unselected

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -159,12 +159,19 @@ const Map = ({
 
   // Update labels when selection is changed
   useEffect(() => {
-    const visibility = label === undefined ? "none" : "visible";
-    // TODO: hardcoding county because we can't set the geolevel yet. This
-    // should instead display only for the current geolevel (GH#200)
-    map && map.setLayoutProperty("county-label", "visibility", visibility);
-    map && map.setLayoutProperty("county-label", "text-field", `{${label}}`);
-  }, [map, label]);
+    // eslint-disable-next-line
+    if (map) {
+      staticMetadata.geoLevelHierarchy.forEach(geoLevel =>
+        map.setLayoutProperty(`${geoLevel.id}-label`, "visibility", "none")
+      );
+      map.setLayoutProperty(`${selectedGeolevel.id}-label`, "visibility", "visible");
+      map.setLayoutProperty(
+        `${selectedGeolevel.id}-label`,
+        "text-field",
+        label ? `{${label}}` : ""
+      );
+    }
+  }, [map, label, staticMetadata, geoLevelIndex]);
 
   useEffect(() => {
     // eslint-disable-next-line

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -46,7 +46,6 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
           "text-field": "{population}",
           "text-max-width": 10,
           "text-font": ["GR"],
-          "text-ignore-placement": true,
           visibility: "none"
         },
         paint: {


### PR DESCRIPTION
Also switches to display the correct labels for the selected geounit, instead of always using the county labels, fixing a `TODO`.

Closes #215 