### PR TITLE
Fix sidebar flicker

### DIFF
--- a/src/client/GTM.ts
+++ b/src/client/GTM.ts
@@ -1,6 +1,6 @@
 import GoogleTagManager from "@redux-beacon/google-tag-manager";
 import { createMiddleware, EventsMap, EventDefinition } from "redux-beacon";
-import { saveDistrictsDefinition } from "./actions/districtDrawing";
+import { updateDistrictsDefinition } from "./actions/projectData";
 import { projectsFetch } from "./actions/projects";
 import { projectFetch } from "./actions/projectData";
 import { regionConfigsFetch } from "./actions/regionConfig";
@@ -12,7 +12,7 @@ const trackingActionTypes = [
   projectFetch, // user loaded a project
   projectsFetch, // user loaded the home page
   regionConfigsFetch, // user loaded the create project screen
-  saveDistrictsDefinition // user saved a district
+  updateDistrictsDefinition // user saved a district
 ];
 
 const gtm = GoogleTagManager();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -25,6 +25,4 @@ export const setGeoLevelIndex = createAction("Set geoLevel index")<number>();
 
 export const setGeoLevelVisibility = createAction("Set geolevel visibility")<readonly boolean[]>();
 
-export const saveDistrictsDefinition = createAction("Save districts definition")();
-
 export const toggleDistrictLocked = createAction("Toggle district locked")<DistrictId>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -1,15 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { FeatureCollection, MultiPolygon } from "geojson";
-import {
-  UintArrays,
-  DistrictProperties,
-  GeoUnitHierarchy,
-  GeoUnits,
-  IProject,
-  IStaticMetadata,
-  ProjectId,
-  S3URI
-} from "../../shared/entities";
+import { GeoUnits, ProjectId } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 
 export const projectFetch = createAction("Project fetch")<ProjectId>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -1,5 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { GeoUnits, ProjectId } from "../../shared/entities";
+import { ProjectId } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 
 export const projectFetch = createAction("Project fetch")<ProjectId>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -7,43 +7,21 @@ import {
   GeoUnits,
   IProject,
   IStaticMetadata,
-  ProjectId
+  ProjectId,
+  S3URI
 } from "../../shared/entities";
+import { DynamicProjectData, StaticProjectData } from "../types";
 
 export const projectDataFetch = createAction("Project data fetch")<ProjectId>();
-
-export const projectFetch = createAction("Project fetch")<ProjectId>();
-export const projectFetchGeoJson = createAction("Project fetch geojson")<ProjectId>();
-export const projectFetchSuccess = createAction("Project fetch success")<IProject>();
-export const projectFetchFailure = createAction("Project fetch failure")<string>();
-export const projectFetchGeoJsonSuccess = createAction("Project fetch GeoJSON success")<
-  FeatureCollection<MultiPolygon, DistrictProperties>
+export const projectDataFetchSuccess = createAction("Project data fetch success")<
+  DynamicProjectData
 >();
-export const projectFetchGeoJsonFailure = createAction("Project fetch GeoJSON failure")<string>();
+export const projectDataFetchFailure = createAction("Project data fetch failure")<string>();
 
-export const staticMetadataFetchSuccess = createAction("Static metadata fetch success")<
-  IStaticMetadata
+export const staticDataFetchSuccess = createAction("Static data fetch success")<
+  StaticProjectData
 >();
-export const staticMetadataFetchFailure = createAction("Static metadata fetch failure")<string>();
-
-export const staticGeoLevelsFetchSuccess = createAction("Static geoLevels fetch success")<
-  UintArrays
->();
-export const staticGeoLevelsFetchFailure = createAction("Static geoLevels fetch failure")<string>();
-
-export const staticDemographicsFetchSuccess = createAction("Static demographics fetch success")<
-  ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>
->();
-export const staticDemographicsFetchFailure = createAction("Static demographics fetch failure")<
-  string
->();
-
-export const staticGeounitHierarchyFetchSuccess = createAction(
-  "Static geounit hierarchy fetch success"
-)<GeoUnitHierarchy>();
-export const staticGeounitHierarchyFetchFailure = createAction(
-  "Static geounit hierarchy fetch failure"
-)<string>();
+export const staticDataFetchFailure = createAction("Static data fetch failure")<string>();
 
 export const updateDistrictsDefinition = createAction("Update districts definition")<{
   readonly selectedGeounits: GeoUnits;
@@ -51,7 +29,7 @@ export const updateDistrictsDefinition = createAction("Update districts definiti
 }>();
 
 export const updateDistrictsDefinitionSuccess = createAction("Update districts definition success")<
-  IProject
+  DynamicProjectData
 >();
 export const updateDistrictsDefinitionFailure = createAction("Update districts definition failure")<
   string

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -12,6 +12,10 @@ import {
 } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 
+export const projectFetch = createAction("Project fetch")<ProjectId>();
+export const projectFetchSuccess = createAction("Project fetch success")<DynamicProjectData>();
+export const projectFetchFailure = createAction("Project fetch failure")<string>();
+
 export const projectDataFetch = createAction("Project data fetch")<ProjectId>();
 export const projectDataFetchSuccess = createAction("Project data fetch success")<
   DynamicProjectData

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -17,10 +17,7 @@ export const staticDataFetchSuccess = createAction("Static data fetch success")<
 >();
 export const staticDataFetchFailure = createAction("Static data fetch failure")<string>();
 
-export const updateDistrictsDefinition = createAction("Update districts definition")<{
-  readonly selectedGeounits: GeoUnits;
-  readonly selectedDistrictId: number;
-}>();
+export const updateDistrictsDefinition = createAction("Update districts definition")();
 
 export const updateDistrictsDefinitionSuccess = createAction("Update districts definition success")<
   DynamicProjectData

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -112,7 +112,7 @@ export async function createProject({
   });
 }
 
