### PR TITLE
Improve map screen performance

### DIFF
--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -39,8 +39,10 @@ const Row = ({
     <Styled.td sx={style.label}>{label}</Styled.td>
     <Styled.td sx={{ minWidth: "50px", py: 0 }}>
       <Box
+        style={{
+          width: `${percent}%`
+        }}
         sx={{
-          width: `${percent}%`,
           height: "10px",
           backgroundColor: color,
           borderRadius: "1px"

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -14,7 +14,8 @@ import {
   IStaticMetadata,
   LockedDistricts
 } from "../../shared/entities";
-import { assertNever, getDemographics, getTotalSelectedDemographics } from "../../shared/functions";
+import { assertNever } from "../../shared/functions";
+import { getDemographics, getTotalSelectedDemographics } from "../functions";
 import {
   getDistrictColor,
   negativeChangeColor,

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -68,16 +68,16 @@ const MapTooltip = ({
     ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
     : undefined;
 
-  const throttledSetFeature = throttle((point, geoLevel) => {
-    const features =
-      map &&
-      map.queryRenderedFeatures(point, {
-        layers: [levelToLineLayerId(geoLevel), levelToSelectionLayerId(geoLevel)]
-      });
-    features && setFeature(features[0]);
-  }, SET_FEATURE_DELAY);
-
   useEffect(() => {
+    const throttledSetFeature = throttle((point, geoLevel) => {
+      const features =
+        map &&
+        map.queryRenderedFeatures(point, {
+          layers: [levelToLineLayerId(geoLevel), levelToSelectionLayerId(geoLevel)]
+        });
+      features && setFeature(features[0]);
+    }, SET_FEATURE_DELAY);
+
     const onMouseMoveThrottled = throttle((e: MapboxGL.MapMouseEvent) => {
       // eslint-disable-next-line
       if (map && staticMetadata && invertedGeoLevelIndex !== undefined) {
@@ -114,7 +114,7 @@ const MapTooltip = ({
     }
 
     return clearHandlers;
-  }, [map, staticMetadata, invertedGeoLevelIndex, throttledSetFeature]);
+  }, [map, staticMetadata, invertedGeoLevelIndex]);
 
   // eslint-disable-next-line
   if (

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -89,19 +89,7 @@ const MapTooltip = ({
       }
     }, 5);
 
-    const onMouseOut = throttle((e: MouseEvent) => {
-      const isOnTooltip =
-        e.relatedTarget instanceof Element &&
-        tooltipRef.current &&
-        (e.relatedTarget === tooltipRef.current || tooltipRef.current.contains(e.relatedTarget));
-
-      !isOnTooltip && setFeature(undefined);
-      isOnTooltip &&
-        setPoint({
-          x: e.offsetX,
-          y: e.offsetY
-        });
-    }, 5);
+    const onMouseOut = throttle(() => setFeature(undefined), 5);
 
     const onDrag = (e: MapboxGL.MapMouseEvent) => {
       setPoint({ x: e.originalEvent.offsetX, y: e.originalEvent.offsetY });
@@ -175,7 +163,8 @@ const MapTooltip = ({
     return demographics ? (
       <Box
         ref={tooltipRef}
-        sx={{ ...style.tooltip, ...{ transform: `translate3d(${x}px, ${y}px, 0)` } }}
+        style={{ transform: `translate3d(${x}px, ${y}px, 0)` }}
+        sx={{ ...style.tooltip }}
       >
         {heading && (
           <Heading sx={{ fontSize: 2, fontFamily: "heading", color: "muted" }}>{heading}</Heading>

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -7,7 +7,8 @@ import { connect } from "react-redux";
 import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 
 import { GeoUnits, GeoUnitHierarchy, IStaticMetadata } from "../../../shared/entities";
-import { geoLevelLabel, getTotalSelectedDemographics } from "../../../shared/functions";
+import { geoLevelLabel } from "../../../shared/functions";
+import { getTotalSelectedDemographics } from "../../functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
 import { Resource } from "../../resource";

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -1,3 +1,4 @@
+import throttle from "lodash/throttle";
 import MapboxGL from "mapbox-gl";
 import store from "../../store";
 import {
@@ -12,7 +13,8 @@ import {
   GEOLEVELS_SOURCE_ID,
   isFeatureSelected,
   levelToSelectionLayerId,
-  ISelectionTool
+  ISelectionTool,
+  SET_FEATURE_DELAY
 } from "./index";
 
 import {
@@ -23,6 +25,11 @@ import {
   IStaticMetadata,
   LockedDistricts
 } from "../../../shared/entities";
+
+const throttledSetHighlightedGeounits = throttle(
+  (geounits: GeoUnits) => store.dispatch(setHighlightedGeounits(geounits)),
+  SET_FEATURE_DELAY
+);
 
 /*
  * Allows user to click and drag to select all geounits within the rectangle
@@ -123,7 +130,7 @@ const RectangleSelectionTool: ISelectionTool = {
       const newGeoUnits = new Map(
         [...geoUnits].filter(([id]) => !setOfInitiallySelectedFeatures.has(id))
       );
-      store.dispatch(setHighlightedGeounits(newGeoUnits));
+      throttledSetHighlightedGeounits(newGeoUnits);
 
       // Set any features that were previously selected and just became unselected to unselected
       // eslint-disable-next-line

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -23,6 +23,9 @@ export const DISTRICTS_LAYER_ID = "districts";
 // Used only to make labels show up on top of all other layers
 export const DISTRICTS_PLACEHOLDER_LAYER_ID = "district-placeholder";
 
+// Delay used to throttle calls to set the current feature(s), in milliseconds
+export const SET_FEATURE_DELAY = 100;
+
 export function getGeolevelLinePaintStyle(geoLevel: string) {
   const largeGeolevel = {
     "line-color": "#000",

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,0 +1,18 @@
+import memoize from "memoizee";
+
+import {
+  getDemographics as getDemographicsBase,
+  getTotalSelectedDemographics as getTotalSelectedDemographicsBase
+} from "../shared/functions";
+
+// TODO: merge this module with shared/functions once the ability to import
+// third party dependencies into the shared module is fixed
+
+export const getDemographics = memoize(getDemographicsBase, {
+  normalizer: args => JSON.stringify([[...args[0]].sort(), args[1]]),
+  primitive: true
+});
+export const getTotalSelectedDemographics = memoize(getTotalSelectedDemographicsBase, {
+  normalizer: args => JSON.stringify([args[0], [...args[3]].sort()]),
+  primitive: true
+});

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect, useParams } from "react-router-dom";
 import { Flex, jsx, Spinner } from "theme-ui";
@@ -57,6 +57,33 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
     projectId && store.dispatch(projectDataFetch(projectId));
   }, [projectId]);
 
+  const sidebar = useMemo(
+    () => (
+      <ProjectSidebar
+        project={project}
+        geojson={geojson}
+        isLoading={isLoading}
+        staticMetadata={staticMetadata}
+        staticDemographics={staticDemographics}
+        selectedDistrictId={districtDrawing.selectedDistrictId}
+        selectedGeounits={districtDrawing.selectedGeounits}
+        geoUnitHierarchy={geoUnitHierarchy}
+        lockedDistricts={districtDrawing.lockedDistricts}
+      />
+    ),
+    [
+      project,
+      geojson,
+      isLoading,
+      staticMetadata,
+      staticDemographics,
+      districtDrawing.selectedDistrictId,
+      districtDrawing.selectedGeounits,
+      geoUnitHierarchy,
+      districtDrawing.lockedDistricts
+    ]
+  );
+
   return "isPending" in user ? (
     <CenteredContent>
       <Flex sx={{ justifyContent: "center" }}>
@@ -70,17 +97,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
       <Toast />
       <ProjectHeader project={project} />
       <Flex sx={{ flex: 1, overflowY: "auto" }}>
-        <ProjectSidebar
-          project={project}
-          geojson={geojson}
-          isLoading={isLoading}
-          staticMetadata={staticMetadata}
-          staticDemographics={staticDemographics}
-          selectedDistrictId={districtDrawing.selectedDistrictId}
-          selectedGeounits={districtDrawing.selectedGeounits}
-          geoUnitHierarchy={geoUnitHierarchy}
-          lockedDistricts={districtDrawing.lockedDistricts}
-        />
+        {sidebar}
         <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>
           <MapHeader
             label={label}


### PR DESCRIPTION
## Overview

A variety of performance improvements to the Project screen:
 - Moved dynamic CSS properties out of Theme-UI `sx` property to avoid recalculating styles
 - Added memoization in a few places
 - Added a  separate throttle to the map tooltip for its _contents_ to provide smooth motion w/o needing as many recalculations of data
 - Fixed up some event handlers that were getting disabled/enabled on every render

### Checklist

- ~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~

### Demo

![Peek 2020-08-26 17-07](https://user-images.githubusercontent.com/4432106/91357373-24c6ce80-e7bf-11ea-9872-ee36d20da4a0.gif)


### Notes

Note that there is still a significant performance hit when the chrome dev tools are open (partially but not fully caused by https://github.com/PublicMapping/districtbuilder/issues/348). This seems to go away when the dev tools are closed so I'm not that worried about it.

I think any further performance enhancements on this page will likely require the use of web workers to offload demographics calculations to a background thread

## Testing Instructions

- Go to the project screen
- Observe the improved performance, particularly with the rectangle selection

Closes #285 
Closes #288 
