### PR TITLE
Static data intermediate index changes

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -46,7 +46,6 @@ const ProjectSidebar = ({
   geojson,
   isLoading,
   staticMetadata,
-  staticGeoLevels,
   staticDemographics,
   selectedDistrictId,
   selectedGeounits,
@@ -56,7 +55,6 @@ const ProjectSidebar = ({
   readonly project?: IProject;
   readonly geojson?: FeatureCollection<MultiPolygon, DistrictProperties>;
   readonly staticMetadata?: IStaticMetadata;
-  readonly staticGeoLevels?: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>;
   readonly staticDemographics?: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>;
   readonly selectedDistrictId: number;
   readonly selectedGeounits: GeoUnits;
@@ -98,7 +96,6 @@ const ProjectSidebar = ({
             {project &&
               geojson &&
               staticMetadata &&
-              staticGeoLevels &&
               staticDemographics &&
               geoUnitHierarchy &&
               getSidebarRows(

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -314,6 +314,7 @@ const Map = ({
             ];
           // Select sub-geounits.
           const subFeatures = map.queryRenderedFeatures(undefined, {
+            layers: [levelToSelectionLayerId(childGeoLevel.id)],
             filter: ["==", ["get", `${geoLevel.id}Idx`], geoUnitIdx]
           });
           const subGeoUnits = featuresToUnlockedGeoUnits(

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -31,8 +31,6 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const geojson = "resource" in projectData.geojson ? projectData.geojson.resource : undefined;
   const staticMetadata =
     "resource" in projectData.staticMetadata ? projectData.staticMetadata.resource : undefined;
-  const staticGeoLevels =
-    "resource" in projectData.staticGeoLevels ? projectData.staticGeoLevels.resource : undefined;
   const staticDemographics =
     "resource" in projectData.staticDemographics
       ? projectData.staticDemographics.resource
@@ -68,7 +66,6 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
           geojson={geojson}
           isLoading={isLoading}
           staticMetadata={staticMetadata}
-          staticGeoLevels={staticGeoLevels}
           staticDemographics={staticDemographics}
           selectedDistrictId={districtDrawing.selectedDistrictId}
           selectedGeounits={districtDrawing.selectedGeounits}
@@ -88,12 +85,14 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
           {"resource" in projectData.project &&
           "resource" in projectData.staticMetadata &&
           "resource" in projectData.staticDemographics &&
+          "resource" in projectData.staticGeoLevels &&
           "resource" in projectData.geojson ? (
             <Map
               project={projectData.project.resource}
               geojson={projectData.geojson.resource}
               staticMetadata={projectData.staticMetadata.resource}
               staticDemographics={projectData.staticDemographics.resource}
+              staticGeoLevels={projectData.staticGeoLevels.resource}
               selectedGeounits={districtDrawing.selectedGeounits}
               selectedDistrictId={districtDrawing.selectedDistrictId}
               selectionTool={districtDrawing.selectionTool}

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -18,7 +18,7 @@ import {
   GeoUnitDefinition,
   IStaticMetadata
 } from "../../../../shared/entities";
-import { getAllIndices, getDemographics } from "../../../../shared/functions";
+import { getAllBaseIndices, getDemographics } from "../../../../shared/functions";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
 
 interface GeoUnitHierarchy {
@@ -170,10 +170,11 @@ export class GeoUnitTopology {
         const levelIds = levelGeometries
           .map(geom => geom.id)
           .filter(id => id !== undefined && typeof id === "number") as number[];
-        const levelIndices =
-          levelIndex === this.geoLevels.length
-            ? levelIds
-            : getAllIndices(this.geoLevels.slice().reverse()[levelIndex], new Set(levelIds));
+        const levelIndices = getAllBaseIndices(
+          this.geoLevels.slice().reverse(),
+          levelIndex,
+          levelIds
+        );
         return indices.concat(levelIndices);
       }, []);
       mutableGeom.id = idx;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -10,20 +10,30 @@ import {
 
 type ArrayBuffer = Uint8Array | Uint16Array | Uint32Array;
 
-// Helper for finding all indices in an array buffer matching a value.
+// Recursively finds all base indices matching a set of values at a specified level.
 // Note: mutation is used, because the union type of array buffers proved
 // too difficult to line up types for reduce or map/filter.
-export function getAllIndices(arrayBuf: ArrayBuffer, vals: ReadonlySet<number>): readonly number[] {
+export function getAllBaseIndices(
+  descGeoLevels: readonly ArrayBuffer[],
+  levelIndex: number,
+  vals: readonly number[]
+): readonly number[] {
+  // eslint-disable-next-line
+  if (vals.length === 0 || levelIndex === descGeoLevels.length) {
+    return vals;
+  }
+
   // eslint-disable-next-line
   let indices: number[] = [];
-  arrayBuf.forEach((el: number, ind: number) => {
+  const valsSet = new Set(vals);
+  descGeoLevels[levelIndex].forEach((el: number, ind: number) => {
     // eslint-disable-next-line
-    if (vals.has(el)) {
+    if (valsSet.has(el)) {
       // eslint-disable-next-line
       indices.push(ind);
     }
   });
-  return indices;
+  return getAllBaseIndices(descGeoLevels, levelIndex + 1, indices);
 }
 
 interface DemographicCounts {

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -10,9 +10,23 @@ import {
 
 type ArrayBuffer = Uint8Array | Uint16Array | Uint32Array;
 
-// Recursively finds all base indices matching a set of values at a specified level.
+// Helper for finding all indices in an array buffer matching a value.
 // Note: mutation is used, because the union type of array buffers proved
 // too difficult to line up types for reduce or map/filter.
+export function getAllIndices(arrayBuf: ArrayBuffer, vals: ReadonlySet<number>): readonly number[] {
+  // eslint-disable-next-line
+  let indices: number[] = [];
+  arrayBuf.forEach((el: number, ind: number) => {
+    // eslint-disable-next-line
+    if (vals.has(el)) {
+      // eslint-disable-next-line
+      indices.push(ind);
+    }
+  });
+  return indices;
+}
+
+// Recursively finds all base indices matching a set of values at a specified level
 export function getAllBaseIndices(
   descGeoLevels: readonly ArrayBuffer[],
   levelIndex: number,
@@ -22,18 +36,11 @@ export function getAllBaseIndices(
   if (vals.length === 0 || levelIndex === descGeoLevels.length) {
     return vals;
   }
-
-  // eslint-disable-next-line
-  let indices: number[] = [];
-  const valsSet = new Set(vals);
-  descGeoLevels[levelIndex].forEach((el: number, ind: number) => {
-    // eslint-disable-next-line
-    if (valsSet.has(el)) {
-      // eslint-disable-next-line
-      indices.push(ind);
-    }
-  });
-  return getAllBaseIndices(descGeoLevels, levelIndex + 1, indices);
+  return getAllBaseIndices(
+    descGeoLevels,
+    levelIndex + 1,
+    getAllIndices(descGeoLevels[levelIndex], new Set(vals))
+  );
 }
 
 interface DemographicCounts {


### PR DESCRIPTION
## Overview

We need to be able to determine the child geounit ids for any given geounit. This is needed during selection when changing between geolevels. In order to accommodate this, the static files have been altered to reference their child geolevels, rather than all of them referencing the base geolevel.

### Notes

I updates `Map.tsx` to use this new file structure for selecting child geounits when switching geolevels. Unfortunately, I was not able to fully remove the code in the `HACK` block, because map features (or more specifically `GeoUnits`) are used in a couple places here: `featuresToUnlockedGeoUnits`, and the dispatched `editSelectedGeounits` payload. I could not find an easy way to construct the `GeoUnits` from the information at hand, and it looks like we'll need to create an issue to address this. As you're reviewing this PR, give some thought to that, and perhaps we can discuss a possible solution path.

## Testing Instructions

- Process and publish a GeoJSON file, and create a map using this new data
- Perform district editing operations, and verify that the intermediate values in the sidebar are always matching the returned values after saving the districts.

Closes #294
