### PR TITLE
Add support for Rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicitly set Fargate platform version for ECS services [#318](https://github.com/PublicMapping/districtbuilder/pull/318)
 - Update Terraform AWS provider to 3.x [#329](https://github.com/PublicMapping/districtbuilder/pull/329)
 - Extend Jenkins pipeline to support production releases [#325](https://github.com/PublicMapping/districtbuilder/pull/325)
+- Add support for Rollbar [#338](https://github.com/PublicMapping/districtbuilder/pull/338)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-338') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-338') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -113,6 +113,8 @@ resource "aws_ecs_task_definition" "app" {
 
     app_port = var.app_port
 
+    rollbar_access_token = var.rollbar_access_token
+
     project     = var.project
     environment = var.environment
     aws_region  = var.aws_region

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -48,6 +48,10 @@
       {
         "name": "CLIENT_URL",
         "value": "${client_url}"
+      },
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "value": "${rollbar_access_token}"
       }
     ],
     "mountPoints": [],

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -278,6 +278,10 @@ variable "client_url" {
   type = string
 }
 
+variable "rollbar_access_token" {
+  type = string
+}
+
 variable "app_port" {
   default = 3005
   type    = number

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -22,5 +22,7 @@ services:
       - GIT_COMMIT=${GIT_COMMIT:-latest}
       - DB_DEBUG=1
       - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-districtbuilder-staging-config-us-east-1}
+      - DB_ROLLBAR_ACCESS_TOKEN
+      - DB_DEPLOYMENT_ENVIRONMENT=${DB_DEPLOYMENT_ENVIRONMENT:-staging}
     working_dir: /usr/local/src
     entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -50,6 +50,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             ;;
         apply)
             terraform apply "${DB_SETTINGS_BUCKET}.tfplan"
+
+            # Notify Rollbar of the deploy when running on Jenkins
+            if [[ -n "${DB_ROLLBAR_ACCESS_TOKEN}" && -n "${DB_DEPLOYMENT_ENVIRONMENT}" ]]; then
+                curl -s https://api.rollbar.com/api/1/deploy/ \
+                    -F "access_token=${DB_ROLLBAR_ACCESS_TOKEN}" \
+                    -F "environment=${DB_DEPLOYMENT_ENVIRONMENT}" \
+                    -F "revision=${GIT_COMMIT}" \
+                    -F "local_username=jenkins"
+            fi
             ;;
         *)
             echo "ERROR: I don't have support for that Terraform subcommand!"

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -48,7 +48,7 @@
     "class-validator": "0.12.2",
     "crypto": "1.0.1",
     "lodash": "4.17.19",
-    "nestjs-rollbar": "^1.4.0",
+    "nestjs-rollbar": "1.3.0",
     "nodemailer": "6.4.6",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -48,12 +48,12 @@
     "class-validator": "0.12.2",
     "crypto": "1.0.1",
     "lodash": "4.17.19",
+    "nestjs-rollbar": "^1.4.0",
     "nodemailer": "6.4.6",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",
     "pg": "7.17.1",
     "reflect-metadata": "0.1.13",
-    "rollbar": "2.19.2",
     "rxjs": "6.5.4",
     "topojson-client": "3.1.0",
     "typeorm": "0.2.22"

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -53,6 +53,7 @@
     "passport-jwt": "4.0.0",
     "pg": "7.17.1",
     "reflect-metadata": "0.1.13",
+    "rollbar": "2.19.2",
     "rxjs": "6.5.4",
     "topojson-client": "3.1.0",
     "typeorm": "0.2.22"

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -48,12 +48,12 @@
     "class-validator": "0.12.2",
     "crypto": "1.0.1",
     "lodash": "4.17.19",
-    "nestjs-rollbar": "1.3.0",
     "nodemailer": "6.4.6",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",
     "pg": "7.17.1",
     "reflect-metadata": "0.1.13",
+    "rollbar": "2.19.2",
     "rxjs": "6.5.4",
     "topojson-client": "3.1.0",
     "typeorm": "0.2.22"

--- a/src/server/src/app.module.ts
+++ b/src/server/src/app.module.ts
@@ -5,15 +5,15 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { HandlebarsAdapter, MailerModule } from "@nestjs-modules/mailer";
 import { SES } from "aws-sdk";
-import { LoggerModule } from "nestjs-rollbar";
 import * as SESTransport from "nodemailer/lib/ses-transport";
 import * as StreamTransport from "nodemailer/lib/stream-transport";
 
-import { DEBUG, ENVIRONMENT } from "./common/constants";
+import { DEBUG } from "./common/constants";
 import { AuthModule } from "./auth/auth.module";
 import { HealthCheckModule } from "./healthcheck/healthcheck.module";
 import { ProjectsModule } from "./projects/projects.module";
 import { RegionConfigsModule } from "./region-configs/region-configs.module";
