### PR TITLE
Update prcocess-geojson to support ingesting VA data

### DIFF
--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -46,7 +46,10 @@ it when necessary (file sizes ~1GB+).
 
     levels: flags.string({
       char: "l",
-      description: "Comma-separated geolevel hierarchy: smallest to largest",
+      description: `Comma-separated geolevel hierarchy: smallest to largest
+      To use a different name for the layer ID from the GeoJSON property, separate values by ':'
+      e.g. -l block,blockgroupuuid:blockgroup,countyid:county
+      `,
       default: "block,blockgroup,county"
     }),
 
@@ -96,7 +99,12 @@ it when necessary (file sizes ~1GB+).
       return;
     }
 
-    const geoLevels = flags.levels.split(",");
+    const geoLevels: readonly [string, string][] = flags.levels
+      .split(",")
+      .map(level =>
+        level.includes(":") ? (level.split(":", 2) as [string, string]) : [level, level]
+      );
+    const geoLevelIds = geoLevels.map(([, id]) => id);
     const minZooms = flags.levelMinZoom.split(",");
     const maxZooms = flags.levelMaxZoom.split(",");
     const demographics = flags.demographics.split(",");
@@ -127,9 +135,9 @@ it when necessary (file sizes ~1GB+).
         return;
       }
     }
