### PR TITLE
Update human readable label processing

### DIFF
--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -228,9 +228,7 @@ it when necessary (file sizes ~1GB+).
 
         // Aggregate all desired demographic data
         for (const demo of demographics) {
-          const value = this.aggProperty(geoms, demo);
-          merged.properties[demo] = value;
-          merged.properties[`${demo}-abbrev`] = abbreviateNumber(value);
+          merged.properties[demo] = this.aggProperty(geoms, demo);
         }
 
         // Set the geolevel keys for this level, as well as all larger levels
@@ -262,6 +260,12 @@ it when necessary (file sizes ~1GB+).
       geomCollection.geometries.forEach((geometry: GeometryObject, index) => {
         // tslint:disable-next-line:no-object-mutation
         geometry.id = index;
+
+        // Add abbreviated label
+        for (const demo of demographics) {
+          // @ts-ignore
+          geometry.properties[`${demo}-abbrev`] = abbreviateNumber(geometry.properties[demo]);
+        }
       });
     }
 
@@ -594,14 +598,13 @@ function abbreviateNumber(value: number) {
   if (value >= 10) {
     suffixNum = Math.floor(Math.log10(value) / 3);
     const abbrevNum = value / Math.pow(1000, suffixNum);
-    
+
     if (Math.log10(abbrevNum) >= 2) {
       shortValue = abbrevNum.toPrecision(3);
-
     } else {
       shortValue = abbrevNum.toPrecision(2);
     }
   }
-  
+
   return shortValue + suffixes[suffixNum];
 }

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -588,7 +588,7 @@ it when necessary (file sizes ~1GB+).
 
 function abbreviateNumber(value: number) {
   const suffixes = ["", "k", "m", "b", "t"];
-  let shortValue = value;
+  let shortValue = value.toPrecision(1);
   let suffixNum = 0;
 
   if (value >= 10) {

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -588,10 +588,10 @@ it when necessary (file sizes ~1GB+).
 
 function abbreviateNumber(value: number) {
   const suffixes = ["", "k", "m", "b", "t"];
-  let shortValue = 0;
+  let shortValue = value;
   let suffixNum = 0;
 
-  if (value !== 0) {
+  if (value >= 10) {
     suffixNum = Math.floor(Math.log10(value) / 3);
     const abbrevNum = value / Math.pow(1000, suffixNum);
     

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -588,16 +588,20 @@ it when necessary (file sizes ~1GB+).
 
 function abbreviateNumber(value: number) {
   const suffixes = ["", "k", "m", "b", "t"];
-  const suffixNum = Math.floor(Math.log10(value) / 3);
-  const abbrevNum = value / Math.pow(1000, suffixNum);
-  let shortValue = "";
+  let shortValue = 0;
+  let suffixNum = 0;
 
-  if (Math.log10(abbrevNum) >= 2) {
-    shortValue = abbrevNum.toPrecision(3).toString();
+  if (value !== 0) {
+    suffixNum = Math.floor(Math.log10(value) / 3);
+    const abbrevNum = value / Math.pow(1000, suffixNum);
+    
+    if (Math.log10(abbrevNum) >= 2) {
+      shortValue = abbrevNum.toPrecision(3);
 
-  } else {
-    shortValue = abbrevNum.toPrecision(2).toString();
+    } else {
+      shortValue = abbrevNum.toPrecision(2);
+    }
   }
-
+  
   return shortValue + suffixes[suffixNum];
 }

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -588,19 +588,16 @@ it when necessary (file sizes ~1GB+).
 
 function abbreviateNumber(value: number) {
   const suffixes = ["", "k", "m", "b", "t"];
-  const suffixNum = Math.floor(`${value}`.length / 3);
+  const suffixNum = Math.floor(Math.log10(value) / 3);
+  const abbrevNum = value / Math.pow(1000, suffixNum);
+  let shortValue = "";
 
-  if (value >= 1000) {
-    let shortValue = "";
-    for (let precision = 2; precision >= 1; precision--) {
-      const abbrevNum = suffixNum !== 0 ? value / Math.pow(1000, suffixNum) : value;
-      shortValue = abbrevNum.toPrecision(precision);
-      const dotLessShortValue = shortValue.replace(/[^a-zA-Z 0-9]+/g, "");
-      if (dotLessShortValue.length <= 2) {
-        break;
-      }
-    }
-    return shortValue + suffixes[suffixNum];
+  if (Math.log10(abbrevNum) >= 2) {
+    shortValue = abbrevNum.toPrecision(3).toString();
+
+  } else {
+    shortValue = abbrevNum.toPrecision(2).toString();
   }
-  return value;
+
+  return shortValue + suffixes[suffixNum];
 }


### PR DESCRIPTION
## Overview

I'm suggesting a couple of changes to the way human-readable labels are generated from the prototype.

1. Change the way we determine the suffix to use for the label. The existing method was using `.length` to determine which label to use. This works for integers, but breaks down for decimal numbers. We don't expect to have decimals for population, but this covers us in case they show up unexpectedly, and makes this more robust in case we do. I instead use `log10` to more reliably determine the 000s bin.
2. Change the way we show hundreds of units, e.g. from 0.1m to 100k. The existing approach displays hundreds of thousands as tenths of millions. I've heard, and agree with, feedback that doing so makes it hard to compare between geounits, e.g. 90k vs. 0.1m is a 10k difference but the different unit makes it hard to recognize that. It's also subject to rounding that can make a significant difference. 0.1m can be 100k or 150k, either a 10k or 60k difference from 90k. 

### Demo
I didn't load up the app but this is what they look like in the prototype.

![image](https://user-images.githubusercontent.com/14098314/89143154-96d92a00-d517-11ea-8537-6b23b715182a.png)


## Testing Instructions

- Rebuild & republish data for a state, then create a new project for that state
- Labels should be abbreviated


