### PR TITLE
Increase max zoom level

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -76,6 +76,9 @@ const Map = ({
 
   const minZoom = Math.min(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.minZoom));
   const maxZoom = Math.max(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.maxZoom));
+
+  // While a geolevel has tiles up to the maxZoom level, we want the enable the user to zoom in
+  // beyond that zoom level. Using lower zoom tiles at higher zoom levels is called overzoom.
   const overZoom = maxZoom + 4;
 
   // Add a color property to the geojson, so it can be used for styling

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -76,6 +76,7 @@ const Map = ({
 
   const minZoom = Math.min(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.minZoom));
   const maxZoom = Math.max(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.maxZoom));
+  const overZoom = maxZoom + 4;
 
   // Add a color property to the geojson, so it can be used for styling
   geojson.features.forEach((feature, id) => {
@@ -100,8 +101,8 @@ const Map = ({
       ),
       bounds: [b0, b1, b2, b3],
       fitBoundsOptions: { padding: 20 },
-      minZoom,
-      maxZoom
+      minZoom: minZoom,
+      maxZoom: overZoom
     });
 
     map.addControl(

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -231,7 +231,7 @@ export function getGeoLevelVisibility(
   return staticMetadata.geoLevelHierarchy
     .slice()
     .reverse()
-    .map(geoLevel => mapZoom <= geoLevel.maxZoom && mapZoom >= geoLevel.minZoom);
+    .map(geoLevel => mapZoom >= geoLevel.minZoom);
 }
 
 /* eslint-disable */


### PR DESCRIPTION
## Overview

Increases the max zoom level of the map while maintaining the max zoom level for tiles.

### Demo

![Map that zooms in farther than before](https://media.giphy.com/media/Q5FHoepsYUidnVkiCu/giphy.gif)

### Notes

To determine whether to enable a geolevel at a certain zoom level, we were checking that the current zoom level is smaller than the maxzoom for that geolevel. I needed to remove this to allow us to enable a geolevel even if we were zoomed past the maxzoom. Maxzoom, in this case, is about tile availability, not layer visibility.

To set the new maxzoom level for the map, I am adding 4 to the tile max zoom. This is a number that looked good to me for Philadelphia, but we might need to adjust after testing with additional states. I think a better long term solution would be to add this value to the state config, so we can adjust it on a case-by-case basis. I wasn't sure how to do that, but if people feel that this would be good to do now, I'm happy to make this change with support.

## Testing Instructions

- Open a project
- Press the + zoom buttom to zoom in one level at a time
- Zoom in until the "Blocks" button becomes enabled
- You should be able to continue to zoom in four additional levels after you reach this point

Closes #231
