### PR TITLE
Remove tooltip pointer events from map tooltip

### DIFF
--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -160,7 +160,8 @@ const MapTooltip = ({
           width: "200px",
           height: "auto",
           p: 2,
-          zIndex: 1
+          zIndex: 1,
+          pointerEvents: "none"
         }}
       >
         {heading && (


### PR DESCRIPTION
## Overview

It was possible for the mouse to get on top of the map tooltip, absorbing pointer events, and allowing text selection. This fixes the problem.

## Testing Instructions

- Load up the map page
- Move your mouse really fast and try to catch it on top of the tooltip
- Realize that you can no longer do so
