### PR TITLE
Reset project state

### DIFF
--- a/src/client/actions/root.ts
+++ b/src/client/actions/root.ts
@@ -1,3 +1,5 @@
 import { createAction } from "typesafe-actions";
 
 export const resetState = createAction("Reset all state")();
+
+export const resetProjectState = createAction("Reset project screen state")();

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -3,21 +3,22 @@ import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
 import {
+  SelectionTool,
   addSelectedGeounits,
+  clearHighlightedGeounits,
   clearSelectedGeounits,
   editSelectedGeounits,
   removeSelectedGeounits,
-  setHighlightedGeounits,
-  clearHighlightedGeounits,
-  SelectionTool,
   saveDistrictsDefinition,
-  setSelectionTool,
-  setSelectedDistrictId,
   setGeoLevelIndex,
   setGeoLevelVisibility,
+  setHighlightedGeounits,
+  setSelectedDistrictId,
+  setSelectionTool,
   toggleDistrictLocked
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition } from "../actions/projectData";
+import { resetProjectState } from "../actions/root";
 import { GeoUnits, LockedDistricts } from "../../shared/entities";
 
 export interface DistrictDrawingState {
@@ -45,6 +46,8 @@ const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
   action: Action
 ): DistrictDrawingState | Loop<DistrictDrawingState, Action> => {
   switch (action.type) {
+    case getType(resetProjectState):
+      return initialState;
     case getType(setSelectedDistrictId):
       return {
         ...state,

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -24,6 +24,7 @@ import {
   staticMetadataFetchSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits } from "../actions/districtDrawing";
+import { resetProjectState } from "../actions/root";
 
 import {
   DistrictProperties,
@@ -59,6 +60,8 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
   action: Action
 ): ProjectDataState | Loop<ProjectDataState, Action> => {
   switch (action.type) {
+    case getType(resetProjectState):
+      return initialState;
     case getType(projectDataFetch):
       return loop(state, Cmd.action(projectFetch(action.payload)));
     case getType(projectFetch):

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -5,6 +5,7 @@ import { Redirect, useParams } from "react-router-dom";
 import { Flex, jsx, Spinner } from "theme-ui";
 import { IUser } from "../../shared/entities";
 import { projectDataFetch } from "../actions/projectData";
+import { resetProjectState } from "../actions/root";
 import { userFetch } from "../actions/user";
 import "../App.css";
 import CenteredContent from "../components/CenteredContent";
@@ -42,6 +43,14 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
     ("isPending" in projectData.geojson && projectData.geojson.isPending);
 
   const [label, setMapLabel] = useState<string | undefined>(undefined);
+
+  // Reset component redux state on unmount
+  useEffect(
+    () => () => {
+      store.dispatch(resetProjectState());
+    },
+    []
+  );
 
   useEffect(() => {
     store.dispatch(userFetch());


### PR DESCRIPTION
## Overview

Fixes two issues:
 - Resets project screen state stored in Redux when unmounting the `ProjectScreen` component 
 - Fixes a warning about calling `setState` on an unmounted component

### Checklist

- ~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~


## Testing Instructions

- Follow the steps in #269 on `develop` to recreate the original issue
- Verify it is fixed on this branch
- Observe the lack of warnings in the console

Closes #269
Closes #233 
