### PR TITLE
Fix labels

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -139,6 +139,8 @@ const GeoLevelButton = ({
   );
 };
 
+const capitalizeFirstLetter = (s: string) => s.substring(0, 1).toUpperCase() + s.substring(1);
+
 const MapHeader = ({
   label,
   setMapLabel,
@@ -158,7 +160,9 @@ const MapHeader = ({
 }) => {
   const labelOptions = metadata
     ? metadata.demographics.map(val => (
-        <option key={val.id}>{val.id.substring(0, 1).toUpperCase() + val.id.substring(1)}</option>
+        <option key={val.id} value={val.id}>
+          {capitalizeFirstLetter(val.id)}
+        </option>
       ))
     : [];
   const geoLevelOptions = metadata


### PR DESCRIPTION
## Overview

Fix labels

The option values were defaulting to the text contained inside the
`<option>` so once that was formatted differently (capitalized) the ids
no longer matched.

This sets the value explicitly to be the label id.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![db_fix_labels](https://user-images.githubusercontent.com/2926237/90797367-89c18680-e2de-11ea-84d1-570ff13ecdd3.png)

### Notes

This is a small fixup from #303 

## Testing Instructions
Select a label and ensure it's shown on the map correctly

Closes #331 
