### PR TITLE
Extend Jenkins pipeline to support production releases

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,66 @@
+#!groovy
+
+node {
+  properties([
+    parameters([
+      [
+        $class: 'ValidatingStringParameterDefinition',
+        defaultValue: '',
+        description: 'First 7 characters of the SHA for the commit you wish to deploy.',
+        failedValidationMessage: 'Invalid SHA.',
+        name: 'GIT_COMMIT',
+        regex: /^[a-z0-9]{7}$/
+      ]
+    ])
+  ])
+
+  // Notify Slack that we're starting a production deploy.
+  def startedMessage =
+    ":jenkins: deploying revision <https://github.com/publicmapping/districtbuilder/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
+  startedMessage += "\n<${env.BUILD_URL}|View Build>"
+
+  slackSend channel: '#district-builder', color: 'warning', message: startedMessage
+
+  try {
+    env.COMPOSE_PROJECT_NAME = "district-builder-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+
+    // Checkout the proper revision into the workspace.
+    stage('checkout') {
+      checkout([
+        $class: 'GitSCM',
+        branches: [[name: params.GIT_COMMIT]],
+        extensions: [[$class: 'PruneStaleBranch']],
+        userRemoteConfigs: [[
+            credentialsId: 'AzaveaCIGitHubCredentials',
+            url: 'git@github.com:publicmapping/districtbuilder.git'
+        ]]
+      ])
+    }
+
+    env.AWS_PROFILE = 'district-builder'
+    env.AWS_DEFAULT_REGION = 'us-east-1'
+
+    env.DB_SETTINGS_BUCKET = 'districtbuilder-production-config-us-east-1'
+
+    // Plan and apply the current state of the production infrastructure
+    // as outlined by whatever SHA is passed through as a build parameter.
+    stage('infra') {
+      wrap([$class: 'AnsiColorBuildWrapper']) {
+        sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+        sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+      }
+    }
+  } catch (err) {
+    // Some exception was raised in the `try` block above. Assemble
+    // an appropirate error message for Slack.
+    def failedMessage =
+      ":jenkins-angry: failed to deploy revision <https://github.com/publicmapping/districtbuilder/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
+    failedMessage += "\n<${env.BUILD_URL}|View Build>"
+
+    slackSend channel: '#district-builder', color: 'danger', message: failedMessage
+
+    // Re-raise the exception so that the failure is propagated to
+    // Jenkins.
+    throw err
+  }
+}


### PR DESCRIPTION
## Overview

- Add [DistrictBuilder Release Pipeline](http://urbanappsci.internal.azavea.com/view/districtbuilder/job/DistrictBuilder%20Release%20Pipeline/) scripted pipeline job
- Add `Jenkinsfile.release` which takes the SHA of an existing container image and runs the `infra` process against the production settings bucket

## Notes

- Before spinning up production, I imported the Route 53 zone for `districtbuilder.azavea.com`, as well as the two ECR repositories. I'd like to find a solution for managing these resources in the future that don't require state intervention 👮 .
- I ran migrations 🚚 .
- I had to add the public key for the `jenkins` user on `urbanappsci` as a deploy key for the [PublicMapping/districtbuilder](https://github.com/PublicMapping/districtbuilder/settings/keys) repository 🔑 .

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

See Jenkins job (invoked with latest staging SHA): http://urbanappsci.internal.azavea.com/view/districtbuilder/job/DistrictBuilder%20Release%20Pipeline/5/console

See Slack notification:

![image](https://user-images.githubusercontent.com/1774125/90660027-62ea4e00-e213-11ea-8e0e-b47b285a3d64.png)

Resolves #250 
