### PR TITLE
Style Project Creation

### DIFF
--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -43,7 +43,7 @@ export default function Field<D, R>({
 }
 
 interface InputFieldProps<D, R> extends FieldProps<D, R> {
-  readonly label: string;
+  readonly label: string | React.ReactElement;
   readonly inputProps: RefAttributes<HTMLInputElement> & InputProps;
 }
 
@@ -71,7 +71,7 @@ export function InputField<D, R>({
 
 interface SelectFieldProps<D, R> extends FieldProps<D, R> {
   readonly children: React.ReactNode;
-  readonly label: string;
+  readonly label: string | React.ReactElement;
   readonly selectProps: RefAttributes<HTMLSelectElement> & SelectProps;
 }
 
@@ -101,7 +101,7 @@ export function SelectField<D, R>({
 }
 
 interface PasswordFieldProps<D, R> extends FieldProps<D, R> {
-  readonly label: string;
+  readonly label: string | React.ReactElement;
   readonly password: string;
   readonly userAttributes: readonly string[];
   readonly inputProps: RefAttributes<HTMLInputElement> & InputProps;

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -102,7 +102,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
       textTransform: "none",
       variant: "text.h4",
       display: "block",
-      mb: 2
+      mb: 4
     },
     radioHeading: {
       textTransform: "none",
@@ -120,11 +120,9 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
       textTransform: "none"
     },
     customInputContainer: {
-      display: "block",
-      ml: "2rem",
-      mt: 1,
-      width: "auto",
-      pt: 2,
+      mt: 2,
+      width: "100%",
+      pt: 4,
       borderTop: "1px solid",
       borderColor: "gray.2"
     }
@@ -234,7 +232,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                         sx={{
                           display: "inline-flex",
                           "@media screen and (min-width: 750px)": {
-                            width: "48%",
+                            flex: "0 0 48%",
                             "&:nth-of-type(even)": {
                               mr: "2%"
                             }
@@ -246,7 +244,10 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                           value={chamber.id}
                           onChange={onDistrictChanged}
                         />
-                        <Flex as="span" sx={{ flexDirection: "column" }}>
+                        <Flex
+                          as="span"
+                          sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                        >
                           <div sx={style.radioHeading}>{chamber.name}</div>
                           <div sx={style.radioSubHeading}>
                             {chamber.numberOfDistricts} districts
@@ -257,9 +258,9 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                     .concat(
                       <div
                         sx={{
-                          width: "50%",
+                          flex: "0 0 50%",
                           "@media screen and (max-width: 770px)": {
-                            width: "100%"
+                            flex: "0 0 100%"
                           }
                         }}
                         key="custom"
@@ -271,30 +272,31 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                             <div sx={style.radioSubHeading}>Define other types of districts</div>
                           </Flex>
                         </Label>
-                        {data.isCustom ? (
-                          <Box sx={style.customInputContainer}>
-                            <InputField
-                              field="numberOfDistricts"
-                              label="Number of districts"
-                              resource={createProjectResource}
-                              inputProps={{
-                                onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                                  const value = parseInt(e.currentTarget.value, 10);
-                                  const numberOfDistricts = isNaN(value) ? null : value;
-                                  setCreateProjectResource({
-                                    data: {
-                                      ...data,
-                                      numberOfDistricts,
-                                      isCustom: true
-                                    }
-                                  });
-                                }
-                              }}
-                            />
-                          </Box>
-                        ) : null}
                       </div>
                     )}
+
+                {data.isCustom ? (
+                  <Box sx={style.customInputContainer}>
+                    <InputField
+                      field="numberOfDistricts"
+                      label="Number of districts"
+                      resource={createProjectResource}
+                      inputProps={{
+                        onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                          const value = parseInt(e.currentTarget.value, 10);
+                          const numberOfDistricts = isNaN(value) ? null : value;
+                          setCreateProjectResource({
+                            data: {
+                              ...data,
+                              numberOfDistricts,
+                              isCustom: true
+                            }
+                          });
+                        }
+                      }}
+                    />
+                  </Box>
+                ) : null}
               </Card>
             ) : (
               undefined

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import { Box, Button, Card, Flex, Heading, jsx, Label, Radio, ThemeUIStyleObject } from "theme-ui";
+import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
 import { IProject, IRegionConfig } from "../../shared/entities";
@@ -140,7 +141,9 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
     >
       <Flex sx={style.header}>
         <Box as="h1" sx={{ lineHeight: "0", mr: 3 }}>
-          <Logo sx={{ width: "2rem" }} />
+          <Link to="/">
+            <Logo sx={{ width: "2rem" }} />
+          </Link>
         </Box>
         <Heading as="h2" sx={{ variant: "text.h4", color: "blue.0", my: 0 }}>
           New Project

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -2,7 +2,8 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Box, Button, Card, Flex, Heading, jsx, Label, Radio } from "theme-ui";
+import { Box, Button, Card, Flex, Heading, jsx, Label, Radio, ThemeUIStyleObject } from "theme-ui";
+import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
 import { IProject, IRegionConfig } from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
@@ -75,6 +76,59 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
     });
   };
 
