### PR TITLE
Fix bug with removed Pol. column

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -380,9 +380,6 @@ const SidebarRow = ({
           </span>
         </Tooltip>
       </Styled.td>
-      <Styled.td sx={{ ...style.td, ...style.number, ...style.blankValue }}>
-        {BLANK_VALUE}
-      </Styled.td>
       <Styled.td sx={{ ...style.td, ...style.number }}>{compactnessDisplay}</Styled.td>
       <Styled.td>
         {isDistrictLocked ? (


### PR DESCRIPTION
## Overview

When I removed the `Pol.` column, I only managed to removed it from the header. This also removes the associated column.

## Testing Instructions

Trivial change, I'm just going to merge it when the build passes.