### PR TITLE
Use humanized numbers for demographic labels

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -168,7 +168,7 @@ const Map = ({
       map.setLayoutProperty(
         `${selectedGeolevel.id}-label`,
         "text-field",
-        label ? `{${label}}` : ""
+        label ? `{${label}-abbrev}` : ""
       );
     }
   }, [map, label, staticMetadata, selectedGeolevel]);

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -43,7 +43,7 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
         layout: {
           "text-size": 12,
           "text-padding": 3,
-          "text-field": "{population}",
+          "text-field": "",
           "text-max-width": 10,
           "text-font": ["GR"],
           visibility: "none"

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -228,7 +228,9 @@ it when necessary (file sizes ~1GB+).
 
         // Aggregate all desired demographic data
         for (const demo of demographics) {
-          merged.properties[demo] = this.aggProperty(geoms, demo);
+          const value = this.aggProperty(geoms, demo);
+          merged.properties[demo] = value;
+          merged.properties[`${demo}-abbrev`] = abbreviateNumber(value);
         }
 
         // Set the geolevel keys for this level, as well as all larger levels
@@ -582,4 +584,23 @@ it when necessary (file sizes ~1GB+).
         )
       : childGeoms.map((childGeom: any) => childGeom.id);
   }
+}
+
+function abbreviateNumber(value: number) {
+  const suffixes = ["", "k", "m", "b", "t"];
+  const suffixNum = Math.floor(`${value}`.length / 3);
+
+  if (value >= 1000) {
+    let shortValue = "";
+    for (let precision = 2; precision >= 1; precision--) {
+      const abbrevNum = suffixNum !== 0 ? value / Math.pow(1000, suffixNum) : value;
+      shortValue = abbrevNum.toPrecision(precision);
+      const dotLessShortValue = shortValue.replace(/[^a-zA-Z 0-9]+/g, "");
+      if (dotLessShortValue.length <= 2) {
+        break;
+      }
+    }
+    return shortValue + suffixes[suffixNum];
+  }
+  return value;
 }


### PR DESCRIPTION
## Overview

Ports over the prototype code to abbreviate demographic labels.

### Demo

![image](https://user-images.githubusercontent.com/4432106/89057004-f0303600-d32a-11ea-9c3d-6fffdcefa967.png)


## Testing Instructions

- Rebuild & republish data for a state, then create a new project for that state
- Labels should be abbreviated

Closes #190