-    for (const level of geoLevels) {
-      if (!(level in firstFeature.properties)) {
-        this.log(`Geolevel: "${level}" not present in features, exiting`);
+    for (const [levelProp, levelId] of geoLevels) {
+      if (!(levelProp in firstFeature.properties)) {
+        this.log(`Geolevel: "${levelProp}" not present in features, exiting`);
         return;
       }
     }
@@ -149,13 +157,13 @@ it when necessary (file sizes ~1GB+).
 
     await this.writeTopoJson(flags.outputDir, topoJsonHierarchy);
 
-    this.addGeoLevelIndices(topoJsonHierarchy, geoLevels);
+    this.addGeoLevelIndices(topoJsonHierarchy, geoLevelIds);
 
-    this.writeIntermediaryGeoJson(flags.outputDir, topoJsonHierarchy, geoLevels);
+    this.writeIntermediaryGeoJson(flags.outputDir, topoJsonHierarchy, geoLevelIds);
 
     const geoLevelHierarchyInfo = this.writeVectorTiles(
       flags.outputDir,
-      geoLevels,
+      geoLevelIds,
       minZooms,
       maxZooms
     );
@@ -163,17 +171,17 @@ it when necessary (file sizes ~1GB+).
     const demographicMetaData = this.writeDemographicData(
       flags.outputDir,
       topoJsonHierarchy,
-      geoLevels[0],
+      geoLevelIds[0],
       demographics
     );
 
     const geoLevelMetaData = this.writeGeoLevelIndices(
       flags.outputDir,
       topoJsonHierarchy,
-      geoLevels
+      geoLevelIds
     );
 
-    this.writeGeounitHierarchy(flags.outputDir, topoJsonHierarchy, geoLevels);
+    this.writeGeounitHierarchy(flags.outputDir, topoJsonHierarchy, geoLevelIds);
 
     this.writeStaticMetadata(
       flags.outputDir,
@@ -187,13 +195,13 @@ it when necessary (file sizes ~1GB+).
   // Generates a TopoJSON topology with aggregated hierarchical data
   mkTopoJsonHierarchy(
     baseGeoJson: FeatureCollection<Polygon, any>,
-    geoLevels: readonly string[],
+    geoLevels: ReadonlyArray<[string, string]>,
     demographics: readonly string[],
     simplification: number
   ): Topology<Objects<{}>> {
-    const baseGeoLevel = geoLevels[0];
-    this.log(`Converting to topojson with base geolevel: ${baseGeoLevel}`);
-    const baseTopoJson = topology({ [baseGeoLevel]: baseGeoJson });
+    const [baseGeoLevelProp, baseGeoLevelId] = geoLevels[0];
+    this.log(`Converting to topojson with base geolevel: ${baseGeoLevelId}`);
+    const baseTopoJson = topology({ [baseGeoLevelId]: baseGeoJson });
 
     this.log("Presimplifying using planar triangle area");
     const preSimplifiedBaseTopoJson = presimplify(
@@ -201,21 +209,21 @@ it when necessary (file sizes ~1GB+).
       planarTriangleArea
     );
 
-    this.log(`Simplifying ${baseGeoLevel} geounits with minWeight: ${simplification}`);
+    this.log(`Simplifying ${baseGeoLevelId} geounits with minWeight: ${simplification}`);
     const topo = simplify(preSimplifiedBaseTopoJson, simplification);
 
     for (const [prevIndex, geoLevel] of geoLevels.slice(1).entries()) {
       const currIndex = prevIndex + 1;
-      const currGeoLevel = geoLevels[currIndex];
-      const prevGeoLevel = geoLevels[prevIndex];
+      const [currGeoLevelProp, currGeoLevelId] = geoLevels[currIndex];
+      const [prevGeoLevelProp, prevGeoLevelId] = geoLevels[prevIndex];
 
       // Note: the types defined by Topojson are lacking, and are often subtly
       // inconsistent among functions. Unfortunately, a batch of `any` types were
       // needed to be deployed here, even though it was very close without them.
-      const prevGeoms: any = (topo.objects[prevGeoLevel] as any).geometries;
+      const prevGeoms: any = (topo.objects[prevGeoLevelId] as any).geometries;
 
       this.log(`Grouping geoLevel "${geoLevel}"`);
-      const grouped = groupBy(prevGeoms, f => f.properties[currGeoLevel]);
+      const grouped = groupBy(prevGeoms, f => f.properties[currGeoLevelProp]);
 
       this.log(`Merging ${Object.keys(grouped).length} features`);
       const mergedGeoms: any = mapValues(grouped, (geoms: readonly [Feature]) => {
@@ -237,8 +245,8 @@ it when necessary (file sizes ~1GB+).
         // and also what county this tract belongs to. This is used for subsequent
         // hierarchy calculations, and is also needed by other parts of the
         // application, such as for constructing districs.
-        for (const level of geoLevels.slice(currIndex)) {
-          merged.properties[level] = firstGeom?.properties?.[level];
+        for (const [levelProp] of geoLevels.slice(currIndex)) {
+          merged.properties[levelProp] = firstGeom?.properties?.[levelProp];
         }
         /* tslint:enable */
 
@@ -246,7 +254,7 @@ it when necessary (file sizes ~1GB+).
       });
 
       // tslint:disable-next-line:no-object-mutation
-      topo.objects[currGeoLevel] = {
+      topo.objects[currGeoLevelId] = {
         type: "GeometryCollection",
         geometries: Object.values(mergedGeoms)
       };
@@ -256,8 +264,8 @@ it when necessary (file sizes ~1GB+).
     // are converted into vector tiles.
     // We are using the id here, rather than a property, because an id is needed
     // in order to use the `setFeatureState` capability on the front-end.
-    for (const geoLevel of geoLevels) {
-      const geomCollection = topo.objects[geoLevel] as GeometryCollection;
+    for (const [levelProp, levelId] of geoLevels) {
+      const geomCollection = topo.objects[levelId] as GeometryCollection;
       geomCollection.geometries.forEach((geometry: GeometryObject, index) => {
         // tslint:disable-next-line:no-object-mutation
         geometry.id = index;
@@ -266,6 +274,16 @@ it when necessary (file sizes ~1GB+).
         for (const demo of demographics) {
           // @ts-ignore
           geometry.properties[`${demo}-abbrev`] = abbreviateNumber(geometry.properties[demo]);
+        }
+
+        // Rename geolevel props to match IDs
+        for (const [prop, id] of geoLevels) {
+          if (geometry && geometry.properties && prop in geometry.properties) {
+            // @ts-ignore
+            geometry.properties[id] = geometry.properties[prop];
+            // @ts-ignore
+            delete geometry.properties[prop];
+          }
         }
       });
     }


### PR DESCRIPTION
## Overview

The VA block GeoJSON had 'blockgroupuuid' as the id field for blockgroup, so I modified the processing script to be able to rename this field

### Checklist

- ~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~

### Demo

![localhost_3003_projects_e4efa0f4-0eca-46d8-8e54-aaddbda42eaa](https://user-images.githubusercontent.com/4432106/90775195-90440400-e2c6-11ea-8185-4d5977240cf1.png)


## Testing Instructions

- `./scripts/manage process-geojson data/VA.geojson -b -o data/output-va -n 12,4,4 -x 12,12,12 -l block,blockgroupuuid:blockgroup,county`

Connects to #123 