+import { RollbarModule } from "./rollbar/rollbar.module";
 import { UsersModule } from "./users/users.module";
 
 import { join } from "path";
@@ -58,18 +58,7 @@ if (DEBUG) {
       }
     }),
     TerminusModule,
-    LoggerModule.forRoot({
-      enabled: !DEBUG,
-      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
-      captureUncaught: true,
-      captureUnhandledRejections: true,
-      payload: {
-        environment: ENVIRONMENT.toLowerCase(),
-        server: {
-          root: __dirname
-        }
-      }
-    }),
+    RollbarModule,
     AuthModule,
     HealthCheckModule,
     UsersModule,

--- a/src/server/src/app.module.ts
+++ b/src/server/src/app.module.ts
@@ -5,10 +5,11 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { HandlebarsAdapter, MailerModule } from "@nestjs-modules/mailer";
 import { SES } from "aws-sdk";
+import { LoggerModule } from "nestjs-rollbar";
 import * as SESTransport from "nodemailer/lib/ses-transport";
 import * as StreamTransport from "nodemailer/lib/stream-transport";
 
-import { DEBUG } from "./common/constants";
+import { DEBUG, ENVIRONMENT } from "./common/constants";
 import { AuthModule } from "./auth/auth.module";
 import { HealthCheckModule } from "./healthcheck/healthcheck.module";
 import { ProjectsModule } from "./projects/projects.module";
@@ -57,6 +58,18 @@ if (DEBUG) {
       }
     }),
     TerminusModule,
+    LoggerModule.forRoot({
+      enabled: !DEBUG,
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
+      captureUncaught: true,
+      captureUnhandledRejections: true,
+      payload: {
+        environment: ENVIRONMENT.toLowerCase(),
+        server: {
+          root: __dirname
+        }
+      }
+    }),
     AuthModule,
     HealthCheckModule,
     UsersModule,

--- a/src/server/src/common/constants.ts
+++ b/src/server/src/common/constants.ts
@@ -1,4 +1,5 @@
-export const DEBUG = process.env.NODE_ENV === "Development";
+export const ENVIRONMENT = process.env.NODE_ENV;
+export const DEBUG = ENVIRONMENT === "Development";
 export const BCRYPT_SALT_ROUNDS = 10;
 export const EMAIL_VERIFICATION_TOKEN_LENGTH = 20;
 export const DEFAULT_FROM_EMAIL =

--- a/src/server/src/common/constants.ts
+++ b/src/server/src/common/constants.ts
@@ -1,4 +1,4 @@
-export const ENVIRONMENT = process.env.NODE_ENV;
+export const ENVIRONMENT = process.env.NODE_ENV || "Development";
 export const DEBUG = ENVIRONMENT === "Development";
 export const BCRYPT_SALT_ROUNDS = 10;
 export const EMAIL_VERIFICATION_TOKEN_LENGTH = 20;

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -1,5 +1,5 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
-import { Response } from "express";
+import { Request, Response } from "express";
 import { RollbarService } from "./rollbar.service";
 
 @Catch(HttpException)
@@ -8,10 +8,11 @@ export class RollbarExceptionFilter implements ExceptionFilter {
 
   catch(exception: HttpException, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus();
 
-    this.rollbar.error("Testing Rollbar");
+    this.rollbar.error(exception, request);
     response.status(status).json(exception.getResponse());
   }
 }

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -6,6 +6,7 @@ import { RollbarService } from "./rollbar.service";
 @Catch()
 export class RollbarExceptionFilter extends BaseExceptionFilter {
   constructor(private rollbar: RollbarService) {
+    // BaseExceptionFilter will load applicationRef itself if no argument is given
     super();
   }
 
@@ -15,6 +16,7 @@ export class RollbarExceptionFilter extends BaseExceptionFilter {
 
     this.rollbar.error(exception, request);
 
+    // Delegate error messaging and response to default global exception filter
     super.catch(exception, host);
   }
 }

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -1,0 +1,17 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import { Response } from "express";
+import { RollbarService } from "./rollbar.service";
+
+@Catch(HttpException)
+export class RollbarExceptionFilter implements ExceptionFilter {
+  constructor(private rollbar: RollbarService) {}
+
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+
+    this.rollbar.error("Testing Rollbar");
+    response.status(status).json(exception.getResponse());
+  }
+}

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -1,6 +1,6 @@
 import { ArgumentsHost, Catch, HttpException } from "@nestjs/common";
 import { BaseExceptionFilter } from "@nestjs/core";
-import { Request, Response } from "express";
+import { Request } from "express";
 import { RollbarService } from "./rollbar.service";
 
 @Catch()

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -1,18 +1,20 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import { ArgumentsHost, Catch, HttpException } from "@nestjs/common";
+import { BaseExceptionFilter } from "@nestjs/core";
 import { Request, Response } from "express";
 import { RollbarService } from "./rollbar.service";
 
