### PR TITLE
Migrate DNS records to districtbuilder.org hosted zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend Jenkins pipeline to support production releases [#325](https://github.com/PublicMapping/districtbuilder/pull/325)
 - Add support for Rollbar [#338](https://github.com/PublicMapping/districtbuilder/pull/338)
 - Provide math for scaling task memory with additional states [#309](https://github.com/PublicMapping/districtbuilder/pull/309)
+
+### Changed
+- Migrate DNS records to districtbuilder.org hosted zones [#360](https://github.com/PublicMapping/districtbuilder/pull/360)

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ While `server` is running, the [Create React App](https://github.com/facebook/cr
 If you want to develop the `client` locally against a `server` running in the AWS staging environment, you can configure a local proxy using the `BASE_URL` environment variable:
 
 ```#bash
-BASE_URL=https://staging.districtbuilder.azavea.com docker-compose up client
+BASE_URL=https://staging.districtbuilder.org docker-compose up client
 ```
 
-This will proxy local all requests directed at `/api` to `https://staging.districtbuilder.azavea.com`.
+This will proxy local all requests directed at `/api` to `https://staging.districtbuilder.org`.
 
 ### Development Data
 
 To have data to work with, you'll need to do a two step process:
 
-1. Process the GeoJSON for your state/region (this outputs all the static files DistrictBuilder needs to work in a local directory) 
+1. Process the GeoJSON for your state/region (this outputs all the static files DistrictBuilder needs to work in a local directory)
 1. Publish the resulting files (upload to S3 for use by the app)
 
 To process PA data, first copy the GeoJSON file into the `src/manage/data` directory, create an output directory (eg. `src/manage/data/output-pa`), and then run this command:

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -122,7 +122,7 @@ resource "aws_ecs_task_definition" "app" {
     postgres_password = var.rds_database_password
     postgres_db       = var.rds_database_name
 
-    default_from_email   = var.default_from_email
+    default_from_email   = "no-reply@${var.r53_public_hosted_zone}"
     jwt_secret           = var.jwt_secret
     jwt_expiration_in_ms = var.jwt_expiration_in_ms
     client_url           = var.client_url

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -17,7 +17,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   comment         = "${var.project} (${var.environment})"
 
   price_class = var.cloudfront_price_class
-  aliases     = [var.r53_public_hosted_zone]
+  aliases     = ["app.${var.r53_public_hosted_zone}"]
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -50,9 +50,9 @@ resource "aws_route53_record" "origin" {
   }
 }
 
-resource "aws_route53_record" "www" {
+resource "aws_route53_record" "app" {
   zone_id = aws_route53_zone.external.zone_id
-  name    = var.r53_public_hosted_zone
+  name    = "app.${var.r53_public_hosted_zone}"
   type    = "A"
 
   alias {
@@ -62,9 +62,9 @@ resource "aws_route53_record" "www" {
   }
 }
 
-resource "aws_route53_record" "www_ipv6" {
+resource "aws_route53_record" "app_ipv6" {
   zone_id = aws_route53_zone.external.zone_id
-  name    = var.r53_public_hosted_zone
+  name    = "app.${var.r53_public_hosted_zone}"
   type    = "AAAA"
 
   alias {

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "scoped_email_sending" {
       test     = "StringEquals"
       variable = "ses:FromAddress"
 
-      values = [var.default_from_email]
+      values = ["no-reply@${var.r53_public_hosted_zone}"]
     }
   }
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -266,10 +266,6 @@ variable "fargate_app_cli_memory" {
   type = number
 }
 
-variable "default_from_email" {
-  type = string
-}
-
 variable "jwt_secret" {
   type = string
 }

--- a/src/server/src/common/constants.ts
+++ b/src/server/src/common/constants.ts
@@ -3,4 +3,4 @@ export const DEBUG = ENVIRONMENT === "Development";
 export const BCRYPT_SALT_ROUNDS = 10;
 export const EMAIL_VERIFICATION_TOKEN_LENGTH = 20;
 export const DEFAULT_FROM_EMAIL =
-  process.env.DEFAULT_FROM_EMAIL || "no-reply@staging.districtbuilder.azavea.com";
+  process.env.DEFAULT_FROM_EMAIL || "no-reply@staging.districtbuilder.org";


### PR DESCRIPTION
## Overview

These changes support us migrating DNS records from GoDaddy to AWS Route 53, and using `districtbuilder.org` DNS records for the application. The application will now be hosted at `app.staging.districtbuilder.org` and `app.districtbuilder.org`.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

Production records have not been altered yet. Staging NS records have been added to GoDaddy for testing.

## Testing Instructions

- Verify that the staging application is functioning at https://app.staging.districtbuilder.org/
- Verify that all `districtbuilder.org` records have been copied from GoDaddy to the `districtbuilder.org` domain in Route 53.

Connects #326 
