### PR TITLE
Fix rectangle highlight trail and hide Pol. column

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -170,11 +170,6 @@ const ProjectSidebar = ({
                   <span>Race</span>
                 </Tooltip>
               </Styled.th>
-              <Styled.th sx={style.th}>
-                <Tooltip content="Political party">
-                  <span>Pol.</span>
-                </Tooltip>
-              </Styled.th>
               <Styled.th sx={{ ...style.th, ...style.number }}>
                 <Tooltip content="Compactness score">
                   <span>Comp.</span>

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -142,15 +142,13 @@ const RectangleSelectionTool: ISelectionTool = {
           districtsDefinition,
           lockedDistricts
         );
-        Object.entries(prevGeoUnits).forEach(([geoLevelId, geoUnitsForLevel]) => {
-          Array.from(prevGeoUnits[geoLevelId].keys())
-            .filter(
-              id => !setOfInitiallySelectedFeatures[geoLevelId].has(id) && !geoUnitsForLevel.has(id)
-            )
-            .forEach(id => {
-              map.setFeatureState(featureStateExpression(id), { selected: false });
-            });
-        });
+        Array.from(prevGeoUnits[geoLevelId].keys())
+          .filter(
+            id => !setOfInitiallySelectedFeatures[geoLevelId].has(id) && !geoUnitsForLevel.has(id)
+          )
+          .forEach(id => {
+            map.setFeatureState(featureStateExpression(id), { selected: false });
+          });
       }
     }
 


### PR DESCRIPTION
## Overview

When using the rectangle select, geounits are highlighted when they fall inside the rectangle but are not un-highlighted when the rectangle moves and they fall outside. This leaves a trail of highlighting everywhere the rectangle has been causing shapes to be highlighted that shouldn't be. This PR fixes that, and also adds another unrelated, but tiny change: removing the unused `Pol.` column in the sidebar.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![trail-highlight](https://user-images.githubusercontent.com/6386/91770183-ba42d380-ebae-11ea-825f-d125d063b83a.gif)

### Notes

The reason it wasn't working is because `geoUnitsForLevel` was being shadowed in the `forEach`, and was then essentially being compared with itself in the code within the block, so there would never be a difference. I initially just removed it from the `forEach`, but then decided to remove the iteration of geolevels completely, since this should really only be a relevant codepath for a single geolevel at a time.

## Testing Instructions

- Load up the map page
- Use the rectange tool on different geolevels, and try to reproduce the bug
- Notice there's no `Pol.` column

Closes #369 
Closes #358 