### PR TITLE
Fix map layer order, labels on top

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../shared/entities";
 import {
   GEOLEVELS_SOURCE_ID,
+  DISTRICTS_PLACEHOLDER_LAYER_ID,
   DISTRICTS_SOURCE_ID,
   DISTRICTS_LAYER_ID,
   featureStateDistricts,
@@ -111,7 +112,7 @@ const Map = ({
               "fill-opacity": 1
             }
           },
-          "district-placeholder"
+          DISTRICTS_PLACEHOLDER_LAYER_ID
         );
         map.addLayer(
           {
@@ -124,7 +125,7 @@ const Map = ({
               "fill-opacity": ["case", ["boolean", ["feature-state", "locked"], false], 1, 0]
             }
           },
-          "district-placeholder"
+          DISTRICTS_PLACEHOLDER_LAYER_ID
         );
 
         map.resize();

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -100,26 +100,32 @@ const Map = ({
           type: "geojson",
           data: geojson
         });
-        map.addLayer({
-          id: DISTRICTS_LAYER_ID,
-          type: "fill",
-          source: DISTRICTS_SOURCE_ID,
-          layout: {},
-          paint: {
-            "fill-color": { type: "identity", property: "color" },
-            "fill-opacity": 0.7
-          }
-        });
-        map.addLayer({
-          id: "districts-locked",
-          type: "fill",
-          source: DISTRICTS_SOURCE_ID,
-          layout: {},
-          paint: {
-            "fill-pattern": "circle-1",
-            "fill-opacity": ["case", ["boolean", ["feature-state", "locked"], false], 1, 0]
-          }
-        });
+        map.addLayer(
+          {
+            id: DISTRICTS_LAYER_ID,
+            type: "fill",
+            source: DISTRICTS_SOURCE_ID,
+            layout: {},
+            paint: {
+              "fill-color": { type: "identity", property: "color" },
+              "fill-opacity": 1
+            }
+          },
+          "district-placeholder"
+        );
+        map.addLayer(
+          {
+            id: "districts-locked",
+            type: "fill",
+            source: DISTRICTS_SOURCE_ID,
+            layout: {},
+            paint: {
+              "fill-pattern": "circle-1",
+              "fill-opacity": ["case", ["boolean", ["feature-state", "locked"], false], 1, 0]
+            }
+          },
+          "district-placeholder"
+        );
 
         map.resize();
       });

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -20,6 +20,8 @@ export const GEOLEVELS_SOURCE_ID = "db";
 export const DISTRICTS_SOURCE_ID = "districts";
 // Id for districts layer
 export const DISTRICTS_LAYER_ID = "districts";
