### PR TITLE
Remove confirm password fields

### DIFF
--- a/src/client/screens/RegistrationScreen.tsx
+++ b/src/client/screens/RegistrationScreen.tsx
@@ -11,27 +11,20 @@ import { InputField, PasswordField } from "../components/Field";
 import FormError from "../components/FormError";
 import { WriteResource } from "../resource";
 
-const isFormInvalid = (form: RegistrationForm): boolean =>
-  Object.values(form).some(value => value.trim() === "") || form.password !== form.confirmPassword;
-
-interface RegistrationForm extends Register {
-  readonly confirmPassword: string;
-}
+const isFormInvalid = (form: Register): boolean =>
+  Object.values(form).some(value => value.trim() === "");
 
 const RegistrationScreen = () => {
-  const [registrationResource, setRegistrationResource] = useState<
-    WriteResource<RegistrationForm, void>
-  >({
+  const [registrationResource, setRegistrationResource] = useState<WriteResource<Register, void>>({
     data: {
       email: "",
       password: "",
-      confirmPassword: "",
       name: ""
     }
   });
   const { data } = registrationResource;
 
-  const setForm = (field: keyof RegistrationForm) => (e: React.ChangeEvent<HTMLInputElement>) =>
+  const setForm = (field: keyof Register) => (e: React.ChangeEvent<HTMLInputElement>) =>
     setRegistrationResource({
       data: { ...data, [field]: e.currentTarget.value }
     });
@@ -91,14 +84,6 @@ const RegistrationScreen = () => {
                   label="Password"
                   resource={registrationResource}
                   inputProps={{ onChange: setForm("password") }}
-                />
-              </Box>
-              <Box sx={{ mb: 4 }}>
-                <InputField
-                  field="confirmPassword"
-                  label="Confirm password"
-                  resource={registrationResource}
-                  inputProps={{ onChange: setForm("confirmPassword"), type: "password" }}
                 />
               </Box>
               <Button

--- a/src/client/screens/ResetPasswordScreen.tsx
+++ b/src/client/screens/ResetPasswordScreen.tsx
@@ -8,17 +8,16 @@ import { ReactComponent as Logo } from "../media/logos/logo.svg";
 import { showPasswordResetNotice } from "../actions/auth";
 import { resetPassword } from "../api";
 import CenteredContent from "../components/CenteredContent";
-import { InputField, PasswordField } from "../components/Field";
+import { PasswordField } from "../components/Field";
 import FormError from "../components/FormError";
 import { WriteResource } from "../resource";
 import store from "../store";
 
 const isFormInvalid = (form: ResetPasswordForm): boolean =>
-  Object.values(form).some(value => value.trim() === "") || form.password !== form.confirmPassword;
+  Object.values(form).some(value => value.trim() === "");
 
 interface ResetPasswordForm {
   readonly password: string;
-  readonly confirmPassword: string;
 }
 
 interface ResetPasswordScreenParams {
@@ -29,8 +28,7 @@ const ResetPasswordScreen = () => {
   const { token } = useParams<ResetPasswordScreenParams>();
   const [passwordResource, setPasswordResource] = useState<WriteResource<ResetPasswordForm, void>>({
     data: {
-      password: "",
-      confirmPassword: ""
+      password: ""
     }
   });
   const { data } = passwordResource;
@@ -77,21 +75,6 @@ const ResetPasswordScreen = () => {
                 onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                   setPasswordResource({
                     data: { ...data, password: e.currentTarget.value }
-                  })
-              }}
-            />
-          </Box>
-          <Box sx={{ mb: 4 }}>
-            <InputField
-              field="confirmPassword"
-              label="Confirm password"
-              resource={passwordResource}
-              inputProps={{
-                required: true,
-                type: "password",
-                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                  setPasswordResource({
-                    data: { ...data, confirmPassword: e.currentTarget.value }
                   })
               }}
             />


### PR DESCRIPTION
## Overview

Removes the confirm password fields from registration and password reset screens, as per issue #312 

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_register(Moto G4)](https://user-images.githubusercontent.com/4432106/91608689-063e1000-e944-11ea-9ed8-2df64f3d3afa.png)

## Testing Instructions

- `scripts/server`

Closes #312 