### PR TITLE
Account for independent city-counties in map tooltip label

### DIFF
--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -133,14 +133,21 @@ const MapTooltip = ({
       selectedGeounits &&
       getDemographics(staticMetadata, geoUnitHierarchy, staticDemographics, selectedGeounits);
 
-    const featureLabel = () => (<span sx={{ textTransform: "capitalize" }}>
-      {feature && feature.properties && typeof feature.properties.name === "string" ? (
-        feature.properties.name.endsWith('city') ? feature.properties.name : `${feature.properties.name} ${geoLevelId}`
-      ) : feature ? (
-        <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
-      ) : (
-        ""
-      )}</span>);
+    const featureLabel = () => (
+      <span sx={{ textTransform: "capitalize" }}>
+        {feature && feature.properties && typeof feature.properties.name === "string" ? (
+          feature.properties.name.endsWith("city") ? (
+            feature.properties.name
+          ) : (
+            `${feature.properties.name} ${geoLevelId}`
+          )
+        ) : feature ? (
+          <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
+        ) : (
+          ""
+        )}
+      </span>
+    );
     const highlightedGeounitsForLevel = highlightedGeounits[geoLevelId];
     const heading =
       feature &&

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -133,15 +133,14 @@ const MapTooltip = ({
       selectedGeounits &&
       getDemographics(staticMetadata, geoUnitHierarchy, staticDemographics, selectedGeounits);
 
-    const featureLabel = () =>
-      feature && feature.properties && feature.properties.name ? (
-        <span sx={{ textTransform: "capitalize" }}>{`${feature.properties
-          .name as string} ${geoLevelId}`}</span>
+    const featureLabel = () => (<span sx={{ textTransform: "capitalize" }}>
+      {feature && feature.properties && typeof feature.properties.name === "string" ? (
+        feature.properties.name.endsWith('city') ? feature.properties.name : `${feature.properties.name} ${geoLevelId}`
       ) : feature ? (
         <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
       ) : (
         ""
-      );
+      )}</span>);
     const highlightedGeounitsForLevel = highlightedGeounits[geoLevelId];
     const heading =
       feature &&


### PR DESCRIPTION
## Overview

We don't want to add "county" after the feature name for city-counties

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/91595712-fae1e900-e931-11ea-891d-097c0e3791b3.png)


## Testing Instructions

- Hovering over city-counties on a VA project should omit the "County" in the label

Closes #281 