+  const style: ThemeUIStyleObject = {
+    header: {
+      py: 3,
+      px: 5,
+      alignItems: "center",
+      bg: "blue.8",
+      borderBottom: "1px solid",
+      borderColor: "blue.7",
+      boxShadow: "bright"
+    },
+    formContainer: {
+      width: "100%",
+      maxWidth: "medium",
+      my: 7,
+      mx: "auto",
+      flexDirection: "column",
+      "@media screen and (max-width: 770px)": {
+        width: "95%",
+        my: 2
+      }
+    },
+    cardLabel: {
+      textTransform: "none",
+      variant: "text.h4",
+      display: "block",
+      mb: 2
+    },
+    radioHeading: {
+      textTransform: "none",
+      variant: "text.body",
+      fontSize: 2,
+      lineHeight: "heading",
+      letterSpacing: "0",
+      mb: "0",
+      color: "heading",
+      fontWeight: "body"
+    },
+    radioSubHeading: {
+      fontSize: 1,
+      letterSpacing: "0",
+      textTransform: "none"
+    },
+    customInputContainer: {
+      display: "block",
+      ml: "2rem",
+      mt: 1,
+      width: "auto",
+      pt: 2,
+      borderTop: "1px solid",
+      borderColor: "gray.2"
+    }
+  };
+
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />
   ) : (
@@ -84,18 +138,16 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
         minHeight: "100vh"
       }}
     >
-      <Heading as="h4" sx={{ textAlign: "left", backgroundColor: "accent", color: "white", p: 3 }}>
-        New Project
-      </Heading>
+      <Flex sx={style.header}>
+        <Box as="h1" sx={{ lineHeight: "0", mr: 3 }}>
+          <Logo sx={{ width: "2rem" }} />
+        </Box>
+        <Heading as="h2" sx={{ variant: "text.h4", color: "blue.0", my: 0 }}>
+          New Project
+        </Heading>
+      </Flex>
       <Flex as="main" sx={{ width: "100%" }}>
-        <Flex
-          sx={{
-            width: "100%",
-            maxWidth: "form",
-            mx: "auto",
-            flexDirection: "column"
-          }}
-        >
+        <Flex sx={style.formContainer}>
           <Flex
             as="form"
             sx={{ flexDirection: "column" }}
@@ -118,10 +170,14 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
               }
             }}
           >
-            <Card sx={{ backgroundColor: "muted", my: 2, p: 4 }}>
+            <Card sx={{ variant: "card.flat" }}>
               <InputField
                 field="name"
-                label="Name"
+                label={
+                  <Box as="span" sx={style.cardLabel}>
+                    Name
+                  </Box>
+                }
                 resource={createProjectResource}
                 inputProps={{
                   onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -131,10 +187,14 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                 }}
               />
             </Card>
-            <Card sx={{ backgroundColor: "muted", my: 2, p: 4 }}>
+            <Card sx={{ variant: "card.flat" }}>
               <SelectField
                 field="regionConfig"
