### PR TITLE
Improve UX for zooming with restricted geolevels

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -106,7 +106,10 @@ const GeoLevelButton = ({
     ((isBaseGeoLevelSelected && !isCurrentLevelBaseGeoLevel) ||
       // non-block level selected, so disable block level
       (!isBaseGeoLevelSelected && isCurrentLevelBaseGeoLevel));
-  const isButtonDisabled = isGeoLevelHidden || areChangesPending;
+  // Always show the currently selected geolevel, even if it would otherwise be hidden
+  const isCurrentLevelSelected = index === geoLevelIndex;
+  const isButtonDisabled = !isCurrentLevelSelected && (isGeoLevelHidden || areChangesPending);
+
   return (
     <Box sx={{ display: "inline-block", position: "relative" }} className="button-wrapper">
       <Tooltip

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -35,6 +35,7 @@ import {
   onlyUnlockedGeoUnits
 } from "./index";
 import DefaultSelectionTool from "./DefaultSelectionTool";
+import MapMessage from "./MapMessage";
 import MapTooltip from "./MapTooltip";
 import RectangleSelectionTool from "./RectangleSelectionTool";
 import store from "../../store";
@@ -230,26 +231,6 @@ const DistrictsMap = ({
       );
   }, [map, project, lockedDistricts]);
 
-  useEffect(() => {
-    // eslint-disable-next-line
-    if (map) {
-      // Restrict zoom levels as per geolevel hierarchy if features are selected.
-      // Without this, zooming too far out before approving/cancelling a
-      // selection could make the user's selection disappear since not all
-      // layers are shown at each zoom level.
-      const restrictZoom = () => {
-        map.setMinZoom(
-          selectedGeounits[selectedGeolevel.id]?.size > 0 ? selectedGeolevel.minZoom : minZoom
-        );
-      };
-      map.on("zoomstart", restrictZoom);
-
-      return () => {
-        map.off("zoomstart", restrictZoom);
-      };
-    }
-  }, [map, selectedGeolevel, staticMetadata, selectedGeounits, minZoom]);
-
   // Update layer visibility when geolevel is selected
   useEffect(() => {
     // eslint-disable-next-line
@@ -404,6 +385,7 @@ const DistrictsMap = ({
   return (
     <Box ref={mapRef} sx={{ width: "100%", height: "100%", position: "relative" }}>
       <MapTooltip map={map || undefined} />
+      <MapMessage />
     </Box>
   );
 };

--- a/src/client/components/map/MapMessage.tsx
+++ b/src/client/components/map/MapMessage.tsx
@@ -1,0 +1,64 @@
+/** @jsx jsx */
+import { connect } from "react-redux";
+import { Box, jsx, ThemeUIStyleObject } from "theme-ui";
+import { State } from "../../reducers";
+import { geoLevelLabel } from "../../functions";
+import { Resource } from "../../resource";
+import { IStaticMetadata } from "../../../shared/entities";
+
+const style: ThemeUIStyleObject = {
+  message: {
+    position: "absolute",
+    margin: "30px",
+    backgroundColor: "white",
+    alignItems: "center",
+    px: 2,
+    py: 1,
+    borderBottom: "1px solid",
+    borderColor: "gray.2",
+    boxShadow: "small",
+    fontSize: 2,
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    zIndex: 1
+  }
+};
+
+const MapMessage = ({
+  geoLevelIndex,
+  geoLevelVisibility,
+  staticMetadataResource
+}: {
+  readonly geoLevelIndex: number;
+  readonly geoLevelVisibility: readonly boolean[];
+  readonly staticMetadataResource: Resource<IStaticMetadata>;
+}) => {
+  const staticMetadata =
+    "resource" in staticMetadataResource ? staticMetadataResource.resource : undefined;
+  const invertedGeoLevelIndex = staticMetadata
+    ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
+    : undefined;
+  const geoLevelId =
+    staticMetadata && invertedGeoLevelIndex !== undefined
+      ? staticMetadata.geoLevelHierarchy[invertedGeoLevelIndex].id
+      : undefined;
+  const levelLabel = geoLevelLabel(geoLevelId || "").toLocaleLowerCase();
+
+  return geoLevelVisibility[geoLevelIndex] ? null : (
+    <Box sx={style.message}>
+      <span>
+        <strong>+</strong> Zoom in to work with {levelLabel}
+      </span>
+    </Box>
+  );
+};
+
+function mapStateToProps(state: State) {
+  return {
+    geoLevelIndex: state.districtDrawing.geoLevelIndex,
+    geoLevelVisibility: state.districtDrawing.geoLevelVisibility,
+    staticMetadataResource: state.projectData.staticMetadata
+  };
+}
+
+export default connect(mapStateToProps)(MapMessage);


### PR DESCRIPTION

## Overview

The following criteria have been implemented in order to address some user friction around working with zoom level restricted geolevels:
  * When a user selects a restricted geolevel and zooms out past the min-zoom, show
    an explanatory message on the map
  * Also when this happens, the blocks geolevel button is still
    active and indicates blocks are still selected (rather than being grayed out)
  * When zoomed out, if a user selects a non-restricted geolevel the restricted
    geolevel button is deactivated
  * If a user has a restricted geounit selected, the user can zoom out past the
    min-zoom (rather than be limited to it) and the selection is maintained

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![ux-zoom-restriction-improvements](https://user-images.githubusercontent.com/6386/91517303-72286600-e8bb-11ea-9267-5e2034266567.gif)

## Testing Instructions

- Browse to a project
- Zoom in and out, selecting different geolevels, and making various selections
- Ensure the criteria described in the issue has been met

Closes #245
