### PR TITLE
Add geolevels-specific line styles

### DIFF
--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -23,6 +23,39 @@ export const DISTRICTS_LAYER_ID = "districts";
 // Used only to make labels show up on top of all other layers
 export const DISTRICTS_PLACEHOLDER_LAYER_ID = "district-placeholder";
 
+export function getGeolevelLinePaintStyle(geoLevel: string) {
+  var largeGeolevel = {
+    "line-color": "#000",
+    "line-opacity": 1,
+    "line-width": ["interpolate", ["linear"], ["zoom"], 6, 1.5, 14, 5]
+  };
+
+  var mediumGeolevel = {
+    "line-color": "#000",
+    "line-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.1, 14, 0.6],
+    "line-width": ["interpolate", ["linear"], ["zoom"], 6, 0.3, 14, 3]
+  };
+
+  var smallGeolevel = {
+    "line-color": "#000",
+    "line-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.1, 14, 0.3],
+    "line-width": ["interpolate", ["linear"], ["zoom"], 6, 0, 14, 2]
+  };
+
+  switch (geoLevel) {
+    case "county":
+      return largeGeolevel;
+    case "tract":
+      return mediumGeolevel;
+    case "blockgroup":
+      return mediumGeolevel;
+    case "block":
+      return smallGeolevel;
+    default:
+      return smallGeolevel;
+  }
+}
+
 export function getMapboxStyle(
   path: string,
   geoLevels: readonly GeoLevelInfo[],
@@ -36,11 +69,7 @@ export function getMapboxStyle(
       source: GEOLEVELS_SOURCE_ID,
       "source-layer": level.id,
       layout: { visibility: "none" },
-      paint: {
-        "line-color": "#000",
-        "line-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.1, 6, 0.1, 12, 0.2],
-        "line-width": ["interpolate", ["linear"], ["zoom"], 6, 1, 12, 2]
-      }
+      paint: getGeolevelLinePaintStyle(level.id)
     }
   ]);
 


### PR DESCRIPTION
## Overview

Visually distinguish between geolevel lines, through width and opacity.

### Demo

![Screen Shot 2020-08-15 at 11 04 01 AM](https://user-images.githubusercontent.com/1809908/90397777-5b397680-e066-11ea-8a2e-f860879a0ea2.png)

![Screen Shot 2020-08-15 at 11 04 12 AM](https://user-images.githubusercontent.com/1809908/90397783-5d033a00-e066-11ea-9f50-6ea728fcd95a.png)

![Screen Shot 2020-08-15 at 11 04 34 AM](https://user-images.githubusercontent.com/1809908/90397793-5f659400-e066-11ea-836b-347175189d1b.png)

### Notes

I want to refine this further after we implement #231 and fix the block simplification.

## Testing Instructions

- Open a project
- Switch between counties, blockgroups/tracts, and blocks; confirm that each geolevel has its own style
