### PR TITLE
Reorder district types

### DIFF
--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -225,7 +225,8 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
               <Card sx={{ variant: "card.flat", display: "flex", flexWrap: "wrap" }}>
                 <Label sx={style.cardLabel}>Districts</Label>
                 {data.regionConfig &&
-                  data.regionConfig.chambers
+                  [...data.regionConfig.chambers]
+                    .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
                     .map(chamber => (
                       <Label
                         key={chamber.id}
@@ -274,7 +275,6 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                         </Label>
                       </div>
                     )}
-
                 {data.isCustom ? (
                   <Box sx={style.customInputContainer}>
                     <InputField


### PR DESCRIPTION
## Overview

Order options from fewest districts to most districts, with custom always as the final option.

### Demo

![image](https://user-images.githubusercontent.com/1809908/91341671-db1eb980-e7a7-11ea-8bb1-5174de21eebe.png)

### Notes

I used a spread operator to get access to the `sort` method. I was getting a typescript error without it. Please let me know if I did this right or if there is a preferable method.
## Testing Instructions

- Create new map
- Select a state
- Confirm that the district types are in order from fewest to most districts

Closes #320 
