### PR TITLE
Add Google Tag Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check-format": "prettier --check 'src/{client,shared}/**/*.{ts,tsx,json,css}'"
   },
   "dependencies": {
+    "@redux-beacon/google-tag-manager": "1.0.1",
     "@tippyjs/react": "^4.1.0",
     "@types/jwt-decode": "2.2.1",
     "axios": "0.19.0",
@@ -33,6 +34,7 @@
     "react-scripts": "3.2.0",
     "react-toastify": "^6.0.8",
     "redux": "4.0.4",
+    "redux-beacon": "2.1.0",
     "redux-loop": "5.0.1",
     "theme-ui": "0.4.0-rc.1",
     "ts.data.json": "0.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -12,8 +12,19 @@
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>DistrictBuilder</title>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NHQ8ST6');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHQ8ST6"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/src/client/GTM.ts
+++ b/src/client/GTM.ts
@@ -1,0 +1,30 @@
+import GoogleTagManager from "@redux-beacon/google-tag-manager";
+import { createMiddleware, EventsMap, EventDefinition } from "redux-beacon";
+import { saveDistrictsDefinition } from "./actions/districtDrawing";
+import { projectsFetch } from "./actions/projects";
+import { projectFetch } from "./actions/projectData";
+import { regionConfigsFetch } from "./actions/regionConfig";
+import { getType } from "typesafe-actions";
+
+// In order to track additional actions, all you need to do is
+// add them to this list and they will automatically be tracked
+const trackingActionTypes = [
+  projectFetch, // user loaded a project
+  projectsFetch, // user loaded the home page
+  regionConfigsFetch, // user loaded the create project screen
+  saveDistrictsDefinition // user saved a district
+];
+
+const gtm = GoogleTagManager();
+
+const trackingEvent: EventDefinition = action => ({
+  hitType: action.type,
+  payload: action.payload
+});
+
+const eventsMap: EventsMap = trackingActionTypes.reduce(
+  (acc, actionType) => ({ ...acc, [getType(actionType)]: trackingEvent }),
+  {}
+);
+
+export default createMiddleware(eventsMap, gtm);

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -1,5 +1,6 @@
-import { compose, createStore } from "redux";
+import { compose, createStore, applyMiddleware } from "redux";
 import { install, StoreCreator } from "redux-loop";
+import GTM from "./GTM";
 import rootReducer, { initialState } from "./reducers";
 
 const enhancedCreateStore = createStore as StoreCreator;
@@ -11,4 +12,8 @@ declare global {
   }
 }
 
-export default enhancedCreateStore(rootReducer, initialState, composeEnhancers(install()));
+export default enhancedCreateStore(
+  rootReducer,
+  initialState,
+  composeEnhancers(install(), applyMiddleware(GTM))
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
+"@redux-beacon/google-tag-manager@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@redux-beacon/google-tag-manager/-/google-tag-manager-1.0.1.tgz#ba3f6ee6f5495933a6fddf08e8071d30b4cf0e13"
+  integrity sha512-WZqKKviHUF30GuvOlAqfAmtfoGmLToE1hVsGGfwmzTlshQmn2peL+xPL38ukIgUvI74UCzTfVmCSFsychFIyMA==
+
 "@styled-system/background@^5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@styled-system/background/-/background-5.1.2.tgz#75c63d06b497ab372b70186c0bf608d62847a2ba"
@@ -2515,6 +2520,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-flatten@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
+  integrity sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
 
 array-flatten@^2.1.0:
   version "2.1.2"
@@ -9657,6 +9667,13 @@ redeyed@~0.4.0:
   integrity sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=
   dependencies:
     esprima "~1.0.4"
+
+redux-beacon@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/redux-beacon/-/redux-beacon-2.1.0.tgz#a88ab3c2861f10ebafa0e5e94b78ca3209b537b9"
+  integrity sha512-KMbopAM7YLnQdospn5ClG3o8c4uhYkLBDEWSmxNbvQb4MGAJJh3sbbPKoEB00qU5rTXbwKuaaqZlWdgrY1Twxw==
+  dependencies:
+    array-flatten "2.1.1"
 
 redux-loop@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Overview

Adds GTM, as well as `redux-beacon` and wired up a few basic tagging events.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![gtm](https://user-images.githubusercontent.com/6386/91613709-0d6a1b80-e94e-11ea-8172-18bb04f78f75.png)


### Notes

I went and added `redux-beacon`, because it didn't look like the vanilla GTM setup was really going to give us anything useful. I only wired up a few events for now so we'll be able to track what page a user loads and when they save a district. It will be straightforward to add more events as desired.

## Testing Instructions

- `./scripts/update`
- See the issue for where to find credentials for logging in to Google Tag Manager
- Open the `DistrictBuilder App` container
- Click the `Preview` button
- Load up the DistrictBuilder app in another tab. Enabling the `Preview` mode will give you a little window like in the screenshot above.
- Browse around the app and ensure you are seeing some events triggered (as is seen in the screenshot)
- When you're satisfied, click `Leave Preview Mode` in the GTM console

Closes #317