-                label="State"
+                label={
+                  <Box as="span" sx={style.cardLabel}>
+                    State
+                  </Box>
+                }
                 resource={createProjectResource}
                 selectProps={{
                   onChange:
@@ -161,57 +221,82 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
               </SelectField>
             </Card>
             {data.regionConfig ? (
-              <Card sx={{ backgroundColor: "muted", my: 2, p: 4 }}>
-                <Label>Districts</Label>
+              <Card sx={{ variant: "card.flat", display: "flex", flexWrap: "wrap" }}>
+                <Label sx={style.cardLabel}>Districts</Label>
                 {data.regionConfig &&
                   data.regionConfig.chambers
                     .map(chamber => (
-                      <Label key={chamber.id} sx={{ display: "inline-flex", width: "50%" }}>
+                      <Label
+                        key={chamber.id}
+                        sx={{
+                          display: "inline-flex",
+                          "@media screen and (min-width: 750px)": {
+                            width: "48%",
+                            "&:nth-of-type(even)": {
+                              mr: "2%"
+                            }
+                          }
+                        }}
+                      >
                         <Radio
                           name="project-district"
                           value={chamber.id}
                           onChange={onDistrictChanged}
                         />
                         <Flex as="span" sx={{ flexDirection: "column" }}>
-                          <span sx={{ display: "block", color: "heading" }}>{chamber.name}</span>
-                          {chamber.numberOfDistricts} districts
+                          <div sx={style.radioHeading}>{chamber.name}</div>
+                          <div sx={style.radioSubHeading}>
+                            {chamber.numberOfDistricts} districts
+                          </div>
                         </Flex>
                       </Label>
                     ))
                     .concat(
-                      <Label key="" sx={{ display: "inline-flex", width: "50%" }}>
-                        <Radio name="project-district" value="" onChange={onDistrictChanged} />
-                        <Flex as="span" sx={{ flexDirection: "column" }}>
-                          <span sx={{ display: "block", color: "heading" }}>Custom</span>
-                          Define other types of districts
-                        </Flex>
-                      </Label>
-                    )}
-                {data.isCustom ? (
-                  <InputField
-                    field="numberOfDistricts"
-                    label="Number of districts"
-                    resource={createProjectResource}
-                    inputProps={{
-                      onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                        const value = parseInt(e.currentTarget.value, 10);
-                        const numberOfDistricts = isNaN(value) ? null : value;
-                        setCreateProjectResource({
-                          data: {
-                            ...data,
-                            numberOfDistricts,
-                            isCustom: true
+                      <div
+                        sx={{
+                          width: "50%",
+                          "@media screen and (max-width: 770px)": {
+                            width: "100%"
                           }
-                        });
-                      }
-                    }}
-                  />
-                ) : null}
+                        }}
+                        key="custom"
+                      >
+                        <Label>
+                          <Radio name="project-district" value="" onChange={onDistrictChanged} />
+                          <Flex as="span" sx={{ flexDirection: "column" }}>
+                            <div sx={style.radioHeading}>Custom</div>
+                            <div sx={style.radioSubHeading}>Define other types of districts</div>
+                          </Flex>
+                        </Label>
+                        {data.isCustom ? (
+                          <Box sx={style.customInputContainer}>
+                            <InputField
+                              field="numberOfDistricts"
+                              label="Number of districts"
+                              resource={createProjectResource}
+                              inputProps={{
+                                onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                                  const value = parseInt(e.currentTarget.value, 10);
+                                  const numberOfDistricts = isNaN(value) ? null : value;
+                                  setCreateProjectResource({
+                                    data: {
+                                      ...data,
+                                      numberOfDistricts,
+                                      isCustom: true
+                                    }
+                                  });
+                                }
+                              }}
+                            />
+                          </Box>
+                        ) : null}
+                      </div>
+                    )}
               </Card>
             ) : (
               undefined
             )}