-export async function fetchProject(id: ProjectId): Promise<readonly IProject[]> {
+async function fetchProject(id: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
       .get(`/api/projects/${id}`)
@@ -121,7 +121,7 @@ export async function fetchProject(id: ProjectId): Promise<readonly IProject[]> 
   });
 }
 
-export async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJSON> {
+async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJSON> {
   return new Promise((resolve, reject) => {
     apiAxios
       .get(`/api/projects/${id}/export/geojson`)
@@ -139,6 +139,13 @@ export async function fetchProjects(): Promise<readonly IProject[]> {
   });
 }
 
+export async function fetchProjectData(id: ProjectId): Promise<DynamicProjectData> {
+  return Promise.all([fetchProject(id), fetchProjectGeoJson(id)]).then(([project, geojson]) => ({
+    project,
+    geojson
+  }));
+}
+
 export async function fetchRegionConfigs(): Promise<IRegionConfig> {
   return new Promise((resolve, reject) => {
     apiAxios
@@ -148,7 +155,7 @@ export async function fetchRegionConfigs(): Promise<IRegionConfig> {
   });
 }
 
-export async function patchDistrictsDefinition(
+async function patchDistrictsDefinition(
   id: ProjectId,
   districtsDefinition: DistrictsDefinition
 ): Promise<IProject> {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -9,7 +9,7 @@ import {
   JWT,
   ProjectId
 } from "../shared/entities";
-import { DistrictsGeoJSON, DynamicProjectData, ProjectData } from "./types";
+import { DistrictsGeoJSON, DynamicProjectData } from "./types";
 import { getJWT, setJWT } from "./jwt";
 
 const apiAxios = axios.create();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -155,7 +155,7 @@ export async function fetchRegionConfigs(): Promise<IRegionConfig> {
   });
 }
 
-async function patchDistrictsDefinition(
+export async function patchDistrictsDefinition(
   id: ProjectId,
   districtsDefinition: DistrictsDefinition
 ): Promise<IProject> {
@@ -165,14 +165,4 @@ async function patchDistrictsDefinition(
       .then(response => resolve(response.data))
       .catch(error => reject(error.response.data));
   });
-}
-
-export async function updateProject(
-  id: ProjectId,
-  districtsDefinition: DistrictsDefinition
-): Promise<DynamicProjectData> {
-  return Promise.all([
-    patchDistrictsDefinition(id, districtsDefinition),
-    fetchProjectGeoJson(id)
-  ]).then(([project, geojson]) => ({ project, geojson }));
 }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosResponse } from "axios";
-import { FeatureCollection, MultiPolygon } from "geojson";
 
 import {
   CreateProjectData,
@@ -10,6 +9,7 @@ import {
   JWT,
   ProjectId
 } from "../shared/entities";
+import { DistrictsGeoJSON, DynamicProjectData, ProjectData } from "./types";
 import { getJWT, setJWT } from "./jwt";
 
 const apiAxios = axios.create();
@@ -121,9 +121,7 @@ export async function fetchProject(id: ProjectId): Promise<readonly IProject[]> 
   });
 }
 
