### PR TITLE
Provide math for scaling task memory with additional states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Terraform AWS provider to 3.x [#329](https://github.com/PublicMapping/districtbuilder/pull/329)
 - Extend Jenkins pipeline to support production releases [#325](https://github.com/PublicMapping/districtbuilder/pull/325)
 - Add support for Rollbar [#338](https://github.com/PublicMapping/districtbuilder/pull/338)
+- Provide math for scaling task memory with additional states [#309](https://github.com/PublicMapping/districtbuilder/pull/309)

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -87,24 +87,28 @@ resource "aws_ecs_cluster" "app" {
   }
 }
 
+// PA uses an additional ~600MiB on my workstation. It is estimated that some
+// larger states could use up to a gig. This math will add an additional
+// 1024MiB for every state. This math will also cap memory by vCPUs to not
+// exceed Fargate limits.
+locals {
+  fargate_app_memory = min(var.fargate_app_base_memory + var.districtbuilder_state_count * 1024, (var.fargate_app_cpu / 1024) * 8192)
+}
+
 resource "aws_ecs_task_definition" "app" {
   family                   = "${var.environment}App"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_app_cpu
-  // PA and DE used an additional 620MiB of memory on my workstation. However,
-  // we can't multiply states by 310MiB because Fargate requires you to provide
-  // memory in specific increments. This math will add an additional 1024MiB for
-  // every 3 states  (e.g. 3 states = 1024 MiB, 4 states = 2048 MiB, 5 states =
-  // 2048 MiB). This math will also cap memory by vCPUs to not exceed Fargate
-  // limits.
-  memory = min(var.fargate_app_memory + ceil(var.districtbuilder_state_count / 3) * 1024, (var.fargate_app_cpu / 1024) * 8192)
+  memory = local.fargate_app_memory
 
   task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
 
   container_definitions = templatefile("${path.module}/task-definitions/app.json.tmpl", {
     image = "${module.ecr.repository_url}:${var.image_tag}"
+
+    memory = local.fargate_app_memory
 
     postgres_host     = aws_route53_record.database.name
     postgres_port     = module.database.port

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -100,7 +100,7 @@ resource "aws_ecs_task_definition" "app" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_app_cpu
-  memory = local.fargate_app_memory
+  memory                   = local.fargate_app_memory
 
   task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -92,7 +92,13 @@ resource "aws_ecs_task_definition" "app" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_app_cpu
-  memory                   = var.fargate_app_memory
+  // PA and DE used an additional 620MiB of memory on my workstation. However,
+  // we can't multiply states by 310MiB because Fargate requires you to provide
+  // memory in specific increments. This math will add an additional 1024MiB for
+  // every 3 states  (e.g. 3 states = 1024 MiB, 4 states = 2048 MiB, 5 states =
+  // 2048 MiB). This math will also cap memory by vCPUs to not exceed Fargate
+  // limits.
+  memory = min(var.fargate_app_memory + ceil(var.districtbuilder_state_count / 3) * 1024, var.fargate_app_cpu * 8192)
 
   task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -108,7 +108,7 @@ resource "aws_ecs_task_definition" "app" {
   container_definitions = templatefile("${path.module}/task-definitions/app.json.tmpl", {
     image = "${module.ecr.repository_url}:${var.image_tag}"
 
-    memory = local.fargate_app_memory
+    max_old_space_size = local.fargate_app_memory * 0.75
 
     postgres_host     = aws_route53_record.database.name
     postgres_port     = module.database.port

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -98,7 +98,7 @@ resource "aws_ecs_task_definition" "app" {
   // every 3 states  (e.g. 3 states = 1024 MiB, 4 states = 2048 MiB, 5 states =
   // 2048 MiB). This math will also cap memory by vCPUs to not exceed Fargate
   // limits.
-  memory = min(var.fargate_app_memory + ceil(var.districtbuilder_state_count / 3) * 1024, var.fargate_app_cpu * 8192)
+  memory = min(var.fargate_app_memory + ceil(var.districtbuilder_state_count / 3) * 1024, (var.fargate_app_cpu / 1024) * 8192)
 
   task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -30,6 +30,10 @@
         "value": "${environment}"
       },
       {
+        "name": "NODE_OPTIONS",
+        "value": "--max_old_space_size=${memory}"
+      },
+      {
         "name": "AWS_REGION",
         "value": "${aws_region}"
       },

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -31,7 +31,7 @@
       },
       {
         "name": "NODE_OPTIONS",
-        "value": "--max_old_space_size=${memory}"
+        "value": "--max_old_space_size=${max_old_space_size}"
       },
       {
         "name": "AWS_REGION",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -246,6 +246,10 @@ variable "fargate_app_deployment_max_percent" {
   type    = number
 }
 
+variable "districtbuilder_state_count" {
+  type = number
+}
+
 variable "fargate_app_cpu" {
   type = number
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -254,7 +254,7 @@ variable "fargate_app_cpu" {
   type = number
 }
 
-variable "fargate_app_memory" {
+variable "fargate_app_base_memory" {
   type = number
 }
 


### PR DESCRIPTION
## Overview

This PR adds `districtbuilder_state_count` in an effort to introduce a tunable parameter for scaling task memory.

Because Fargate has specific [supported configurations](https://aws.amazon.com/fargate/pricing/), my math takes a conservative approach where we put **1024 MiB** on the table, **3** states eat it up, and the next state will add another **1024 MiB**.

## Testing Instructions

- Set `districtbuilder_state_count` to `3`. 
- Cycle Terraform.
```bash
     ~ memory                   = "2048" -> "3072" # forces replacement
```

- Set `districtbuilder_state_count` to `4`. 
- Cycle Terraform.
```bash
     ~ memory                   = "2048" -> "4096" # forces replacement
```

- Set `districtbuilder_state_count` to `1000`. 
- Cycle Terraform. 
- See that memory is capped to `8GB (1 vCPU)`.
```bash
      ~ memory                   = "2048" -> "8192" # forces replacement
```


Closes #192 