-            <Box sx={{ textAlign: "left" }}>
+            <Box sx={{ mt: 3, textAlign: "left" }}>
               <Button
                 type="submit"
                 disabled={

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -18,7 +18,7 @@ const appButtonStyles = {
   "& > svg": {
     mr: 1
   },
-  "&:hover": {
+  "&:hover:not([disabled])": {
     bg: "blue.5"
   },
   "&:active": {
@@ -28,7 +28,10 @@ const appButtonStyles = {
     outline: "none",
     boxShadow: "focus"
   },
-  "&[disabled]": { opacity: 0.6 }
+  "&[disabled]": {
+    opacity: 0.6,
+    cursor: "not-allowed"
+  }
 };
 
 const theme: Theme & StyledSystemTheme = {
@@ -92,9 +95,10 @@ const theme: Theme & StyledSystemTheme = {
     focus: "0 0 0 2px rgba(109, 152, 186, 0.3)"
   },
   sizes: {
-    form: "350px"
+    form: "350px",
+    medium: "750px"
   },
-  fontSizes: [9, 13, 15, 18, 21, 31, 37, 54],
+  fontSizes: [11, 13, 15, 18, 21, 31, 37, 54],
   fontWeights: {
     light: 300,
     medium: 500,
@@ -110,14 +114,60 @@ const theme: Theme & StyledSystemTheme = {
     heading: {
       mb: 2,
       fontWeight: "heading",
+      lineHeight: "heading",
       color: "heading"
     },
     caps: {
       textTransform: "uppercase",
       letterSpacing: "1px"
+    },
+    h1: {
+      variant: "text.heading",
+      fontSize: 7,
+      letterSpacing: 0
+    },
+    h2: {
+      variant: "text.heading",
+      fontSize: 6,
+      letterSpacing: 0
+    },
+    h3: {
+      variant: "text.heading",
+      fontSize: 5,
+      letterSpacing: 0
+    },
+    h4: {
+      variant: "text.heading",
+      fontSize: 4,
+      fontWeight: "body",
+      letterSpacing: 0
+    },
+    h5: {
+      variant: "text.heading",
+      fontSize: 3,
+      fontWeight: "body",
+      letterSpacing: 0
+    },
+    h6: {
+      variant: "text.caps",
+      fontSize: 2,
+      fontWeight: "bold"
     }
   },
   card: {
+    flat: {
+      borderRadius: "small",
+      backgroundColor: "muted",
+      my: 4,
+      p: 24
+    },
+    disabled: {
+      borderRadius: "small",
+      backgroundColor: "muted",
+      my: 4,
+      p: 24,
+      opacity: "0.4"
+    },
     floating: {
       borderRadius: "small",
       boxShadow: "bright",
@@ -133,7 +183,7 @@ const theme: Theme & StyledSystemTheme = {
       ...appButtonStyles,
       ...{
         backgroundColor: "secondary",
-        "&:hover": {
+        "&:hover:not([disabled])": {
           bg: "gray.6"
         },
         "&:active": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,8 +1107,8 @@
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
   dependencies:
     regenerator-runtime "^0.13.4"
-    
-"@babel/runtime@^7.10.1", "@babel/runtime@^7.11.1":
+
+"@babel/runtime@^7.10.1", "@babel/runtime@^7.11.1", "@babel/runtime@^7.8.7":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==


### PR DESCRIPTION
## Overview
Styles the Project creation page and fixes a disabled button issue.

### Demo
<img width="1791" alt="Screen Shot 2020-08-14 at 9 57 53 PM" src="https://user-images.githubusercontent.com/5672295/90292133-39c76780-de79-11ea-88bf-e90924e67a66.png">

<img width="1792" alt="Screen Shot 2020-08-14 at 9 42 37 PM" src="https://user-images.githubusercontent.com/5672295/90291558-17811a00-de78-11ea-9a85-b5776e5980ef.png">
<img width="1792" alt="Screen Shot 2020-08-14 at 9 42 33 PM" src="https://user-images.githubusercontent.com/5672295/90291568-1b14a100-de78-11ea-8e26-e216bf6f6654.png">

### Notes
- The wireframes show a disabled card for the districts, rather than hiding the whole card as above. If you would like me to do this, let me know!
- This is responsive, just because it's another form like "Sign up" that someone might want to fill out on a phone. I recognize that the meat of the app won't be usable that way, but seemed worthwhile here.
- I noticed some issues with the buttons I'd styled previously: the cursor was wrong and hover was showing for disabled buttons. Those issues are resolved here.
- I added some reusable `text` variant to our theme: `variant: "text.h1"` & the like. Some of them feel way too big and might not be useful, but I figured going by the established text scale still made sense. IDK, open to feedback.

## Testing Instructions
- `git pull`
- Go to http://localhost:3000/create-project
- Hover on the "Create Project" button. It should show the `not-allowed` cursor and display no hover.
- Add your project name.
- Select a state from the select.
- Click one of the radio inputs. The Create button should no longer be disabled.
- Click the "Custom" option. Note the new input. The Create button should be disabled.
- Enter a value into the input. 


Closes #275