-export async function fetchProjectGeoJson(
-  id: ProjectId
-): Promise<FeatureCollection<MultiPolygon, { readonly [name: string]: number }>> {
+export async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJSON> {
   return new Promise((resolve, reject) => {
     apiAxios
       .get(`/api/projects/${id}/export/geojson`)
@@ -160,4 +158,14 @@ export async function patchDistrictsDefinition(
       .then(response => resolve(response.data))
       .catch(error => reject(error.response.data));
   });
+}
+
+export async function updateProject(
+  id: ProjectId,
+  districtsDefinition: DistrictsDefinition
+): Promise<DynamicProjectData> {
+  return Promise.all([
+    patchDistrictsDefinition(id, districtsDefinition),
+    fetchProjectGeoJson(id)
+  ]).then(([project, geojson]) => ({ project, geojson }));
 }

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -15,6 +15,7 @@ import {
   IStaticMetadata,
   LockedDistricts
 } from "../../shared/entities";
+import { DistrictGeoJSON, DistrictsGeoJSON } from "../types";
 import {
   allGeoUnitIndices,
   areAnyGeoUnitsSelected,
@@ -132,7 +133,7 @@ const ProjectSidebar = ({
   lockedDistricts
 }: {
   readonly project?: IProject;
-  readonly geojson?: FeatureCollection<MultiPolygon, DistrictProperties>;
+  readonly geojson?: DistrictsGeoJSON;
   readonly staticMetadata?: IStaticMetadata;
   readonly staticDemographics?: UintArrays;
   readonly selectedDistrictId: number;
@@ -296,7 +297,7 @@ const SidebarRow = ({
   districtId,
   isDistrictLocked
 }: {
-  readonly district: Feature<MultiPolygon, DistrictProperties>;
+  readonly district: DistrictGeoJSON;
   readonly selected: boolean;
   readonly selectedPopulationDifference: number;
   readonly demographics: { readonly [id: string]: number };
@@ -470,7 +471,7 @@ const getSavedDistrictSelectedDemographics = (
 
 const getSidebarRows = (
   project: IProject,
-  geojson: FeatureCollection<MultiPolygon, DistrictProperties>,
+  geojson: DistrictsGeoJSON,
   staticMetadata: IStaticMetadata,
   staticDemographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
   selectedDistrictId: number,

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useEffect, useRef, useState, Fragment } from "react";
+import React, { useState, Fragment } from "react";
 import { Box, Button, Flex, Heading, jsx, Spinner, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
@@ -32,9 +32,9 @@ import DemographicsTooltip from "./DemographicsTooltip";
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
 
+import { updateDistrictsDefinition } from "../actions/projectData";
 import {
   clearSelectedGeounits,
-  saveDistrictsDefinition,
   setSelectedDistrictId,
   toggleDistrictLocked
 } from "../actions/districtDrawing";
@@ -226,7 +226,7 @@ const SidebarHeader = ({
             variant="circular"
             sx={{ cursor: "pointer" }}
             onClick={() => {
-              store.dispatch(saveDistrictsDefinition());
+              store.dispatch(updateDistrictsDefinition());
             }}
           >
             <Icon name="check" />

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { Feature, FeatureCollection, MultiPolygon } from "geojson";
 import React, { useState, Fragment } from "react";
 import { Box, Button, Flex, Heading, jsx, Spinner, Styled, ThemeUIStyleObject } from "theme-ui";
 
@@ -7,7 +6,6 @@ import {
   UintArrays,
   CompactnessScore,
   DistrictsDefinition,
-  DistrictProperties,
   GeoUnitHierarchy,
   GeoUnitIndices,
   GeoUnits,
@@ -313,6 +311,7 @@ const SidebarRow = ({
       ? positiveChangeColor
       : negativeChangeColor
     : "inherit";
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   const intermediatePopulation = district.properties.population + selectedPopulationDifference;
   const intermediateDeviation = deviation + selectedPopulationDifference;
   const populationDisplay = intermediatePopulation.toLocaleString();

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -142,10 +142,7 @@ const ProjectSidebar = ({
 } & LoadingProps) => {
   return (
     <Flex sx={style.sidebar}>
-      {project && geoUnitHierarchy && (
-        <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
-      )}
-
+      <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       <Box sx={{ overflowY: "auto", flex: 1 }}>
         <Styled.table sx={{ mx: 2, mb: 2 }}>
           <thead>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -14,12 +14,12 @@ import {
 import { getDistrictColor } from "../../constants/colors";
 import {
   UintArrays,
-  DistrictProperties,
   GeoUnits,
   IProject,
   IStaticMetadata,
   LockedDistricts
 } from "../../../shared/entities";
+import { DistrictsGeoJSON } from "../../types";
 import { areAnyGeoUnitsSelected, getSelectedGeoLevel } from "../../functions";
 import { getAllIndices } from "../../../shared/functions";
 import {
@@ -42,7 +42,7 @@ import store from "../../store";
 
 interface Props {
   readonly project: IProject;
-  readonly geojson: FeatureCollection<MultiPolygon, DistrictProperties>;
+  readonly geojson: DistrictsGeoJSON;
   readonly staticMetadata: IStaticMetadata;
   readonly staticDemographics: UintArrays;
   readonly staticGeoLevels: UintArrays;

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import { FeatureCollection, MultiPolygon } from "geojson";
 import { useEffect, useRef, useState } from "react";
 import { Box, jsx } from "theme-ui";
 

--- a/src/client/components/map/MapMessage.tsx
+++ b/src/client/components/map/MapMessage.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
 import { connect } from "react-redux";
 import { Box, jsx, ThemeUIStyleObject } from "theme-ui";
+
 import { State } from "../../reducers";
 import { geoLevelLabel } from "../../functions";
-import { Resource } from "../../resource";
 import { IStaticMetadata } from "../../../shared/entities";
+import { destructureResource } from "../../functions";
 
 const style: ThemeUIStyleObject = {
   message: {
@@ -27,14 +28,12 @@ const style: ThemeUIStyleObject = {
 const MapMessage = ({
   geoLevelIndex,
   geoLevelVisibility,
-  staticMetadataResource
+  staticMetadata
 }: {
   readonly geoLevelIndex: number;
   readonly geoLevelVisibility: readonly boolean[];
-  readonly staticMetadataResource: Resource<IStaticMetadata>;
+  readonly staticMetadata?: IStaticMetadata;
 }) => {
-  const staticMetadata =
-    "resource" in staticMetadataResource ? staticMetadataResource.resource : undefined;
   const invertedGeoLevelIndex = staticMetadata
     ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
     : undefined;
@@ -55,9 +54,9 @@ const MapMessage = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: state.districtDrawing.geoLevelIndex,
-    geoLevelVisibility: state.districtDrawing.geoLevelVisibility,
-    staticMetadataResource: state.projectData.staticMetadata
+    geoLevelIndex: state.project.geoLevelIndex,
+    geoLevelVisibility: state.project.geoLevelVisibility,
+    staticMetadata: destructureResource(state.project.staticData, "staticMetadata")
   };
 }
 

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -9,6 +9,7 @@ import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 import { UintArrays, GeoUnits, GeoUnitHierarchy, IStaticMetadata } from "../../../shared/entities";
 import {
   areAnyGeoUnitsSelected,
+  destructureResource,
   geoLevelLabel,
   getTotalSelectedDemographics
 } from "../../functions";
@@ -185,11 +186,11 @@ const MapTooltip = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: state.districtDrawing.geoLevelIndex,
-    highlightedGeounits: state.districtDrawing.highlightedGeounits,
-    staticDemographics: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.staticDemographics : undefined,
-    staticMetadata: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.staticMetadata : undefined,
-    geoUnitHierarchy: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.geoUnitHierarchy : undefined,
+    geoLevelIndex: state.project.geoLevelIndex,
+    highlightedGeounits: state.project.highlightedGeounits,
+    staticDemographics: destructureResource(state.project.staticData, "staticDemographics"),
+    staticMetadata: destructureResource(state.project.staticData, "staticMetadata"),
+    geoUnitHierarchy: destructureResource(state.project.staticData, "geoUnitHierarchy")
   };
 }
 

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
-import { Resource } from "../../resource";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -43,28 +43,22 @@ const style: ThemeUIStyleObject = {
 const MapTooltip = ({
   geoLevelIndex,
   highlightedGeounits,
-  staticDemographicsResource,
-  staticMetadataResource,
-  geoUnitHierarchyResource,
+  staticDemographics,
+  staticMetadata,
+  geoUnitHierarchy,
   map
 }: {
   readonly geoLevelIndex: number;
   readonly highlightedGeounits: GeoUnits;
-  readonly staticDemographicsResource: Resource<UintArrays>;
-  readonly staticMetadataResource: Resource<IStaticMetadata>;
-  readonly geoUnitHierarchyResource: Resource<GeoUnitHierarchy>;
+  readonly staticDemographics?: UintArrays;
+  readonly staticMetadata?: IStaticMetadata;
+  readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly map?: MapboxGL.Map;
 }) => {
   const [point, setPoint] = useState({ x: 0, y: 0 });
   const [feature, setFeature] = useState<MapboxGL.MapboxGeoJSONFeature | undefined>(undefined);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  const staticMetadata =
-    "resource" in staticMetadataResource ? staticMetadataResource.resource : undefined;
-  const staticDemographics =
-    "resource" in staticDemographicsResource ? staticDemographicsResource.resource : undefined;
-  const geoUnitHierarchy =
-    "resource" in geoUnitHierarchyResource ? geoUnitHierarchyResource.resource : undefined;
   const invertedGeoLevelIndex = staticMetadata
     ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
     : undefined;
@@ -194,9 +188,9 @@ function mapStateToProps(state: State) {
   return {
     geoLevelIndex: state.districtDrawing.geoLevelIndex,
     highlightedGeounits: state.districtDrawing.highlightedGeounits,
-    staticDemographicsResource: state.projectData.staticDemographics,
-    staticMetadataResource: state.projectData.staticMetadata,
-    geoUnitHierarchyResource: state.projectData.geoUnitHierarchy
+    staticDemographics: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.staticDemographics : undefined,
+    staticMetadata: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.staticMetadata : undefined,
+    geoUnitHierarchy: "resource" in state.projectData.staticData ? state.projectData.staticData.resource.geoUnitHierarchy : undefined,
   };
 }
 

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -205,12 +205,3 @@ export function destructureResource<T extends object>(
 ): any | undefined {
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
 }
-
-export function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
-  return Object.keys(geoUnits).reduce((geoUnits, geoLevelId) => {
-    return {
-      ...geoUnits,
-      [geoLevelId]: new Map()
-    };
-  }, {});
-}

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -197,9 +197,11 @@ export function getSelectedGeoLevel(geoLevelHierarchy: GeoLevelHierarchy, geoLev
   return geoLevelHierarchy[geoLevelHierarchy.length - 1 - geoLevelIndex];
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function destructureResource<T extends object>(
   resourceT: Resource<T>,
   key: keyof T
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any | undefined {
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
 }

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,4 +1,5 @@
 import memoize from "memoizee";
+import { cloneDeep } from "lodash";
 
 import {
   DemographicCounts,
@@ -11,6 +12,7 @@ import {
   IStaticMetadata,
   NestedArray
 } from "../shared/entities";
+import { Resource } from "./resource";
 import { getDemographics as getDemographicsBase } from "../shared/functions";
 
 // TODO: merge this function with shared/functions once the ability to import
@@ -147,6 +149,7 @@ export function assignGeounitsToDistrict(
   geounitIndices: readonly GeoUnitIndices[],
   districtId: number
 ): DistrictsDefinition {
+  const districtsDefinitionCopy = cloneDeep(districtsDefinition);
   return geounitIndices.reduce((newDistrictsDefinition, geounitData) => {
     const initialGeounitId = geounitData[0];
     // eslint-disable-next-line
@@ -162,7 +165,7 @@ export function assignGeounitsToDistrict(
             districtId
           );
     return newDistrictsDefinition;
-  }, districtsDefinition);
+  }, districtsDefinitionCopy);
 }
 
 /*
@@ -192,4 +195,20 @@ export const geoLevelLabel = (id: string): string => {
 
 export function getSelectedGeoLevel(geoLevelHierarchy: GeoLevelHierarchy, geoLevelIndex: number) {
   return geoLevelHierarchy[geoLevelHierarchy.length - 1 - geoLevelIndex];
+}
+
+export function destructureResource<T extends object>(
+  resourceT: Resource<T>,
+  key: keyof T
+): any | undefined {
+  return "resource" in resourceT ? resourceT.resource[key] : undefined;
+}
+
+export function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
+  return Object.keys(geoUnits).reduce((geoUnits, geoLevelId) => {
+    return {
+      ...geoUnits,
+      [geoLevelId]: new Map()
+    };
+  }, {});
 }

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -4,14 +4,6 @@ import { getType } from "typesafe-actions";
 import { Action } from "./actions";
 import { resetState } from "./actions/root";
 import authReducer, { AuthState, initialState as initialAuthState } from "./reducers/auth";
-import districtDrawingReducer, {
-  initialState as initialDistrictDrawingState,
-  DistrictDrawingState
-} from "./reducers/districtDrawing";
-import projectDataReducer, {
-  initialState as initialProjectDataState,
-  ProjectDataState
-} from "./reducers/projectData";
 import projectsReducer, {
   initialState as initialProjectsState,
   ProjectsState
@@ -21,32 +13,30 @@ import regionConfigReducer, {
   RegionConfigState
 } from "./reducers/regionConfig";
 import userReducer, { initialState as initialUserState, UserState } from "./reducers/user";
+import projectReducer, { ProjectState, initialProjectState } from "./reducers/project";
 
 export interface State {
   readonly auth: AuthState;
   readonly user: UserState;
   readonly regionConfig: RegionConfigState;
-  readonly projectData: ProjectDataState;
   readonly projects: ProjectsState;
-  readonly districtDrawing: DistrictDrawingState;
+  readonly project: ProjectState;
 }
 
 export const initialState: State = {
   auth: initialAuthState,
   user: initialUserState,
   regionConfig: initialRegionConfigState,
-  projectData: initialProjectDataState,
   projects: initialProjectsState,
-  districtDrawing: initialDistrictDrawingState
+  project: initialProjectState
 };
 
 const allReducers = combineReducers({
   auth: authReducer,
   user: userReducer,
   regionConfig: regionConfigReducer,
-  projectData: projectDataReducer,
   projects: projectsReducer,
-  districtDrawing: districtDrawingReducer
+  project: projectReducer
 });
 
 export default (state = initialState, action: Action) => {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -18,7 +18,6 @@ import {
 import { SelectionTool } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entities";
-import { clearGeoUnits } from "../functions";
 import { ProjectState, initialProjectState } from "./project";
 
 function setGeoUnitsForLevel(
@@ -53,6 +52,15 @@ function editGeoUnits(
       )
     };
   }, {} as GeoUnits);
+}
+
+function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
+  return Object.keys(geoUnits).reduce((geoUnits, geoLevelId) => {
+    return {
+      ...geoUnits,
+      [geoLevelId]: new Map()
+    };
+  }, {});
 }
 
 export interface DistrictDrawingState {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -3,13 +3,11 @@ import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
 import {
-  SelectionTool,
   addSelectedGeounits,
   clearHighlightedGeounits,
   clearSelectedGeounits,
   editSelectedGeounits,
   removeSelectedGeounits,
-  saveDistrictsDefinition,
   setGeoLevelIndex,
   setGeoLevelVisibility,
   setHighlightedGeounits,
@@ -17,9 +15,11 @@ import {
   setSelectionTool,
   toggleDistrictLocked
 } from "../actions/districtDrawing";
-import { updateDistrictsDefinition } from "../actions/projectData";
+import { SelectionTool } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entities";
+import { clearGeoUnits } from "../functions";
+import { ProjectState, initialProjectState } from "./project";
 
 function setGeoUnitsForLevel(
   currentGeoUnits: GeoUnitsForLevel,
@@ -55,15 +55,6 @@ function editGeoUnits(
   }, {} as GeoUnits);
 }
 
-function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
-  return Object.keys(geoUnits).reduce((geoUnits, geoLevelId) => {
-    return {
-      ...geoUnits,
-      [geoLevelId]: new Map()
-    };
-  }, {});
-}
-
 export interface DistrictDrawingState {
   readonly selectedDistrictId: number;
   readonly selectedGeounits: GeoUnits;
@@ -74,7 +65,7 @@ export interface DistrictDrawingState {
   readonly lockedDistricts: LockedDistricts;
 }
 
-export const initialState: DistrictDrawingState = {
+export const initialDistrictDrawingState: DistrictDrawingState = {
   selectedDistrictId: 1,
   selectedGeounits: {},
   highlightedGeounits: {},
@@ -84,13 +75,16 @@ export const initialState: DistrictDrawingState = {
   lockedDistricts: new Set()
 };
 
-const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
-  state: DistrictDrawingState = initialState,
+const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
+  state: ProjectState = initialProjectState,
   action: Action
-): DistrictDrawingState | Loop<DistrictDrawingState, Action> => {
+): ProjectState | Loop<ProjectState, Action> => {
   switch (action.type) {
     case getType(resetProjectState):
-      return initialState;
+      return {
+        ...state,
+        ...initialDistrictDrawingState
+      };
     case getType(setSelectedDistrictId):
       return {
         ...state,
@@ -148,16 +142,6 @@ const districtDrawingReducer: LoopReducer<DistrictDrawingState, Action> = (
         ...state,
         geoLevelIndex: action.payload
       };
-    case getType(saveDistrictsDefinition):
-      return loop(
-        state,
-        Cmd.action(
-          updateDistrictsDefinition({
-            selectedGeounits: state.selectedGeounits,
-            selectedDistrictId: state.selectedDistrictId
-          })
-        )
-      );
     case getType(setGeoLevelVisibility):
       return {
         ...state,

--- a/src/client/reducers/project.ts
+++ b/src/client/reducers/project.ts
@@ -1,0 +1,15 @@
+import { reduceReducers } from "redux-loop";
+
+import districtDrawingReducer, {
+  DistrictDrawingState,
+  initialDistrictDrawingState
+} from "./districtDrawing";
+import projectDataReducer, { ProjectDataState, initialProjectDataState } from "./projectData";
+
+export const initialProjectState = { ...initialProjectDataState, ...initialDistrictDrawingState };
+
+export type ProjectState = ProjectDataState & DistrictDrawingState;
+
+const projectReducer = reduceReducers(projectDataReducer, districtDrawingReducer);
+
+export default projectReducer;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -38,6 +38,12 @@ import { fetchProject, fetchProjectGeoJson, patchDistrictsDefinition } from "../
 import { Resource } from "../resource";
 import { fetchStaticFiles, fetchStaticMetadata, fetchGeoUnitHierarchy } from "../s3";
 
+export function isProjectDataLoading(projectDataState: ProjectDataState): boolean {
+  return Object.values(projectDataState).some(
+    resource => "isPending" in resource && resource.isPending
+  );
+}
+
 export interface ProjectDataState {
   readonly project: Resource<IProject>;
   readonly staticMetadata: Resource<IStaticMetadata>;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -15,12 +15,13 @@ import {
   staticDataFetchFailure,
   staticDataFetchSuccess
 } from "../actions/projectData";
+import { clearSelectedGeounits } from "../actions/districtDrawing";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
 import { DynamicProjectData, StaticProjectData } from "../types";
 import { Resource } from "../resource";
 
-import { allGeoUnitIndices, assignGeounitsToDistrict, clearGeoUnits } from "../functions";
+import { allGeoUnitIndices, assignGeounitsToDistrict } from "../functions";
 import { fetchProjectData, patchDistrictsDefinition } from "../api";
 import { fetchAllStaticData } from "../s3";
 
@@ -64,13 +65,15 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         })
       );
     case getType(projectFetchSuccess):
-      return {
-        ...state,
-        selectedGeounits: clearGeoUnits(state.selectedGeounits),
-        projectData: {
-          resource: action.payload
-        }
-      };
+      return loop(
+        {
+          ...state,
+          projectData: {
+            resource: action.payload
+          }
+        },
+        Cmd.action(clearSelectedGeounits())
+      );
     case getType(projectFetchFailure):
       return {
         ...state,

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -1,4 +1,3 @@
-import { FeatureCollection, MultiPolygon } from "geojson";
 import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
 import { getType } from "typesafe-actions";
 
@@ -32,8 +31,8 @@ export function isProjectDataLoading(projectDataState: ProjectDataState): boolea
 }
 
 export type ProjectDataState = {
-  projectData: Resource<DynamicProjectData>;
-  staticData: Resource<StaticProjectData>;
+  readonly projectData: Resource<DynamicProjectData>;
+  readonly staticData: Resource<StaticProjectData>;
 };
 
 export const initialState = {

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -101,19 +101,16 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
             isPending: true
           }
         },
-        Cmd.list<Action>(
-          [
-            Cmd.run(fetchAllStaticData, {
-              successActionCreator: staticDataFetchSuccess,
-              failActionCreator: staticDataFetchFailure,
-              args: [action.payload.project.regionConfig.s3URI] as Parameters<
-                typeof fetchAllStaticData
-              >
-            }),
-            Cmd.action(clearSelectedGeounits())
-          ],
-          { sequence: true }
-        )
+        Cmd.list<Action>([
+          Cmd.action(clearSelectedGeounits()),
+          Cmd.run(fetchAllStaticData, {
+            successActionCreator: staticDataFetchSuccess,
+            failActionCreator: staticDataFetchFailure,
+            args: [action.payload.project.regionConfig.s3URI] as Parameters<
+              typeof fetchAllStaticData
+            >
+          })
+        ])
       );
     case getType(projectDataFetchFailure):
       return {
@@ -159,13 +156,10 @@ const projectDataReducer: LoopReducer<ProjectDataState, Action> = (
       return "resource" in state.projectData
         ? loop(
             state,
-            Cmd.list<Action>(
-              [
-                Cmd.action(projectFetch(state.projectData.resource.project.id)),
-                Cmd.action(clearSelectedGeounits())
-              ],
-              { sequence: true }
-            )
+            Cmd.list<Action>([
+              Cmd.action(clearSelectedGeounits()),
+              Cmd.action(projectFetch(state.projectData.resource.project.id))
+            ])
           )
         : state;
     case getType(updateDistrictsDefinitionFailure):

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -9,6 +9,7 @@ import {
   IStaticMetadata,
   S3URI
 } from "../shared/entities";
+import { StaticProjectData } from "./types";
 
 const s3Axios = axios.create();
 
@@ -66,4 +67,22 @@ export async function fetchStaticFiles(
       )
       .catch(error => reject(error.message));
   });
+}
+
+export async function fetchAllStaticData(path: S3URI): Promise<StaticProjectData> {
+  return fetchStaticMetadata(path)
+    .then(staticMetadata =>
+      Promise.all([
+        Promise.resolve(staticMetadata),
+        fetchGeoUnitHierarchy(path),
+        fetchStaticFiles(path, staticMetadata.geoLevels),
+        fetchStaticFiles(path, staticMetadata.demographics)
+      ])
+    )
+    .then(([staticMetadata, geoUnitHierarchy, staticGeoLevels, staticDemographics]) => ({
+      staticMetadata,
+      geoUnitHierarchy,
+      staticGeoLevels,
+      staticDemographics
+    }));
 }

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -18,11 +18,11 @@ export function s3ToHttps(path: S3URI): HttpsURI {
   return resolve(`https://${uri.host}.s3.amazonaws.com`, uri.path || "");
 }
 
-export function staticDataUri(path: S3URI, fileName: string): HttpsURI {
+function staticDataUri(path: S3URI, fileName: string): HttpsURI {
   return resolve(s3ToHttps(path), fileName);
 }
 
-export async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata> {
+async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata> {
   return new Promise((resolve, reject) => {
     s3Axios
       .get(staticDataUri(path, "static-metadata.json"))
@@ -31,7 +31,7 @@ export async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata>
   });
 }
 
-export async function fetchGeoUnitHierarchy(path: S3URI): Promise<GeoUnitHierarchy> {
+async function fetchGeoUnitHierarchy(path: S3URI): Promise<GeoUnitHierarchy> {
   return new Promise((resolve, reject) => {
     s3Axios
       .get(staticDataUri(path, "geounit-hierarchy.json"))
@@ -40,10 +40,7 @@ export async function fetchGeoUnitHierarchy(path: S3URI): Promise<GeoUnitHierarc
   });
 }
 
-export async function fetchStaticFiles(
-  path: S3URI,
-  files: readonly IStaticFile[]
-): Promise<UintArrays> {
+async function fetchStaticFiles(path: S3URI, files: readonly IStaticFile[]): Promise<UintArrays> {
   const requests = files.map(fileMeta =>
     s3Axios.get(staticDataUri(path, fileMeta.fileName), {
       responseType: "arraybuffer"

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -8,11 +8,9 @@ import { destructureResource } from "../functions";
 import { DistrictsGeoJSON } from "../types";
 import {
   GeoUnitHierarchy,
-  GeoUnits,
   IProject,
   IStaticMetadata,
   IUser,
-  LockedDistricts,
   UintArrays
 } from "../../shared/entities";
 import { projectDataFetch } from "../actions/projectData";

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -16,7 +16,7 @@ import ProjectSidebar from "../components/ProjectSidebar";
 import Toast from "../components/Toast";
 import { State } from "../reducers";
 import { DistrictDrawingState } from "../reducers/districtDrawing";
-import { ProjectDataState } from "../reducers/projectData";
+import { isProjectDataLoading, ProjectDataState } from "../reducers/projectData";
 import { Resource } from "../resource";
 import store from "../store";
 
@@ -38,9 +38,7 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
       : undefined;
   const geoUnitHierarchy =
     "resource" in projectData.geoUnitHierarchy ? projectData.geoUnitHierarchy.resource : undefined;
-  const isLoading =
-    ("isPending" in projectData.project && projectData.project.isPending) ||
-    ("isPending" in projectData.geojson && projectData.geojson.isPending);
+  const isLoading = isProjectDataLoading(projectData);
 
   const [label, setMapLabel] = useState<string | undefined>(undefined);
 

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -28,16 +28,26 @@ interface StateProps {
 
 const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
   const { projectId } = useParams();
-  const project = "resource" in projectData.project ? projectData.project.resource : undefined;
-  const geojson = "resource" in projectData.geojson ? projectData.geojson.resource : undefined;
+  const project =
+    "resource" in projectData.projectData ? projectData.projectData.resource.project : undefined;
+  const geojson =
+    "resource" in projectData.projectData ? projectData.projectData.resource.geojson : undefined;
   const staticMetadata =
-    "resource" in projectData.staticMetadata ? projectData.staticMetadata.resource : undefined;
+    "resource" in projectData.staticData
+      ? projectData.staticData.resource.staticMetadata
+      : undefined;
+  const staticGeoLevels =
+    "resource" in projectData.staticData
+      ? projectData.staticData.resource.staticGeoLevels
+      : undefined;
   const staticDemographics =
-    "resource" in projectData.staticDemographics
-      ? projectData.staticDemographics.resource
+    "resource" in projectData.staticData
+      ? projectData.staticData.resource.staticDemographics
       : undefined;
   const geoUnitHierarchy =
-    "resource" in projectData.geoUnitHierarchy ? projectData.geoUnitHierarchy.resource : undefined;
+    "resource" in projectData.staticData
+      ? projectData.staticData.resource.geoUnitHierarchy
+      : undefined;
   const isLoading = isProjectDataLoading(projectData);
 
   const [label, setMapLabel] = useState<string | undefined>(undefined);
@@ -106,17 +116,13 @@ const ProjectScreen = ({ projectData, user, districtDrawing }: StateProps) => {
             geoLevelVisibility={districtDrawing.geoLevelVisibility}
             selectedGeounits={districtDrawing.selectedGeounits}
           />
-          {"resource" in projectData.project &&
-          "resource" in projectData.staticMetadata &&
-          "resource" in projectData.staticDemographics &&
-          "resource" in projectData.staticGeoLevels &&
-          "resource" in projectData.geojson ? (
+          {project && staticMetadata && staticDemographics && staticGeoLevels && geojson ? (
             <Map
-              project={projectData.project.resource}
-              geojson={projectData.geojson.resource}
-              staticMetadata={projectData.staticMetadata.resource}
-              staticDemographics={projectData.staticDemographics.resource}
-              staticGeoLevels={projectData.staticGeoLevels.resource}
+              project={project}
+              geojson={geojson}
+              staticMetadata={staticMetadata}
+              staticDemographics={staticDemographics}
+              staticGeoLevels={staticGeoLevels}
               selectedGeounits={districtDrawing.selectedGeounits}
               selectedDistrictId={districtDrawing.selectedDistrictId}
               selectionTool={districtDrawing.selectionTool}

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -7,6 +7,7 @@ import {
   DistrictProperties
 } from "../shared/entities";
 
+export type DistrictGeoJSON = Feature<MultiPolygon, DistrictProperties>;
 export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
 
 export interface DynamicProjectData {

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -1,0 +1,24 @@
+import { FeatureCollection, MultiPolygon } from "geojson";
+import {
+  IProject,
+  IStaticMetadata,
+  UintArrays,
+  GeoUnitHierarchy,
+  DistrictProperties
+} from "../shared/entities";
+
+export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
+
+export interface DynamicProjectData {
+  readonly project: IProject;
+  readonly geojson: DistrictsGeoJSON;
+}
+
+export interface StaticProjectData {
+  readonly staticMetadata: IStaticMetadata;
+  readonly staticGeoLevels: UintArrays;
+  readonly staticDemographics: UintArrays;
+  readonly geoUnitHierarchy: GeoUnitHierarchy;
+}
+
+export type ProjectData = DynamicProjectData & StaticProjectData;


### PR DESCRIPTION
## Overview

Fix sidebar flicker + various refactors

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![db_sidebar_flicker_fix](https://user-images.githubusercontent.com/2926237/91878060-cbdab880-ec4c-11ea-95c3-54e0aae09dd1.gif)

### Notes

This PR contains a lot of refactors, some of which turned out to not be strictly necessary but seemed valuable enough to include anyway (eg. making `getSidebarRows` into a component). The most notable example of this is using `reduceReducers` to combine district drawing state with project state. Having them be separate has required some kludgy workarounds in the past (see the now defunct `saveDistrictsDefinition`) in order to share data between them. I thought at one point that doing a single state update was important to avoid flicker, but that later turned out not to be true. In any case, this is a positive change (IMO) and will give us flexibility to avoid similar kludges in the future.

This also includes a large refactor of the `projectData` reducer which was important in terms of fixing this issue and also simplifies things considerably. The key change there was to add new S3/API functions to fetch all static data (see `fetchAllStaticData`) and fetch all updated project data (see `fetchProjectData`) this simplifies the `projectData` reducer considerably and should make it easier to manage state and avoid some of the unnecessary the intermediate states which trigger re-renders of components.

The other real, important change that had to be in this PR for it to work, in addition to some reworking of project state, is to make `assignGeounitsToDistrict` _not_ mutate the `DistrictsDefinition` (this was a mistake and it made everything super confusing to make sense of since a fundamental rule of Redux is that you don't mutate state). 

Another nice small change (IMO) was the addition of `destructureResource` to grab a key from inside a resource if it exists, which allows us to avoid a lot of repeated code in component functions (the way it's used in this PR is to grab it when wrangling Redux state and just pass the component what it needs directly to avoid dealing with resources).  

I also added a file for frontend-only types to avoid sharing them unnecessarily (see `src/client/types.d.ts`) and used various type aliases (eg. `DistrictsGeoJSON`, `UintArrays`) in more places on the frontend. It would be good to keep moving them over to that file in the future as appropriate.

## Testing Instructions
* Reassign geounits at different levels and ensure there is no flicker in the sidebar (only color of numbers change)
* Test that a loading state is shown in the sidebar header (spinner) while the request is pending

Closes #253 