-@Catch(HttpException)
-export class RollbarExceptionFilter implements ExceptionFilter {
-  constructor(private rollbar: RollbarService) {}
+@Catch()
+export class RollbarExceptionFilter extends BaseExceptionFilter {
+  constructor(private rollbar: RollbarService) {
+    super();
+  }
 
   catch(exception: HttpException, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const request = ctx.getRequest<Request>();
-    const response = ctx.getResponse<Response>();
-    const status = exception.getStatus();
 
     this.rollbar.error(exception, request);
-    response.status(status).json(exception.getResponse());
+
+    super.catch(exception, host);
   }
 }

--- a/src/server/src/rollbar/rollbar.module.ts
+++ b/src/server/src/rollbar/rollbar.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { RollbarService } from "./rollbar.service";
+
+@Module({
+  providers: [RollbarService],
+  exports: [RollbarService]
+})
+export class RollbarModule {}

--- a/src/server/src/rollbar/rollbar.module.ts
+++ b/src/server/src/rollbar/rollbar.module.ts
@@ -1,8 +1,16 @@
 import { Module } from "@nestjs/common";
+import { APP_FILTER } from "@nestjs/core";
 import { RollbarService } from "./rollbar.service";
+import { RollbarExceptionFilter } from "./rollbar-exception.filter";
 
 @Module({
-  providers: [RollbarService],
+  providers: [
+    RollbarService,
+    {
+      provide: APP_FILTER,
+      useClass: RollbarExceptionFilter
+    }
+  ],
   exports: [RollbarService]
 })
 export class RollbarModule {}

--- a/src/server/src/rollbar/rollbar.module.ts
+++ b/src/server/src/rollbar/rollbar.module.ts
@@ -7,6 +7,7 @@ import { RollbarExceptionFilter } from "./rollbar-exception.filter";
   providers: [
     RollbarService,
     {
+      // Load Rollbar filter as a global filter to catch all unhandled exceptions
       provide: APP_FILTER,
       useClass: RollbarExceptionFilter
     }

--- a/src/server/src/rollbar/rollbar.service.ts
+++ b/src/server/src/rollbar/rollbar.service.ts
@@ -11,6 +11,7 @@ export class RollbarService extends Rollbar {
       accessToken: process.env.ROLLBAR_ACCESS_TOKEN || "",
       captureUncaught: true,
       captureUnhandledRejections: true,
+      nodeSourceMaps: true,
       payload: {
         environment: ENVIRONMENT.toLowerCase(),
         server: {

--- a/src/server/src/rollbar/rollbar.service.ts
+++ b/src/server/src/rollbar/rollbar.service.ts
@@ -1,0 +1,22 @@
+import { join } from "path";
+import { Injectable } from "@nestjs/common";
+import Rollbar from "rollbar";
+import { DEBUG, ENVIRONMENT } from "../common/constants";
+
+@Injectable()
+export class RollbarService extends Rollbar {
+  constructor() {
+    super({
+      enabled: !DEBUG,
+      accessToken: process.env.ROLLBAR_ACCESS_TOKEN || "",
+      captureUncaught: true,
+      captureUnhandledRejections: true,
+      payload: {
+        environment: ENVIRONMENT.toLowerCase(),
+        server: {
+          root: join(__dirname, "..")
+        }
+      }
+    });
+  }
+}

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -5835,6 +5835,13 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+nestjs-rollbar@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/nestjs-rollbar/-/nestjs-rollbar-1.4.0.tgz#dc45e68f1656d3e332c96360701e4c8c38a627bb"
+  integrity sha512-BQV6QxJOZbkw/Uh2HskG5ONQAuCG5BQ2TO3/rU4zw2046UfQVfULfbYD2xL0GJ4vqmrXD4oeiBySYCiZh1GSUA==
+  dependencies:
+    rollbar "^2.9.0"
+
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
@@ -7301,7 +7308,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollbar@2.19.2:
+rollbar@^2.9.0:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.19.2.tgz#1d874c8a02cac77b2dad1d907a2937cc7b8d0964"
   integrity sha512-aR2Mm4Gkq0UzpIZHOU0MYSQW+u/rWFgsuoPW5cR1E+UKn+jxp1ezKggQVAyPcdoEDBbFGAZ9lCLGu18aFVYgZA==

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -5835,13 +5835,6 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-nestjs-rollbar@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/nestjs-rollbar/-/nestjs-rollbar-1.3.0.tgz#4f992ea4f3083e802d205126f356438203fb9d5f"
-  integrity sha512-XnJ0P33ITM4Eh/aSOzt9YoNhhLbICdB+TgRIS7J1pkPlriaq6fDfvuNAE9waHbNmZSAEgkMo2ARzNyxtxLKQQg==
-  dependencies:
-    rollbar "^2.9.0"
-
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
@@ -7308,7 +7301,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollbar@^2.9.0:
+rollbar@2.19.2:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.19.2.tgz#1d874c8a02cac77b2dad1d907a2937cc7b8d0964"
   integrity sha512-aR2Mm4Gkq0UzpIZHOU0MYSQW+u/rWFgsuoPW5cR1E+UKn+jxp1ezKggQVAyPcdoEDBbFGAZ9lCLGu18aFVYgZA==

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -5835,10 +5835,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-nestjs-rollbar@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/nestjs-rollbar/-/nestjs-rollbar-1.4.0.tgz#dc45e68f1656d3e332c96360701e4c8c38a627bb"
-  integrity sha512-BQV6QxJOZbkw/Uh2HskG5ONQAuCG5BQ2TO3/rU4zw2046UfQVfULfbYD2xL0GJ4vqmrXD4oeiBySYCiZh1GSUA==
+nestjs-rollbar@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/nestjs-rollbar/-/nestjs-rollbar-1.3.0.tgz#4f992ea4f3083e802d205126f356438203fb9d5f"
+  integrity sha512-XnJ0P33ITM4Eh/aSOzt9YoNhhLbICdB+TgRIS7J1pkPlriaq6fDfvuNAE9waHbNmZSAEgkMo2ARzNyxtxLKQQg==
   dependencies:
     rollbar "^2.9.0"
 

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -1511,6 +1511,11 @@ async@0.9.x:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
+async@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.2.1.tgz#a4816a17cd5ff516dfa2c7698a453369b9790de0"
+  integrity sha1-pIFqF81f9RbfosdpikUzabl5DeA=
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2335,6 +2340,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+console-polyfill@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
+  integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
+
 constantinople@^3.0.1, constantinople@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/constantinople/-/constantinople-3.1.2.tgz#d45ed724f57d3d10500017a7d3a889c1381ae647"
@@ -2593,6 +2603,13 @@ debug@^3.1.0, debug@^3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+decache@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-3.1.0.tgz#4f5036fbd6581fcc97237ac3954a244b9536c2da"
+  integrity sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=
+  dependencies:
+    find "^0.2.4"
 
 decamelize@^1.0.0, decamelize@^1.2.0:
   version "1.2.0"
@@ -2939,6 +2956,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
 
 es-abstract@^1.17.0:
   version "1.17.5"
@@ -3600,6 +3624,13 @@ find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+find@^0.2.4:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
+  integrity sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=
+  dependencies:
+    traverse-chain "~0.1.0"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -4485,6 +4516,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+is_js@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
+  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -5026,7 +5062,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -5392,6 +5428,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@~2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
+  integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
 
 lru-queue@0.1:
   version "0.1.0"
@@ -7104,6 +7145,13 @@ repeat-string@^1.5.2, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+request-ip@~2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
+  integrity sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=
+  dependencies:
+    is_js "^0.9.0"
+
 request-promise-core@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
@@ -7252,6 +7300,22 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollbar@2.19.2:
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.19.2.tgz#1d874c8a02cac77b2dad1d907a2937cc7b8d0964"
+  integrity sha512-aR2Mm4Gkq0UzpIZHOU0MYSQW+u/rWFgsuoPW5cR1E+UKn+jxp1ezKggQVAyPcdoEDBbFGAZ9lCLGu18aFVYgZA==
+  dependencies:
+    async "~1.2.1"
+    console-polyfill "0.3.0"
+    error-stack-parser "^2.0.4"
+    json-stringify-safe "~5.0.0"
+    lru-cache "~2.2.1"
+    request-ip "~2.0.1"
+    source-map "^0.5.7"
+    uuid "3.0.x"
+  optionalDependencies:
+    decache "^3.0.5"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -7567,7 +7631,7 @@ source-map@0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -7666,6 +7730,11 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stackframe@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
+  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -8170,6 +8239,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
+
 tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -8472,6 +8546,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.0.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
 
 uuid@3.3.2:
   version "3.3.2"


### PR DESCRIPTION
## Overview

Integrates Rollbar for server-side exception reporting and deploy reporting.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

Server-scoped access tokens have been created for production and staging environments in Rollbar.

## Testing Instructions

* Confirm the presence of a deploy notification in #district-builder, such as [this one](https://azavea.slack.com/archives/C6UD5FG3T/p1598035482037000).
* Confirm the presence of test error items in the Rollbar console, such as [this one](https://rollbar.com/Azavea/DistrictBuilder/items/6/).
* Verify that Rollbar account configuration, notifications, and teams / users reflect organizational standards and project needs.

Closes #73 