+// Used only to make labels show up on top of all other layers
+export const DISTRICTS_PLACEHOLDER_LAYER_ID = "district-placeholder";
 
 export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[]): MapboxGL.Style {
   const lineLayers = geoLevels.flatMap(level => [
@@ -76,7 +78,7 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
   return {
     layers: [
       {
-        id: "district-placeholder",
+        id: DISTRICTS_PLACEHOLDER_LAYER_ID,
         type: "background",
         paint: {
           "background-color": "transparent"
@@ -88,7 +90,7 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
       ...selectionLayers,
       ...lineLayers,
       ...labelLayers
-    ] as MapboxGL.Layer[],
+    ] as MapboxGL.Layer[], // eslint-disable-line
     glyphs: window.location.origin + "/fonts/{fontstack}/{range}.pbf",
     sprite: window.location.origin + "/sprites/sprite",
     name: "District Builder",

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -22,51 +22,74 @@ export const DISTRICTS_SOURCE_ID = "districts";
 export const DISTRICTS_LAYER_ID = "districts";
 
 export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[]): MapboxGL.Style {
-  return {
-    layers: geoLevels.flatMap(level => [
-      {
-        id: levelToLineLayerId(level.id),
-        type: "line",
-        source: GEOLEVELS_SOURCE_ID,
-        "source-layer": level.id,
-        paint: {
-          "line-color": "#000",
-          "line-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.1, 6, 0.1, 12, 0.2],
-          "line-width": ["interpolate", ["linear"], ["zoom"], 6, 1, 12, 2]
-        }
-      },
-      {
-        id: levelToSelectionLayerId(level.id),
-        type: "fill",
-        source: GEOLEVELS_SOURCE_ID,
-        "source-layer": level.id,
-        paint: {
-          "fill-color": "#000",
-          "fill-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 0.5, 0]
-        }
-      },
-      {
-        id: levelToLabelLayerId(level.id),
-        type: "symbol",
-        source: GEOLEVELS_SOURCE_ID,
-        "source-layer": `${level.id}labels`,
-        layout: {
-          "text-size": 12,
-          "text-padding": 3,
-          "text-field": "",
-          "text-max-width": 10,
-          "text-font": ["GR"],
-          visibility: "none"
-        },
-        paint: {
-          "text-color": "#000",
-          "text-opacity": 0.9,
-          "text-halo-color": "#fff",
-          "text-halo-width": 1.25,
-          "text-halo-blur": 0
-        }
+  const lineLayers = geoLevels.flatMap(level => [
+    {
+      id: levelToLineLayerId(level.id),
+      type: "line",
+      source: GEOLEVELS_SOURCE_ID,
+      "source-layer": level.id,
+      paint: {
+        "line-color": "#000",
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.1, 6, 0.1, 12, 0.2],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 6, 1, 12, 2]
       }
-    ]),
+    }
+  ]);
+
+  const selectionLayers = geoLevels.flatMap(level => [
+    {
+      id: levelToSelectionLayerId(level.id),
+      type: "fill",
+      source: GEOLEVELS_SOURCE_ID,
+      "source-layer": level.id,
+      paint: {
+        "fill-color": "#000",
+        "fill-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 0.5, 0]
+      }
+    }
+  ]);
+
+  const labelLayers = geoLevels.flatMap(level => [
+    {
+      id: levelToLabelLayerId(level.id),
+      type: "symbol",
+      source: GEOLEVELS_SOURCE_ID,
+      "source-layer": `${level.id}labels`,
+      layout: {
+        "text-size": 12,
+        "text-padding": 3,
+        "text-field": "",
+        "text-max-width": 10,
+        "text-font": ["GR"],
+        visibility: "none"
+      },
+      paint: {
+        "text-color": "#000",
+        "text-opacity": 0.9,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1.25,
+        "text-halo-blur": 0
+      }
+    }
+  ]);
+
+  return {
+    // @ts-ignore
+    layers: [
+      {
+        id: "district-placeholder",
+        type: "background",
+        paint: {
+          "background-color": "transparent"
+        },
+        layout: {
+          visibility: "none"
+        }
+      },
+      ...selectionLayers,
+      ...lineLayers,
+      ...labelLayers
+    ],
     glyphs: window.location.origin + "/fonts/{fontstack}/{range}.pbf",
     sprite: window.location.origin + "/sprites/sprite",
     name: "District Builder",

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -74,7 +74,6 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
   ]);
 
   return {
-    // @ts-ignore
     layers: [
       {
         id: "district-placeholder",
@@ -89,7 +88,7 @@ export function getMapboxStyle(path: string, geoLevels: readonly GeoLevelInfo[])
       ...selectionLayers,
       ...lineLayers,
       ...labelLayers
-    ],
+    ] as MapboxGL.Layer[],
     glyphs: window.location.origin + "/fonts/{fontstack}/{range}.pbf",
     sprite: window.location.origin + "/sprites/sprite",
     name: "District Builder",


### PR DESCRIPTION
## Overview

Updates the render order for map layers, placing labels on top.

### Demo

<img width="655" alt="Screen Shot 2020-08-09 at 12 26 29 AM" src="https://user-images.githubusercontent.com/1809908/89783402-dc33c380-dae4-11ea-8149-76cf3fc0bfa6.png">

### Notes

I'm getting a confusing TypeScript error, which I am currently [ignoring](https://github.com/PublicMapping/districtbuilder/compare/develop...feature/jdf/layer-order#diff-12e430e5de057c50e51970797f34c617R77). @pcaisse I'd appreciate your help on understanding this and suggesting a potential fix.

## Testing Instructions

- Load application
- View labels
- The labels should appear as they do in the attached screenshot, clear and "on top" of the other layers

Closes #249
