### PR TITLE
Remove duplicated code

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -185,12 +185,6 @@ const Map = ({
     // eslint-disable-next-line
   }, [map, selectedGeounits, staticMetadata]);
 
-  // Update districts source when geojson is fetched
-  useEffect(() => {
-    const districtsSource = map && map.getSource("districts");
-    districtsSource && districtsSource.type === "geojson" && districtsSource.setData(geojson);
-  }, [map, geojson]);
-
   // Update labels when selection is changed
   useEffect(() => {
     // eslint-disable-next-line


### PR DESCRIPTION
## Overview

When we receive a new GeoJSON file, it seems that we are updating the map twice using two nearly
identical blocks of code. I tested the application with one removed and I do not detect a change.

### Notes

I removed the variation that seemed to be less flexible (used hardcoded names rather than variables).

## Testing Instructions

- Open a project
- Confirm that the geojson updates as expected when the districts change
