### PR TITLE
Fix feature id conflict and avoid fitting map when splitting up a geounit

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "http-proxy-middleware": "0.20.0",
-    "prettier": "1.18.2"
+    "prettier": "1.19.1"
   }
 }

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -12,8 +12,8 @@ export const addSelectedGeounits = createAction("Add selected geounits")<GeoUnit
 export const removeSelectedGeounits = createAction("Remove selected geounits")<GeoUnits>();
 export const clearSelectedGeounits = createAction("Clear selected geounits")();
 export const editSelectedGeounits = createAction("Edit selected geounits")<{
-  readonly add: GeoUnits;
-  readonly remove: GeoUnits;
+  readonly add?: GeoUnits;
+  readonly remove?: GeoUnits;
 }>();
 
 export const setHighlightedGeounits = createAction("Add highlighted geounit ids")<GeoUnits>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -1,6 +1,7 @@
 import { createAction } from "typesafe-actions";
 import { FeatureCollection, MultiPolygon } from "geojson";
 import {
+  UintArrays,
   DistrictProperties,
   GeoUnitHierarchy,
   GeoUnits,
@@ -26,7 +27,7 @@ export const staticMetadataFetchSuccess = createAction("Static metadata fetch su
 export const staticMetadataFetchFailure = createAction("Static metadata fetch failure")<string>();
 
 export const staticGeoLevelsFetchSuccess = createAction("Static geoLevels fetch success")<
-  ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>
+  UintArrays
 >();
 export const staticGeoLevelsFetchFailure = createAction("Static geoLevels fetch failure")<string>();
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
-import { geoLevelLabel } from "../../shared/functions";
+import { areAnyGeoUnitsSelected, geoLevelLabel } from "../functions";
 
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
@@ -96,7 +96,7 @@ const GeoLevelButton = ({
   readonly selectedGeounits: GeoUnits;
 }) => {
   const label = geoLevelLabel(value.id);
-  const areGeoUnitsSelected = selectedGeounits.size > 0;
+  const areGeoUnitsSelected = areAnyGeoUnitsSelected(selectedGeounits);
   const isGeoLevelHidden = geoLevelVisibility[index] === false;
   const isBaseGeoLevelSelected = geoLevelIndex === geoLevelHierarchy.length - 1;
   const isCurrentLevelBaseGeoLevel = index === geoLevelHierarchy.length - 1;

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -4,6 +4,7 @@ import React, { useState, Fragment } from "react";
 import { Box, Button, Flex, Heading, jsx, Spinner, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
+  UintArrays,
   CompactnessScore,
   DistrictsDefinition,
   DistrictProperties,
@@ -14,8 +15,13 @@ import {
   IStaticMetadata,
   LockedDistricts
 } from "../../shared/entities";
-import { assertNever } from "../../shared/functions";
-import { getDemographics, getTotalSelectedDemographics } from "../functions";
+import {
+  allGeoUnitIndices,
+  areAnyGeoUnitsSelected,
+  assertNever,
+  getDemographics,
+  getTotalSelectedDemographics
+} from "../functions";
 import {
   getDistrictColor,
   negativeChangeColor,
@@ -128,7 +134,7 @@ const ProjectSidebar = ({
   readonly project?: IProject;
   readonly geojson?: FeatureCollection<MultiPolygon, DistrictProperties>;
   readonly staticMetadata?: IStaticMetadata;
-  readonly staticDemographics?: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>;
+  readonly staticDemographics?: UintArrays;
   readonly selectedDistrictId: number;
   readonly selectedGeounits: GeoUnits;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
@@ -217,7 +223,7 @@ const SidebarHeader = ({
         <Flex sx={{ alignItems: "center", justifyContent: "center" }}>
           <Spinner variant="spinner.small" />
         </Flex>
-      ) : selectedGeounits.size ? (
+      ) : areAnyGeoUnitsSelected(selectedGeounits) ? (
         <Flex sx={{ variant: "header.right" }}>
           <Button
             variant="circularSubtle"
@@ -461,8 +467,8 @@ const getSavedDistrictSelectedDemographics = (
     }
   };
 
-  selectedGeounits.forEach(selectedGeounit => {
-    accumulateGeounits(selectedGeounit, project.districtsDefinition, geoUnitHierarchy);
+  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices => {
+    accumulateGeounits(geoUnitIndices, project.districtsDefinition, geoUnitHierarchy);
   });
 
   return mutableDistrictGeounitAccum.map(baseGeounitIdsForDistrict =>

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -61,9 +61,10 @@ const DefaultSelectionTool: ISelectionTool = {
         districtsDefinition,
         lockedDistricts
       );
+      const geoUnitsForLevel = geoUnits[geoLevelId] || new Map();
       const addFeatures = () => {
         map.setFeatureState(featureStateGeoLevel(feature), { selected: true });
-        const geoUnitIndices = geoUnits.get(feature.id as FeatureId) as GeoUnitIndices;
+        const geoUnitIndices = geoUnitsForLevel.get(feature.id as FeatureId) as GeoUnitIndices;
         const subFeatures = findSelectedSubFeatures(map, staticMetadata, feature, geoUnitIndices);
         subFeatures.forEach(feature => {
           map.setFeatureState(featureStateGeoLevel(feature), { selected: false });
@@ -86,7 +87,7 @@ const DefaultSelectionTool: ISelectionTool = {
         store.dispatch(removeSelectedGeounits(geoUnits));
       };
 
-      geoUnits.has(feature.id as FeatureId) &&
+      geoUnitsForLevel.has(feature.id as FeatureId) &&
         (isFeatureSelected(map, feature) ? removeFeatures() : addFeatures());
     };
     map.on("click", clickHandler);

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,18 +1,195 @@
 import memoize from "memoizee";
 
 import {
-  getDemographics as getDemographicsBase,
-  getTotalSelectedDemographics as getTotalSelectedDemographicsBase
-} from "../shared/functions";
+  DemographicCounts,
+  DistrictsDefinition,
+  MutableGeoUnitCollection,
+  GeoLevelHierarchy,
+  GeoUnits,
+  GeoUnitIndices,
+  GeoUnitHierarchy,
+  IStaticMetadata,
+  NestedArray
+} from "../shared/entities";
+import { getDemographics as getDemographicsBase } from "../shared/functions";
 
-// TODO: merge this module with shared/functions once the ability to import
+// TODO: merge this function with shared/functions once the ability to import
 // third party dependencies into the shared module is fixed
-
 export const getDemographics = memoize(getDemographicsBase, {
   normalizer: args => JSON.stringify([[...args[0]].sort(), args[1]]),
   primitive: true
 });
+
+/*
+ * Return all base indices for this subset of the geounit hierarchy.
+ */
+// eslint-disable-next-line
+function accumulateBaseIndices(geoUnitHierarchy: GeoUnitHierarchy): number[] {
+  // eslint-disable-next-line
+  const baseIndices: number[] = [];
+  geoUnitHierarchy.forEach(currentIndices =>
+    // eslint-disable-next-line
+    baseIndices.push(
+      ...(typeof currentIndices === "number"
+        ? [currentIndices]
+        : accumulateBaseIndices(currentIndices))
+    )
+  );
+  return baseIndices;
+}
+
+/*
+ * Return all corresponding base indices (i.e. smallest geounit, eg. blocks) for a given geounit.
+ */
+function baseIndicesForGeoUnit(
+  geoUnitHierarchy: GeoUnitHierarchy,
+  geoUnitIndices: GeoUnitIndices
+  // eslint-disable-next-line
+): number[] {
+  const [geoUnitIndex, ...remainingGeoUnitIndices] = geoUnitIndices;
+  const indicesForGeoLevel: number | NestedArray<number> = geoUnitHierarchy[geoUnitIndex];
+  // eslint-disable-next-line
+  if (remainingGeoUnitIndices.length) {
+    // Need to recurse to find the geounit in question in the hierarchy
+    return baseIndicesForGeoUnit(indicesForGeoLevel as GeoUnitHierarchy, remainingGeoUnitIndices);
+  }
+  // We've reached the geounit we're after. Now we need to return all the base geounit ids below it
+  // eslint-disable-next-line
+  if (typeof indicesForGeoLevel === "number") {
+    // Must be working with base geounit. Wrap it in an array and return.
+    return [indicesForGeoLevel];
+  }
+  return accumulateBaseIndices(indicesForGeoLevel);
+}
+
+export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
+  return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
+}
+
+export function allGeoUnitIndices(geoUnits: GeoUnits) {
+  return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.values()));
+}
+
+// Aggregate all demographics that are included in the selection
+function getTotalSelectedDemographicsBase(
+  staticMetadata: IStaticMetadata,
+  geoUnitHierarchy: GeoUnitHierarchy,
+  staticDemographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
+  selectedGeounits: GeoUnits
+): DemographicCounts {
+  // Build up set of blocks ids corresponding to selected geounits
+  // eslint-disable-next-line
+  const selectedBaseIndices: Set<number> = new Set();
+  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices =>
+    baseIndicesForGeoUnit(geoUnitHierarchy, geoUnitIndices).forEach(index =>
+      // eslint-disable-next-line
+      selectedBaseIndices.add(index)
+    )
+  );
+  // Aggregate all counts for selected blocks
+  return getDemographics(selectedBaseIndices, staticMetadata, staticDemographics);
+}
+
 export const getTotalSelectedDemographics = memoize(getTotalSelectedDemographicsBase, {
-  normalizer: args => JSON.stringify([args[0], [...args[3]].sort()]),
+  normalizer: args => JSON.stringify([args[0], [...allGeoUnitIndices(args[3])].sort()]),
   primitive: true
 });
+
+/*
+ * Assign nested geounit to district.
+ *
+ * This can require the creation of intermediate levels using the current
+ * district id as we recurse more deeply.
+ */
+function assignNestedGeounit(
+  currentDistrictsDefinition: MutableGeoUnitCollection,
+  currentGeounitData: readonly number[],
+  currentGeoUnitHierarchy: GeoUnitHierarchy,
+  districtId: number
+): MutableGeoUnitCollection {
+  const [currentLevelGeounitId, ...remainingLevelsGeounitIds] = currentGeounitData;
+  // Update districts definition using existing values or explode out district id using hierarchy
+  // eslint-disable-next-line
+  let newDefinition: MutableGeoUnitCollection =
+    typeof currentDistrictsDefinition === "number"
+      ? // Auto-fill district ids using current value based on number of geounits at this level
+        new Array(currentGeoUnitHierarchy.length).fill(currentDistrictsDefinition)
+      : // Copy existing district ids at this level
+        currentDistrictsDefinition;
+  /* eslint-disable */
+  if (remainingLevelsGeounitIds.length) {
+    // We need to go deeper...
+    newDefinition[currentLevelGeounitId] = assignNestedGeounit(
+      newDefinition[currentLevelGeounitId] as MutableGeoUnitCollection,
+      currentGeounitData.slice(1),
+      currentGeoUnitHierarchy[currentLevelGeounitId] as readonly number[],
+      districtId
+    );
+  } else {
+    // End of the line. Update value with new district id
+    newDefinition[currentLevelGeounitId] = districtId;
+    if (newDefinition.every(value => value === districtId)) {
+      // Update district definition for this level to be just the district id
+      // eg. instead of [3, 3, 3, 3, ...] for every geounit at this level, just 3
+      newDefinition = districtId;
+    }
+  }
+  /* eslint-enable */
+  return newDefinition;
+}
+
+/*
+ * Return new districts definition after assigning the selected geounits to the current district
+ */
+export function assignGeounitsToDistrict(
+  districtsDefinition: DistrictsDefinition,
+  geoUnitHierarchy: GeoUnitHierarchy,
+  geounitIndices: readonly GeoUnitIndices[],
+  districtId: number
+): DistrictsDefinition {
+  return geounitIndices.reduce((newDistrictsDefinition, geounitData) => {
+    const initialGeounitId = geounitData[0];
+    // eslint-disable-next-line
+    newDistrictsDefinition[initialGeounitId] =
+      geounitData.length === 1
+        ? // Assign entire county
+          districtId
+        : // Need to assign nested geounit
+          assignNestedGeounit(
+            newDistrictsDefinition[initialGeounitId],
+            geounitData.slice(1),
+            geoUnitHierarchy[initialGeounitId] as NestedArray<number>,
+            districtId
+          );
+    return newDistrictsDefinition;
+  }, districtsDefinition);
+}
+
+/*
+ * Helper function to get exhaustiveness checking.
+ *
+ * See: https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
+ */
+export function assertNever(x: never): never {
+  // eslint-disable-next-line
+  throw new Error(`Unexpected: ${x}`);
+}
+
+export const geoLevelLabel = (id: string): string => {
+  switch (id) {
+    case "block":
+      return "Blocks";
+    case "tract":
+      return "Tracts";
+    case "blockgroup":
+      return "Blockgroups";
+    case "county":
+      return "Counties";
+    default:
+      return id;
+  }
+};
+
+export function getSelectedGeoLevel(geoLevelHierarchy: GeoLevelHierarchy, geoLevelIndex: number) {
+  return geoLevelHierarchy[geoLevelHierarchy.length - 1 - geoLevelIndex];
+}

--- a/src/client/reducers/auth.ts
+++ b/src/client/reducers/auth.ts
@@ -11,7 +11,9 @@ export const initialState: AuthState = { passwordResetNoticeShown: false };
 
 const authReducer = createReducer<AuthState, Action>(initialState).handleAction(
   showPasswordResetNotice,
-  (state, action) => ({ passwordResetNoticeShown: action.payload })
+  (state, action) => ({
+    passwordResetNoticeShown: action.payload
+  })
 );
 
 export default authReducer;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -27,12 +27,13 @@ import { clearSelectedGeounits } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
 
 import {
+  UintArrays,
   DistrictProperties,
   GeoUnitHierarchy,
   IProject,
   IStaticMetadata
 } from "../../shared/entities";
-import { assignGeounitsToDistrict } from "../../shared/functions";
+import { allGeoUnitIndices, assignGeounitsToDistrict } from "../functions";
 import { fetchProject, fetchProjectGeoJson, patchDistrictsDefinition } from "../api";
 import { Resource } from "../resource";
 import { fetchStaticFiles, fetchStaticMetadata, fetchGeoUnitHierarchy } from "../s3";
@@ -40,8 +41,8 @@ import { fetchStaticFiles, fetchStaticMetadata, fetchGeoUnitHierarchy } from "..
 export interface ProjectDataState {
   readonly project: Resource<IProject>;
   readonly staticMetadata: Resource<IStaticMetadata>;
-  readonly staticGeoLevels: Resource<ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>>;
-  readonly staticDemographics: Resource<ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>>;
+  readonly staticGeoLevels: Resource<UintArrays>;
+  readonly staticDemographics: Resource<UintArrays>;
   readonly geojson: Resource<FeatureCollection<MultiPolygon, DistrictProperties>>;
   readonly geoUnitHierarchy: Resource<GeoUnitHierarchy>;
 }
@@ -227,7 +228,7 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
                 assignGeounitsToDistrict(
                   state.project.resource.districtsDefinition,
                   state.geoUnitHierarchy.resource,
-                  Array.from(action.payload.selectedGeounits.values()),
+                  allGeoUnitIndices(action.payload.selectedGeounits),
                   action.payload.selectedDistrictId
                 )
               ] as Parameters<typeof patchDistrictsDefinition>

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { parse, resolve } from "url";
 
 import {
+  UintArrays,
   GeoUnitHierarchy,
   HttpsURI,
   IStaticFile,
@@ -41,7 +42,7 @@ export async function fetchGeoUnitHierarchy(path: S3URI): Promise<GeoUnitHierarc
 export async function fetchStaticFiles(
   path: S3URI,
   files: readonly IStaticFile[]
-): Promise<ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>> {
+): Promise<UintArrays> {
   const requests = files.map(fileMeta =>
     s3Axios.get(staticDataUri(path, fileMeta.fileName), {
       responseType: "arraybuffer"

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -14,6 +14,7 @@ import { topology } from "topojson-server";
 import { planarTriangleArea, presimplify, simplify } from "topojson-simplify";
 import { GeometryCollection, GeometryObject, Objects, Topology } from "topojson-specification";
 import {
+  UintArray,
   GeoLevelInfo,
   GeoUnitDefinition,
   HierarchyDefinition,
@@ -344,7 +345,7 @@ it when necessary (file sizes ~1GB+).
   }
 
   // Makes an appropriately-sized typed array containing the data
-  mkTypedArray(data: readonly number[]): Uint8Array | Uint16Array | Uint32Array {
+  mkTypedArray(data: readonly number[]): UintArray {
     // Can't use Math.max here, because it's a recursive function that will
     // reach a maximum call stack when working with large arrays.
     const maxVal = data.reduce((max, v) => (max >= v ? max : v), -Infinity);

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -13,6 +13,7 @@ import length from "@turf/length";
 import polygonToLine from "@turf/polygon-to-line";
 
 import {
+  UintArrays,
   CompactnessScore,
   GeoUnitCollection,
   GeoUnitDefinition,
@@ -117,8 +118,8 @@ export class GeoUnitTopology {
     public readonly topology: Topology,
     public readonly definition: GeoUnitDefinition,
     public readonly staticMetadata: IStaticMetadata,
-    public readonly demographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
-    public readonly geoLevels: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>
+    public readonly demographics: UintArrays,
+    public readonly geoLevels: UintArrays
   ) {
     this.hierarchy = group(topology, definition);
   }

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -4,7 +4,7 @@ import S3, { GetObjectRequest } from "aws-sdk/clients/s3";
 import { Topology } from "topojson-specification";
 import { Repository } from "typeorm";
 
-import { IStaticFile, IStaticMetadata, S3URI } from "../../../../shared/entities";
+import { UintArrays, IStaticFile, IStaticMetadata, S3URI } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { GeoUnitTopology } from "../entities/geo-unit-topology.entity";
 
@@ -82,10 +82,7 @@ export class TopologyService {
     }
   }
 
-  private async fetchStaticFiles(
-    path: S3URI,
-    files: readonly IStaticFile[]
-  ): Promise<ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>> {
+  private async fetchStaticFiles(path: S3URI, files: readonly IStaticFile[]): Promise<UintArrays> {
     const requests = files.map(fileMeta =>
       this.s3.getObject(s3Options(path, fileMeta.fileName)).promise()
     );

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -125,11 +125,26 @@ export type GeoUnitIndices = readonly number[];
 
 export type FeatureId = number;
 
-// TODO: Store feature properties instead of the indices
-export type GeoUnits = ReadonlyMap<FeatureId, GeoUnitIndices>;
+// Geounits are partitioned by level to avoid feature id collisions
+// Feature ids are used to describe internal order for geounits at a given level
+export type GeoUnitsForLevel = ReadonlyMap<FeatureId, GeoUnitIndices>;
+
+export interface GeoUnits {
+  // eslint-disable-next-line
+  [geoLevelId: string]: GeoUnitsForLevel;
+}
 
 export type CompactnessScore = number | null | "non-contiguous";
 
 export type DistrictId = number;
 
 export type LockedDistricts = ReadonlySet<DistrictId>;
+
+export interface DemographicCounts {
+  // key is demographic group (eg. population, white, black, etc)
+  // value is the number of people in that group
+  [id: string]: number; // eslint-disable-line
+}
+
+export type UintArray = Uint8Array | Uint16Array | Uint32Array;
+export type UintArrays = ReadonlyArray<UintArray>;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -1,19 +1,9 @@
-import {
-  DistrictsDefinition,
-  MutableGeoUnitCollection,
-  GeoUnits,
-  GeoUnitIndices,
-  GeoUnitHierarchy,
-  IStaticMetadata,
-  NestedArray
-} from "../shared/entities";
-
-type ArrayBuffer = Uint8Array | Uint16Array | Uint32Array;
+import { UintArray, DemographicCounts, IStaticMetadata } from "../shared/entities";
 
 // Helper for finding all indices in an array buffer matching a value.
 // Note: mutation is used, because the union type of array buffers proved
 // too difficult to line up types for reduce or map/filter.
-export function getAllIndices(arrayBuf: ArrayBuffer, vals: ReadonlySet<number>): readonly number[] {
+export function getAllIndices(arrayBuf: UintArray, vals: ReadonlySet<number>): readonly number[] {
   // eslint-disable-next-line
   let indices: number[] = [];
   arrayBuf.forEach((el: number, ind: number) => {
@@ -28,7 +18,7 @@ export function getAllIndices(arrayBuf: ArrayBuffer, vals: ReadonlySet<number>):
 
 // Recursively finds all base indices matching a set of values at a specified level
 export function getAllBaseIndices(
-  descGeoLevels: readonly ArrayBuffer[],
+  descGeoLevels: readonly UintArray[],
   levelIndex: number,
   vals: readonly number[]
 ): readonly number[] {
@@ -43,16 +33,10 @@ export function getAllBaseIndices(
   );
 }
 
-interface DemographicCounts {
-  // key is demographic group (eg. population, white, black, etc)
-  // value is the number of people in that group
-  [id: string]: number; // eslint-disable-line
-}
-
 export function getDemographics(
   baseIndices: number[] | Set<number>, // eslint-disable-line
   staticMetadata: IStaticMetadata,
-  staticDemographics: readonly ArrayBuffer[]
+  staticDemographics: readonly UintArray[]
 ): DemographicCounts {
   // Aggregate demographic data for the IDs
   return staticMetadata.demographics.reduce(
@@ -72,160 +56,3 @@ export function getDemographics(
     {} as DemographicCounts
   );
 }
-
-/*
- * Return all base indices for this subset of the geounit hierarchy.
- */
-// eslint-disable-next-line
-function accumulateBaseIndices(geoUnitHierarchy: GeoUnitHierarchy): number[] {
-  // eslint-disable-next-line
-  const baseIndices: number[] = [];
-  geoUnitHierarchy.forEach(currentIndices =>
-    // eslint-disable-next-line
-    baseIndices.push(
-      ...(typeof currentIndices === "number"
-        ? [currentIndices]
-        : accumulateBaseIndices(currentIndices))
-    )
-  );
-  return baseIndices;
-}
-
-/*
- * Return all corresponding base indices (i.e. smallest geounit, eg. blocks) for a given geounit.
- */
-function baseIndicesForGeoUnit(
-  geoUnitHierarchy: GeoUnitHierarchy,
-  geoUnitIndices: GeoUnitIndices
-  // eslint-disable-next-line
-): number[] {
-  const [geoUnitIndex, ...remainingGeoUnitIndices] = geoUnitIndices;
-  const indicesForGeoLevel: number | NestedArray<number> = geoUnitHierarchy[geoUnitIndex];
-  // eslint-disable-next-line
-  if (remainingGeoUnitIndices.length) {
-    // Need to recurse to find the geounit in question in the hierarchy
-    return baseIndicesForGeoUnit(indicesForGeoLevel as GeoUnitHierarchy, remainingGeoUnitIndices);
-  }
-  // We've reached the geounit we're after. Now we need to return all the base geounit ids below it
-  // eslint-disable-next-line
-  if (typeof indicesForGeoLevel === "number") {
-    // Must be working with base geounit. Wrap it in an array and return.
-    return [indicesForGeoLevel];
-  }
-  return accumulateBaseIndices(indicesForGeoLevel);
-}
-
-// Aggregate all demographics that are included in the selection
-export function getTotalSelectedDemographics(
-  staticMetadata: IStaticMetadata,
-  geoUnitHierarchy: GeoUnitHierarchy,
-  staticDemographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
-  selectedGeounits: GeoUnits
-): DemographicCounts {
-  // Build up set of blocks ids corresponding to selected geounits
-  // eslint-disable-next-line
-  const selectedBaseIndices: Set<number> = new Set();
-  selectedGeounits.forEach(geoUnitIndices =>
-    baseIndicesForGeoUnit(geoUnitHierarchy, geoUnitIndices).forEach(index =>
-      // eslint-disable-next-line
-      selectedBaseIndices.add(index)
-    )
-  );
-  // Aggregate all counts for selected blocks
-  return getDemographics(selectedBaseIndices, staticMetadata, staticDemographics);
-}
-
-/*
- * Assign nested geounit to district.
- *
- * This can require the creation of intermediate levels using the current
- * district id as we recurse more deeply.
- */
-function assignNestedGeounit(
-  currentDistrictsDefinition: MutableGeoUnitCollection,
-  currentGeounitData: readonly number[],
-  currentGeoUnitHierarchy: GeoUnitHierarchy,
-  districtId: number
-): MutableGeoUnitCollection {
-  const [currentLevelGeounitId, ...remainingLevelsGeounitIds] = currentGeounitData;
-  // Update districts definition using existing values or explode out district id using hierarchy
-  // eslint-disable-next-line
-  let newDefinition: MutableGeoUnitCollection =
-    typeof currentDistrictsDefinition === "number"
-      ? // Auto-fill district ids using current value based on number of geounits at this level
-        new Array(currentGeoUnitHierarchy.length).fill(currentDistrictsDefinition)
-      : // Copy existing district ids at this level
-        currentDistrictsDefinition;
-  /* eslint-disable */
-  if (remainingLevelsGeounitIds.length) {
-    // We need to go deeper...
-    newDefinition[currentLevelGeounitId] = assignNestedGeounit(
-      newDefinition[currentLevelGeounitId] as MutableGeoUnitCollection,
-      currentGeounitData.slice(1),
-      currentGeoUnitHierarchy[currentLevelGeounitId] as readonly number[],
-      districtId
-    );
-  } else {
-    // End of the line. Update value with new district id
-    newDefinition[currentLevelGeounitId] = districtId;
-    if (newDefinition.every(value => value === districtId)) {
-      // Update district definition for this level to be just the district id
-      // eg. instead of [3, 3, 3, 3, ...] for every geounit at this level, just 3
-      newDefinition = districtId;
-    }
-  }
-  /* eslint-enable */
-  return newDefinition;
-}
-
-/*
- * Return new districts definition after assigning the selected geounits to the current district
- */
-export function assignGeounitsToDistrict(
-  districtsDefinition: DistrictsDefinition,
-  geoUnitHierarchy: GeoUnitHierarchy,
-  geounitIndices: readonly GeoUnitIndices[],
-  districtId: number
-): DistrictsDefinition {
-  return geounitIndices.reduce((newDistrictsDefinition, geounitData) => {
-    const initialGeounitId = geounitData[0];
-    // eslint-disable-next-line
-    newDistrictsDefinition[initialGeounitId] =
-      geounitData.length === 1
-        ? // Assign entire county
-          districtId
-        : // Need to assign nested geounit
-          assignNestedGeounit(
-            newDistrictsDefinition[initialGeounitId],
-            geounitData.slice(1),
-            geoUnitHierarchy[initialGeounitId] as NestedArray<number>,
-            districtId
-          );
-    return newDistrictsDefinition;
-  }, districtsDefinition);
-}
-
-/*
- * Helper function to get exhaustiveness checking.
- *
- * See: https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
- */
-export function assertNever(x: never): never {
-  // eslint-disable-next-line
-  throw new Error(`Unexpected: ${x}`);
-}
-
-export const geoLevelLabel = (id: string): string => {
-  switch (id) {
-    case "block":
-      return "Blocks";
-    case "tract":
-      return "Tracts";
-    case "blockgroup":
-      return "Blockgroups";
-    case "county":
-      return "Counties";
-    default:
-      return id;
-  }
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9112,10 +9112,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
## Overview

Fix feature id conflict and avoid fitting map when splitting up a geounit

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![db_no_feature_id_conflict](https://user-images.githubusercontent.com/2926237/91456031-ca764e00-e850-11ea-92b0-591f4c2d05c0.gif)
![db_no_map_fit_bounds](https://user-images.githubusercontent.com/2926237/91456033-ca764e00-e850-11ea-8057-ec43a474cb82.gif)

### Notes
Includes moving frontend-only functions out of shared functions (see 4b6a55a) and upgrading prettier to support new operators used in the PR (namely optional chaining `?.`; see 5a0e4d1). FWIW I upgraded Prettier to the newest version (2.1+) and it reformatted tons of files so I decided to just upgrade to the latest minor release (looks like we'll have to add some configuration in the future to maintain our current formatting).

## Testing Instructions
* Go to a project using DE test data
* Select the first (northernmost) county
* Switch to tracts
* All tracts in the county should be selected _without fitting the map bounds_
* Assign all tracts to a given district
* Check that all tracts (including tract 0) were be assigned

Closes #307 
Closes #315 
