### PR TITLE
Explicitly set Fargate platform version for ECS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Explicitly set Fargate platform version for ECS services [#318](https://github.com/PublicMapping/districtbuilder/pull/318)

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -134,7 +134,8 @@ resource "aws_ecs_service" "app" {
   deployment_minimum_healthy_percent = var.fargate_app_deployment_min_percent
   deployment_maximum_percent         = var.fargate_app_deployment_max_percent
 
-  launch_type = "FARGATE"
+  launch_type      = "FARGATE"
+  platform_version = var.fargate_platform_version
 
   network_configuration {
     security_groups = [aws_security_group.app.id]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -227,6 +227,10 @@ variable "image_tag" {
   type = string
 }
 
+variable "fargate_platform_version" {
+  default = "1.4.0"
+}
+
 variable "fargate_app_desired_count" {
   default = 1
   type    = number


### PR DESCRIPTION
## Overview

For each ECS service that supports the application, ensure that the Fargate platform version is specified. The default platform version if left unset is `LATEST`, which currently resolves to 1.3.0, but will soon resolve to 1.4.0.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

<img width="1182" alt="CleanShot 2020-08-18 at 07 07 28@2x" src="https://user-images.githubusercontent.com/43639/90505955-86cd6700-e121-11ea-87ea-177fc5a3ac34.png">

## Testing Instructions

- With these changes applied to the staging environment (they are currently applied), review the **Platform version** column of the `ecsStagingCluster ` [service listing](https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/ecsStagingCluster/services)
- Ensure that the value listed is 1.4.0 vs. `LATEST`

Fixes https://github.com/PublicMapping/districtbuilder/issues/166
