### PR TITLE
Healthcheck topology service

### DIFF
--- a/src/server/src/districts/districts.module.ts
+++ b/src/server/src/districts/districts.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+
+import { RegionConfigsModule } from "../region-configs/region-configs.module";
+import { TopologyService } from "./services/topology.service";
+
+@Module({
+  imports: [RegionConfigsModule],
+  providers: [TopologyService],
+  exports: [TopologyService]
+})
+export class DistrictsModule {}

--- a/src/server/src/healthcheck/healthcheck.controller.ts
+++ b/src/server/src/healthcheck/healthcheck.controller.ts
@@ -6,13 +6,22 @@ import {
   TypeOrmHealthIndicator
 } from "@nestjs/terminus";
 
+import TopologyLoadedIndicator from "./topology-loaded.indicator";
+
 @Controller("healthcheck")
 export class HealthcheckController {
-  constructor(private health: HealthCheckService, private readonly db: TypeOrmHealthIndicator) {}
+  constructor(
+    private health: HealthCheckService,
+    private readonly db: TypeOrmHealthIndicator,
+    private topoLoaded: TopologyLoadedIndicator
+  ) {}
 
   @Get()
   @HealthCheck()
   healthCheck(): Promise<HealthCheckResult> {
-    return this.health.check([async () => this.db.pingCheck("database")]);
+    return this.health.check([
+      async () => this.db.pingCheck("database"),
+      () => this.topoLoaded.isHealthy("topology")
+    ]);
   }
 }

--- a/src/server/src/healthcheck/healthcheck.module.ts
+++ b/src/server/src/healthcheck/healthcheck.module.ts
@@ -1,10 +1,13 @@
 import { Module } from "@nestjs/common";
 import { TerminusModule } from "@nestjs/terminus";
 
+import { DistrictsModule } from "../districts/districts.module";
 import { HealthcheckController } from "./healthcheck.controller";
+import TopologyLoadedIndicator from "./topology-loaded.indicator";
 
 @Module({
   controllers: [HealthcheckController],
-  imports: [TerminusModule]
+  imports: [TerminusModule, DistrictsModule],
+  providers: [TopologyLoadedIndicator]
 })
 export class HealthCheckModule {}

--- a/src/server/src/healthcheck/topology-loaded.indicator.ts
+++ b/src/server/src/healthcheck/topology-loaded.indicator.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from "@nestjs/terminus";
+
+import { TopologyService } from "../districts/services/topology.service";
+
+@Injectable()
+export default class TopologyLoadedIndicator extends HealthIndicator {
+  constructor(public topologyService: TopologyService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const layers = this.topologyService.layers();
+    const layerEntries = (await Promise.all(
+      Object.entries(layers).map(([layerId, topology]) => {
+        return new Promise((resolve, reject) => {
+          // Promise.race should return the first already resolved promise
+          // immediately when provided at least one, so this shouldn't block
+          void Promise.race([topology, Promise.resolve(undefined)]).then(topology => {
+            resolve([layerId, topology !== undefined]);
+          });
+        });
+      })
+    )) as [string, boolean][];
+    const layerStatus = Object.fromEntries(layerEntries);
+    const isHealthy = Object.values(layerStatus).every(status => status);
+    const result = this.getStatus(key, isHealthy, layerStatus);
+
+    if (isHealthy) {
+      return result;
+    }
+    throw new HealthCheckError("Topology not fully loaded", result);
+  }
+}

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -1,16 +1,16 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
-import { TopologyService } from "../districts/services/topology.service";
-import { RegionConfig } from "../region-configs/entities/region-config.entity";
+
+import { DistrictsModule } from "../districts/districts.module";
+import { RegionConfigsModule } from "../region-configs/region-configs.module";
 import { ProjectsController } from "./controllers/projects.controller";
 import { Project } from "./entities/project.entity";
 import { ProjectsService } from "./services/projects.service";
-import { RegionConfigsService } from "../region-configs/services/region-configs.service";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project]), TypeOrmModule.forFeature([RegionConfig])],
+  imports: [TypeOrmModule.forFeature([Project]), DistrictsModule, RegionConfigsModule],
   controllers: [ProjectsController],
-  providers: [ProjectsService, RegionConfigsService, TopologyService],
+  providers: [ProjectsService],
   exports: [ProjectsService]
 })
 export class ProjectsModule {}

--- a/src/server/src/region-configs/region-configs.module.ts
+++ b/src/server/src/region-configs/region-configs.module.ts
@@ -8,6 +8,6 @@ import { RegionConfigsService } from "./services/region-configs.service";
   imports: [TypeOrmModule.forFeature([RegionConfig])],
   controllers: [RegionConfigsController],
   providers: [RegionConfigsService],
-  exports: [RegionConfigsService]
+  exports: [RegionConfigsService, TypeOrmModule]
 })
 export class RegionConfigsModule {}


### PR DESCRIPTION
## Overview

Adds an indicator to the healthcheck for whether all the layers in the topology service have loaded

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Still loading:
![Screen Shot 2020-08-27 at 16 10 04](https://user-images.githubusercontent.com/4432106/91492559-df200980-e883-11ea-8ff9-212c7722bf75.png)

Fully loaded:
![Screen Shot 2020-08-27 at 16 09 25](https://user-images.githubusercontent.com/4432106/91492561-dfb8a000-e883-11ea-812b-c7ab59e5cf1b.png)


### Notes

The level of detail provided here may be too much, especially as we ramp up the number of states, but I thought it might prove helpful to err on the side of being too detailed for now given that we plan to launch with a small number.

## Testing Instructions

- http://localhost:3005/healthcheck should return a 503 status code after starting the service while it is still downloading and processing TopoJSON
- http://localhost:3005/healthcheck should start to return `true` for individual layers as they finish downloading
- http://localhost:3005/healthcheck should return a 200 status code once all layers have finished downloading

Closes #254 
