### PR TITLE
Update sidebar intermediate calculations to support multiple geolevels

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -242,7 +242,7 @@ const getTotalSelectedDemographics = (
   selectedGeounits: GeoUnits,
   geoLevelIndex: number
 ) => {
-  const selectedGeounitIds = new Set([...selectedGeounits].map(geounit => geounit[0]));
+  const selectedGeounitIds = new Set([...selectedGeounits.keys()]);
   const baseIndices = staticGeoLevels.slice().reverse()[geoLevelIndex];
   const selectedBaseIndices = baseIndices
     ? getAllIndices(baseIndices, selectedGeounitIds)

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -10,20 +10,12 @@ import {
   featuresToSet
 } from "./index";
 import { IStaticMetadata } from "../../../shared/entities";
-import { getAllIndices, getDemographics } from "../../../shared/functions";
 
 /*
  * Allows users to individually select/deselect specific geounits by clicking them.
  */
 const DefaultSelectionTool: ISelectionTool = {
-  enable: function(
-    map: MapboxGL.Map,
-    geoLevelId: string,
-    geoLevelIndex: number,
-    staticMetadata: IStaticMetadata,
-    staticGeoLevels: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
-    staticDemographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>
-  ) {
+  enable: function(map: MapboxGL.Map, geoLevelId: string, staticMetadata: IStaticMetadata) {
     /* eslint-disable */
     this.setCursor = () => (map.getCanvas().style.cursor = "pointer");
     this.unsetCursor = () => (map.getCanvas().style.cursor = "");
@@ -60,19 +52,6 @@ const DefaultSelectionTool: ISelectionTool = {
         store.dispatch(removeSelectedGeounitIds(selectedFeatures));
       };
       isFeatureSelected(map, feature) ? removeFeatures() : addFeatures();
-
-      // Indices of all base geounits belonging to the clicked feature
-      // TODO: Make demographic calculations work for all geolevels (#202)
-      const baseIndices = staticGeoLevels.slice().reverse()[geoLevelIndex];
-      const selectedFeatureIds = new Set([...selectedFeatures].map(feature => feature[0]));
-      const selectedBaseIndices = baseIndices
-        ? getAllIndices(baseIndices, selectedFeatureIds)
-        : Array.from(selectedFeatureIds);
-      const demographics = getDemographics(selectedBaseIndices, staticMetadata, staticDemographics);
-
-      // As a proof of concept, log to the console the aggregated demographic data for the feature
-      // eslint-disable-next-line
-      console.log(demographics);
     };
     map.on("click", clickHandler);
     // Save the click handler function so it can be removed later

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -198,14 +198,7 @@ const Map = ({
       RectangleSelectionTool.disable(map);
       // Enable appropriate tool
       if (selectionTool === SelectionTool.Default) {
-        DefaultSelectionTool.enable(
-          map,
-          selectedGeolevel.id,
-          geoLevelIndex,
-          staticMetadata,
-          staticGeoLevels,
-          staticDemographics
-        );
+        DefaultSelectionTool.enable(map, selectedGeolevel.id, staticMetadata);
       } else if (selectionTool === SelectionTool.Rectangle) {
         RectangleSelectionTool.enable(map, selectedGeolevel.id, staticMetadata);
       }


### PR DESCRIPTION
## Overview

Updates the sidebar intermediate calculation to support cross-geolevel district definitions

### Demo

![screenshot_2](https://user-images.githubusercontent.com/6386/89046313-c242f580-d31a-11ea-8d1a-29fe8b263673.png)

## Testing Instructions

- Select many different geounits across several geolevels and save them
- Verify that each time, the intermediate calculation matches up with the value that's returned after saving the district

Closes #202
