### PR TITLE
Fix sidebar, update Theme UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-scripts": "3.2.0",
     "redux": "4.0.4",
     "redux-loop": "5.0.1",
-    "theme-ui": "0.4.0-alpha.1",
+    "theme-ui": "0.4.0-rc.1",
     "ts.data.json": "0.3.0",
     "typesafe-actions": "5.1.0",
     "typescript": "3.7.5"
@@ -57,6 +57,7 @@
     "@types/react-redux": "7.1.5",
     "@types/react-router": "5.1.2",
     "@types/react-router-dom": "5.1.2",
+    "@types/styled-system__css": "^5.0.13",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
     "eslint": "^6.8.0",

--- a/src/client/App.css
+++ b/src/client/App.css
@@ -1,10 +1,3 @@
-html,
-body {
-  padding: 0;
-  margin: 0;
-  height: 100%;
-}
-
 #root {
   height: 100%;
 }

--- a/src/client/components/DemographicsChart.tsx
+++ b/src/client/components/DemographicsChart.tsx
@@ -25,7 +25,7 @@ const DemographicsChart = ({
       `${(demographics.population ? population / demographics.population : 0) * 100}%`
   );
   return (
-    <Flex sx={{ flexDirection: "column", width: "100%", minHeight: "100%" }}>
+    <Flex sx={{ flexDirection: "column", width: "40px", minHeight: "20px", flexShrink: 0 }}>
       <Bar width={percentages.white} color={demographicsColors.white} />
       <Bar width={percentages.black} color={demographicsColors.black} />
       <Bar width={percentages.asian} color={demographicsColors.asian} />

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -79,39 +79,41 @@ const ProjectSidebar = ({
       {project && geoUnitHierarchy && (
         <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       )}
-      <Styled.table>
-        <thead>
-          <Styled.tr>
-            <Styled.th>Number</Styled.th>
-            <Styled.th>Population</Styled.th>
-            <Styled.th>Deviation</Styled.th>
-            <Styled.th>Race</Styled.th>
-            <Styled.th>Pol.</Styled.th>
-            <Styled.th>Comp.</Styled.th>
-            <Styled.th></Styled.th>
-          </Styled.tr>
-        </thead>
-        <tbody>
-          {project &&
-            geojson &&
-            staticMetadata &&
-            staticGeoLevels &&
-            staticDemographics &&
-            geoUnitHierarchy &&
-            getSidebarRows(
-              project,
-              geojson,
-              staticMetadata,
-              staticGeoLevels,
-              staticDemographics,
-              selectedDistrictId,
-              selectedGeounits,
-              geoLevelIndex,
-              geoUnitHierarchy,
-              lockedDistricts
-            )}
-        </tbody>
-      </Styled.table>
+      <Box sx={{ overflowY: "auto", flex: 1 }}>
+        <Styled.table>
+          <thead>
+            <Styled.tr>
+              <Styled.th>Number</Styled.th>
+              <Styled.th>Population</Styled.th>
+              <Styled.th>Deviation</Styled.th>
+              <Styled.th>Race</Styled.th>
+              <Styled.th>Pol.</Styled.th>
+              <Styled.th>Comp.</Styled.th>
+              <Styled.th></Styled.th>
+            </Styled.tr>
+          </thead>
+          <tbody>
+            {project &&
+              geojson &&
+              staticMetadata &&
+              staticGeoLevels &&
+              staticDemographics &&
+              geoUnitHierarchy &&
+              getSidebarRows(
+                project,
+                geojson,
+                staticMetadata,
+                staticGeoLevels,
+                staticDemographics,
+                selectedDistrictId,
+                selectedGeounits,
+                geoLevelIndex,
+                geoUnitHierarchy,
+                lockedDistricts
+              )}
+          </tbody>
+        </Styled.table>
+      </Box>
     </Flex>
   );
 };

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Feature, FeatureCollection, MultiPolygon } from "geojson";
 import { useState } from "react";
-import { Box, Button, Flex, Heading, jsx, Styled } from "theme-ui";
+import { Box, Button, Flex, Heading, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
   CompactnessScore,
@@ -38,6 +38,10 @@ interface LoadingProps {
   readonly isLoading: boolean;
 }
 
+const style: ThemeUIStyleObject = {
+  number: { textAlign: "right" }
+};
+
 const ProjectSidebar = ({
   project,
   geojson,
@@ -66,29 +70,30 @@ const ProjectSidebar = ({
     <Flex
       sx={{
         background: "#fff",
-        height: "100%",
+        boxShadow:
+          "0 0 0 1px rgba(16,22,26,.1), 0 0 0 rgba(16,22,26,0), 0 1px 1px rgba(16,22,26,.2)",
         display: "flex",
         flexDirection: "column",
-        zIndex: 20,
-        position: "relative",
         flexShrink: 0,
-        boxShadow: "0 0 1px #a9acae",
-        minWidth: "300px"
+        height: "100%",
+        minWidth: "300px",
+        position: "relative",
+        zIndex: 200
       }}
     >
       {project && geoUnitHierarchy && (
         <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       )}
       <Box sx={{ overflowY: "auto", flex: 1 }}>
-        <Styled.table>
+        <Styled.table sx={{ m: 2 }}>
           <thead>
             <Styled.tr>
               <Styled.th>Number</Styled.th>
-              <Styled.th>Population</Styled.th>
-              <Styled.th>Deviation</Styled.th>
+              <Styled.th sx={style.number}>Population</Styled.th>
+              <Styled.th sx={style.number}>Deviation</Styled.th>
               <Styled.th>Race</Styled.th>
               <Styled.th>Pol.</Styled.th>
-              <Styled.th>Comp.</Styled.th>
+              <Styled.th sx={style.number}>Comp.</Styled.th>
               <Styled.th></Styled.th>
             </Styled.tr>
           </thead>
@@ -223,7 +228,7 @@ const SidebarRow = ({
       onMouseOver={toggleHover}
       onMouseOut={toggleHover}
     >
-      <Styled.td sx={{ textAlign: "left" }}>
+      <Styled.td>
         <span
           sx={{
             backgroundColor: getDistrictColor(district.id),
@@ -234,8 +239,8 @@ const SidebarRow = ({
         </span>
         {district.id || "∅"}
       </Styled.td>
-      <Styled.td sx={{ color: textColor }}>{populationDisplay}</Styled.td>
-      <Styled.td sx={{ color: textColor }}>{deviationDisplay}</Styled.td>
+      <Styled.td sx={{ ...style.number, ...{ color: textColor } }}>{populationDisplay}</Styled.td>
+      <Styled.td sx={{ ...style.number, ...{ color: textColor } }}>{deviationDisplay}</Styled.td>
       <Styled.td
         sx={{ width: "100%", height: "100%" }}
         onMouseOver={() => setDemographicsTooltipVisible(true)}
@@ -249,7 +254,7 @@ const SidebarRow = ({
         )}
       </Styled.td>
       <Styled.td>{BLANK_VALUE}</Styled.td>
-      <Styled.td>{compactnessDisplay}</Styled.td>
+      <Styled.td sx={style.number}>{compactnessDisplay}</Styled.td>
       <Styled.td>
         {isDistrictLocked ? (
           <span onClick={toggleLocked}>

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -1,9 +1,15 @@
+html,
 body {
+  padding: 0;
   margin: 0;
+  height: 100%;
+}
+
+body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "tnum";
+  font-variant: tabular-nums;
 }
 
 code {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -24,18 +24,6 @@ interface StateProps {
   readonly districtDrawing: DistrictDrawingState;
 }
 
-const FullScreenApp = ({ children }: { readonly children: React.ReactNode }) => {
-  return <Flex sx={{ height: "100%", flexDirection: "column" }}>{children}</Flex>;
-};
-
-const Main = ({ children }: { readonly children: React.ReactNode }) => {
-  return <Flex sx={{ flex: 1, overflowY: "auto" }}>{children}</Flex>;
-};
-
-const MapContainer = ({ children }: { readonly children: React.ReactNode }) => {
-  return <Flex sx={{ flexDirection: "column", flex: 1 }}>{children}</Flex>;
-};
-
 const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const { projectId } = useParams();
   const project = "resource" in projectData.project ? projectData.project.resource : undefined;
@@ -66,9 +54,9 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   ) : "errorMessage" in user ? (
     <Redirect to={"/login"} />
   ) : (
-    <FullScreenApp>
+    <Flex sx={{ height: "100%", flexDirection: "column" }}>
       <ProjectHeader project={project} />
-      <Main>
+      <Flex sx={{ flex: 1, overflowY: "auto" }}>
         <ProjectSidebar
           project={project}
           geojson={geojson}
@@ -82,7 +70,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
           geoUnitHierarchy={geoUnitHierarchy}
           lockedDistricts={districtDrawing.lockedDistricts}
         />
-        <MapContainer>
+        <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>
           <MapHeader
             label={label}
             setMapLabel={setMapLabel}
@@ -110,9 +98,9 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
               label={label}
             />
           ) : null}
-        </MapContainer>
-      </Main>
-    </FullScreenApp>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -140,8 +140,7 @@ const theme: Theme & StyledSystemTheme = {
       fontSize: 1
     },
     table: {
-      borderCollapse: "collapse",
-      m: 2
+      borderCollapse: "collapse"
     },
     tr: {
       borderBottomColor: "gray.3",
@@ -149,9 +148,7 @@ const theme: Theme & StyledSystemTheme = {
       borderBottomStyle: "solid",
       "tbody > &:last-child": { borderBottom: "none" }
     },
-    td: {
-      textAlign: "right"
-    }
+    td: {}
   },
   header: {
     app: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,7 +210,14 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.1", "@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
+  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-module-imports@^7.10.1", "@babel/helper-module-imports@^7.8.3":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz#dd331bd45bccc566ce77004e9d05fe17add13876"
   integrity sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==
@@ -289,6 +296,11 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
   integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-wrap-function@^7.10.1":
   version "7.10.1"
@@ -1129,6 +1141,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.10.4":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
+  integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1499,9 +1520,9 @@
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
 "@mdx-js/react@^1.0.0":
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.5.tgz#70380f25209b62ef69349b7eef09fad7e1103824"
-  integrity sha512-y1Yu9baw3KokFrs7g5RxHpJNSU4e1zk/5bAJX94yVATglG5HyAL0lYMySU8YzebXNE+fJJMCx9CuiQHy2ezoew==
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.16.tgz#538eb14473194d0b3c54020cb230e426174315cd"
+  integrity sha512-+FhuSVOPo7+4fZaRwWuCSRUcZkJOkZu0rfAbBKvoCg1LWb1Td8Vzi0DTLORdSvgWNbU6+EL40HIgwTOs00x2Jw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -3954,10 +3975,15 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.7:
+csstype@^2.2.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^2.5.7:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
+  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,62 +1718,62 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@theme-ui/color-modes@^0.4.0-alpha.1", "@theme-ui/color-modes@^0.4.0-highlight.0":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/color-modes/-/color-modes-0.4.0-highlight.0.tgz#333400c5d30ac65b71ff1b23a7d7ebee72f3c477"
-  integrity sha512-xdcAgfkL0gs0Z832lojtNGiTNtnQKoCu85t3Cxvqg2r1hVHar0SOJAyx+ljdV6tIHsBTxgVwUvdcby+QYCghRg==
+"@theme-ui/color-modes@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/color-modes/-/color-modes-0.4.0-rc.1.tgz#c8c7e7297d22ffcf4a0b6db42def4527da26fdf2"
+  integrity sha512-ySJIO3MVIvPiso+NDFQastmnGzZMl2Q6tpJRNPwgyNhkYeOJznYtmexQFQ+CKqt/u9plevBhwaVOvlwRoDuhbw==
   dependencies:
     "@emotion/core" "^10.0.0"
-    "@theme-ui/core" "^0.4.0-highlight.0"
-    "@theme-ui/css" "^0.4.0-highlight.0"
+    "@theme-ui/core" "^0.4.0-rc.1"
+    "@theme-ui/css" "^0.4.0-rc.1"
     deepmerge "^4.2.2"
 
-"@theme-ui/components@^0.4.0-alpha.1":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/components/-/components-0.4.0-highlight.0.tgz#e4eafd517e347b3c8f380906f504103e215ca222"
-  integrity sha512-dwVKGcXf29m4nehEKwaX/Vbl5fi/xhMNqHIYo1hnYmInKdUOnKDJOyxiiu4iNdmjTuXmpjj9WxBap1WHM07hkQ==
+"@theme-ui/components@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/components/-/components-0.4.0-rc.1.tgz#98b42de03bc9d00d31a8eb19395297e6f4a93c80"
+  integrity sha512-xyHme8TIxhKxAefbvus6QfBo2Azh0gfpKC7fGteJqsI6gqkBpLPl+kXVf7s4XbhenXIcJDvCTQaV020hBcYYBA==
   dependencies:
     "@emotion/core" "^10.0.0"
     "@emotion/styled" "^10.0.0"
     "@styled-system/color" "^5.1.2"
     "@styled-system/should-forward-prop" "^5.1.2"
     "@styled-system/space" "^5.1.2"
-    "@theme-ui/css" "^0.4.0-highlight.0"
+    "@theme-ui/css" "^0.4.0-rc.1"
 
-"@theme-ui/core@^0.4.0-alpha.1", "@theme-ui/core@^0.4.0-highlight.0":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/core/-/core-0.4.0-highlight.0.tgz#8989fc45347ad750ab9b1ab10c896387582dd48f"
-  integrity sha512-r5S0tiO51sBrFPXWOnotWfhA+L+s60JI5ewLJU+P6wE2ZOKdnn3HorphRgZWusxjTrzjNfBfgwhwXK+GkQFycw==
+"@theme-ui/core@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/core/-/core-0.4.0-rc.1.tgz#52bab9e4ed9c35a19092992e5dd3b52c6b7e89c2"
+  integrity sha512-4Kjv0zi5/wGcD7H7I0CTCziSvf8Brrgmc9IdgtjEuz99wNx8u5XmXtIV9slPUW4MzVY7RShbYfrj34t5vkRJdA==
   dependencies:
     "@emotion/core" "^10.0.0"
-    "@theme-ui/css" "^0.4.0-highlight.0"
+    "@theme-ui/css" "^0.4.0-rc.1"
     deepmerge "^4.2.2"
 
-"@theme-ui/css@^0.4.0-alpha.1", "@theme-ui/css@^0.4.0-highlight.0":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/css/-/css-0.4.0-highlight.0.tgz#ee239d61ce7c7e076ffb49a7c5fcd5b9f1bbfb48"
-  integrity sha512-0O9ERm3l4arXip9EmaVl83I84l0ZhEj1ZUrKHrNbjiW2/rhIdEWUQOdYcWdBCb8/nr5NwRMOJQ4rdqiUj7S5IQ==
+"@theme-ui/css@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/css/-/css-0.4.0-rc.1.tgz#96105db23dcba421a334228d00e9d672fa73511d"
+  integrity sha512-kDfFlqpc5gm54NDF3SMvcWcXlM4EdrgfOHyiiesdr2SBd42Ns3THLHbkdXcjMt+TJuBFisZFHisF17dir7qAFA==
   dependencies:
     csstype "^2.5.7"
 
-"@theme-ui/mdx@^0.4.0-alpha.1", "@theme-ui/mdx@^0.4.0-highlight.0":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/mdx/-/mdx-0.4.0-highlight.0.tgz#e7c9bfea7d2c9ab8cbd8318726d8e14661a2b373"
-  integrity sha512-kyEU0+AGaE3EoIe5Sip2PvEYx0w6CnkaryxEtqi6XH2A0Vu4jlRTVeDS0/ZrKVcsbqOWGdyc0Kpti3DN/JBhIg==
+"@theme-ui/mdx@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/mdx/-/mdx-0.4.0-rc.1.tgz#ce9b6a15dde889ba4f3db6051b56f3d4e24488f8"
+  integrity sha512-bVxtwawmUp3rFaEjVe72+H5q7StkJDpaY0WMrEwNXwa9myfQ5zMD97ORh37fev0wVhZqJy/fslFrFZF/szEnyw==
   dependencies:
     "@emotion/core" "^10.0.0"
     "@emotion/styled" "^10.0.0"
     "@mdx-js/react" "^1.0.0"
 
-"@theme-ui/theme-provider@^0.4.0-alpha.1":
-  version "0.4.0-highlight.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/theme-provider/-/theme-provider-0.4.0-highlight.0.tgz#88e8cb28bc5f7d9629573e1bdbec4369fdacd044"
-  integrity sha512-QBpTmyyQenyc6fZd/4ereXdMGZiaJ8IVN+FmoRXo9UnV3EJDBrAAt708lMRaVw7ccWpa4KQb7HQnN3FpxXlnTg==
+"@theme-ui/theme-provider@^0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/theme-provider/-/theme-provider-0.4.0-rc.1.tgz#672b19364db6ee0bac22ee5debdf61ce648267d6"
+  integrity sha512-8HJ3HGL1rzDwGsysK1AdhnTiN2t56MGT+GHPIhSqqeL29dA6GvBBgaFJkv++xWPd3wBPqBC8a2CgutxSUPu1aA==
   dependencies:
     "@emotion/core" "^10.0.0"
-    "@theme-ui/color-modes" "^0.4.0-highlight.0"
-    "@theme-ui/core" "^0.4.0-highlight.0"
-    "@theme-ui/mdx" "^0.4.0-highlight.0"
+    "@theme-ui/color-modes" "^0.4.0-rc.1"
+    "@theme-ui/core" "^0.4.0-rc.1"
+    "@theme-ui/mdx" "^0.4.0-rc.1"
 
 "@types/babel__core@^7.1.0":
   version "7.1.7"
@@ -1980,42 +1980,12 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-system@*":
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.9.tgz#8baac8f6eca9e0bd5768c175ca5ce1f2d6f61ade"
-  integrity sha512-QlWv6tmQV8dqk8s+LSLb9QAtmuQEnfv4f8lKKZkMgDqRFVmxJDBwEw0u4zhpxp56u0hdR+TCIk9dGfOw3TkCoQ==
+"@types/styled-system__css@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.13.tgz#37ccff101739ed4c67b2f13142f67fb656f5dd0f"
+  integrity sha512-weoDj0SVCGB8/BmFVbQKaOCygGoMWiPGt+CVtgWHC/pcWtiWioCplMxTpza2cpYQs/Cf72+A4mAY24a3RbXllQ==
   dependencies:
-    csstype "^2.6.9"
-
-"@types/styled-system__css@*":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.11.tgz#a9ff7e5d75e69a0d5ccff36acb4bbd491f1a9da9"
-  integrity sha512-hUieAt4sFS7zwbdU9Vlnn/c3vkfhTMhyiccYGpUSX96nJ4BF3NjLIjMu3cQOYS5EX4gPkHJZhkfdw41ov1NjhQ==
-  dependencies:
-    csstype "^2.6.6"
-
-"@types/theme-ui@*":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/theme-ui/-/theme-ui-0.3.2.tgz#f8e49734398725f72195866cdc2462a07743bf38"
-  integrity sha512-xAHYIyIsInPbcRf2YqCnioTmTsVjX+5fClO6NqwNORn0j9deGuSMp2gI8lPjm5b0eZwxM5ugExLbz01lxjjVqw==
-  dependencies:
-    "@emotion/serialize" "^0.11.15"
-    "@types/react" "*"
-    "@types/styled-system" "*"
-    "@types/styled-system__css" "*"
-    "@types/theme-ui__components" "*"
-    csstype "^2.6.6"
-
-"@types/theme-ui__components@*", "@types/theme-ui__components@^0.2.3":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@types/theme-ui__components/-/theme-ui__components-0.2.5.tgz#65ef4e160e2e0cf7c52ae220f6579a707d33667d"
-  integrity sha512-qqhIJboXzGXE0ZpKRHrwQvRbuOAcGNyAWMPXXP2jGs65XcaTuDJJpz1Rx5JCaQ1h+Tt99uIriRzZRthWarh1wg==
-  dependencies:
-    "@emotion/core" "^10.0.0"
-    "@emotion/styled" "^10.0.0"
-    "@types/react" "*"
-    "@types/styled-system" "*"
-    "@types/theme-ui" "*"
+    csstype "^3.0.2"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3984,10 +3954,15 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.6, csstype@^2.6.9:
+csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -10831,18 +10806,17 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-theme-ui@0.4.0-alpha.1:
-  version "0.4.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.4.0-alpha.1.tgz#9f5c97b9a65a0b8b8397c90060da0a11737ca031"
-  integrity sha512-NKlYIfzE5bxxhYSO9QncDrResQmO02LltrWFlMENrs9EXGluqTUvclv3dQ4Oxy3K9AZRKt2QAbp/wV6z8nXMPw==
+theme-ui@0.4.0-rc.1:
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.4.0-rc.1.tgz#bbf7b2cf679a09fda4430f2768b59ce253a6c6ac"
+  integrity sha512-c5pGGMTnC34QBJg16ZB5c5JAwDcvFDpFwhA9/qoypoLSzn6RqIqCRDeBnm0q/KP9thZqFToEXSHhiFQwrjMn9g==
   dependencies:
-    "@theme-ui/color-modes" "^0.4.0-alpha.1"
-    "@theme-ui/components" "^0.4.0-alpha.1"
-    "@theme-ui/core" "^0.4.0-alpha.1"
-    "@theme-ui/css" "^0.4.0-alpha.1"
-    "@theme-ui/mdx" "^0.4.0-alpha.1"
-    "@theme-ui/theme-provider" "^0.4.0-alpha.1"
-    "@types/theme-ui__components" "^0.2.3"
+    "@theme-ui/color-modes" "^0.4.0-rc.1"
+    "@theme-ui/components" "^0.4.0-rc.1"
+    "@theme-ui/core" "^0.4.0-rc.1"
+    "@theme-ui/css" "^0.4.0-rc.1"
+    "@theme-ui/mdx" "^0.4.0-rc.1"
+    "@theme-ui/theme-provider" "^0.4.0-rc.1"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
## Overview

The project view was scrolling. Only the table of districts in the sidebar should scroll. This PR fixes that issue and updates Theme UI.

### Demo

#### Before
![image](https://user-images.githubusercontent.com/1809908/89687349-17a87500-d8ce-11ea-8bcc-bf552fb56ef5.png)

#### After

![image](https://user-images.githubusercontent.com/1809908/89687329-0c554980-d8ce-11ea-8df2-50bf2c6338c7.png)

### Notes

I updated to a more recent version of Theme UI and am using the `ThemeUIStyleObject` TS definitions to save out reusable style definitions. See `ProjectSidebar.tsx`.

As discussed with @maurizi, I replaced the custom React components in `ProjectScreen.tsx`, which were being used exclusively for style purposes, with inline `sx` styles. In the future, we want to use the inline `sx` prop to style singular elements. For repeated styles, use something like:

```
import { ThemeUIStyleObject } from "theme-ui";

...

const style: ThemeUIStyleObject = {
  number: { textAlign: "right" }
};
```

## Testing Instructions

- Run the update script
- Go to a project with a large number of districts
- Try to scroll the sidebar; only the table in the sidebar should scroll, nothing else on the page

Closes #271
