### PR TITLE
Style disabled for buttons better and fix sidebar width in Firefox

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -57,7 +57,7 @@ const style: ThemeUIStyleObject = {
     flexDirection: "column",
     flexShrink: 0,
     height: "100%",
-    minWidth: "400px",
+    minWidth: "415px",
     position: "relative",
     color: "gray.8",
     zIndex: 200
@@ -143,7 +143,7 @@ const ProjectSidebar = ({
     <Flex sx={style.sidebar}>
       <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       <Box sx={{ overflowY: "auto", flex: 1 }}>
-        <Styled.table sx={{ mx: 2, mb: 2 }}>
+        <Styled.table sx={{ width: "calc(100% - 16px)", mx: 2, mb: 2 }}>
           <thead>
             <Styled.tr>
               <Styled.th sx={style.th}>
@@ -250,7 +250,7 @@ function getCompactnessDisplay(compactness: CompactnessScore) {
         </em>
       }
     >
-      <span>{BLANK_VALUE}</span>
+      <span sx={{ color: "gray.2" }}>{BLANK_VALUE}</span>
     </Tooltip>
   ) : typeof compactness === "number" ? (
     <Tooltip

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -215,7 +215,7 @@ const SidebarHeader = ({
         <Flex sx={{ variant: "header.right" }}>
           <Button
             variant="circularSubtle"
-            sx={{ mr: "2", cursor: "pointer" }}
+            sx={{ mr: "2" }}
             onClick={() => {
               store.dispatch(clearSelectedGeounits());
             }}
@@ -224,7 +224,6 @@ const SidebarHeader = ({
           </Button>
           <Button
             variant="circular"
-            sx={{ cursor: "pointer" }}
             onClick={() => {
               store.dispatch(updateDistrictsDefinition());
             }}

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -18,7 +18,7 @@ const appButtonStyles = {
   "& > svg": {
     mr: 1
   },
-  "&:hover:not([disabled])": {
+  "&:hover:not([disabled]):not(:active)": {
     bg: "blue.5"
   },
   "&:active": {
@@ -29,7 +29,8 @@ const appButtonStyles = {
     boxShadow: "focus"
   },
   "&[disabled]": {
-    opacity: 0.6,
+    opacity: 0.2,
+    bg: "gray.3",
     cursor: "not-allowed"
   }
 };
@@ -182,8 +183,8 @@ const theme: Theme & StyledSystemTheme = {
     secondary: {
       ...appButtonStyles,
       ...{
-        backgroundColor: "secondary",
-        "&:hover:not([disabled])": {
+        bg: "secondary",
+        "&:hover:not([disabled]):not(:active)": {
           bg: "gray.6"
         },
         "&:active": {
@@ -194,8 +195,8 @@ const theme: Theme & StyledSystemTheme = {
     ghost: {
       ...appButtonStyles,
       ...{
-        backgroundColor: "rgba(256,256,256,0.2)",
-        "&:hover": {
+        bg: "rgba(256,256,256,0.2)",
+        "&:hover:not([disabled]):not(:active)": {
           bg: "rgba(256,256,256,0.3)"
         },
         "&:active": {
@@ -207,16 +208,37 @@ const theme: Theme & StyledSystemTheme = {
     subtle: {
       ...appButtonStyles,
       ...{
-        backgroundColor: "gray.1",
+        bg: "gray.1",
         color: "heading"
+      },
+      "&:hover:not([disabled]):not(:active)": {
+        bg: "gray.2"
+      },
+      "&:active": {
+        bg: "gray.3",
+        color: "muted"
+      },
+      "&[disabled]": {
+        bg: "gray.1",
+        color: "heading",
+        opacity: 0.25,
+        cursor: "not-allowed"
       }
     },
     minimal: {
       ...appButtonStyles,
       ...{
-        background: "none",
-        "&:hover:not([disabled])": {
+        bg: "transparent",
+        color: "gray.8",
+        "&:hover:not([disabled]):not(:active)": {
+          textDecoration: "underline",
           bg: "rgba(256,256,256,0.2)"
+        },
+        "&[disabled]": {
+          bg: "transparent",
+          color: "gray.8",
+          opacity: 0.25,
+          cursor: "not-allowed"
         },
         "&:active": {
           bg: "rgba(256,256,256,0.3)"
@@ -240,7 +262,7 @@ const theme: Theme & StyledSystemTheme = {
       "& > svg": {
         mr: 1
       },
-      "&:hover:not([disabled])": {
+      "&:hover:not([disabled]):not(:active)": {
         bg: "gray.1"
       },
       "&:active": {
@@ -251,8 +273,9 @@ const theme: Theme & StyledSystemTheme = {
         boxShadow: "focus"
       },
       "&[disabled]": {
-        opacity: 0.6,
-        cursor: "not-allowed"
+        cursor: "not-allowed",
+        bg: "muted",
+        opacity: 0.25
       }
     },
     quiet: {
@@ -260,7 +283,7 @@ const theme: Theme & StyledSystemTheme = {
       ...{
         backgroundColor: "#fff",
         color: "text",
-        "&:hover": {
+        "&:hover:not([disabled]):not(:active)": {
           bg: "blue.1"
         },
         "&:active": {
@@ -288,7 +311,7 @@ const theme: Theme & StyledSystemTheme = {
         borderRadius: "100px",
         backgroundColor: "gray.1",
         color: "heading",
-        "&:hover:not([disabled])": {
+        "&:hover:not([disabled]):not(:active)": {
           bg: "gray.2"
         },
         "&:active": {
@@ -312,7 +335,8 @@ const theme: Theme & StyledSystemTheme = {
         borderColor: "primary",
         boxShadow: "focus",
         outline: "none"
-      }
+      },
+      "&[type='radio']": {}
     },
     select: {
       borderColor: "gray.2",


### PR DESCRIPTION
## Overview
Fixes a horizontal scrollbar for the sidebar in the Map view. I also styled disabled states for buttons to be more clearly disabled. The hover state had been fixed in a previous PR, so I reduced opacity and changed the color to generally be gray.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
Firefox
<img width="1792" alt="Screen Shot 2020-09-02 at 4 19 59 PM" src="https://user-images.githubusercontent.com/5672295/92002825-3157a380-ed38-11ea-9f11-8370e17ffc1d.png">

Chrome
<img width="1792" alt="Screen Shot 2020-09-02 at 4 20 02 PM" src="https://user-images.githubusercontent.com/5672295/92002838-361c5780-ed38-11ea-99b3-9a454a732860.png">

Disabled primary button
<img width="1231" alt="Screen Shot 2020-09-02 at 4 21 20 PM" src="https://user-images.githubusercontent.com/5672295/92002960-5b10ca80-ed38-11ea-9172-6f850c5e5c9f.png">


### Notes
- Jeff and I noticed that the Political affiliations column was left in the table, so I also removed that here.
- The min-width of the sidebar needed to be slightly wider.

## Testing Instructions
- `git pull`
- View the login page
- In `LoginScreen.tsx`, locate `<Button type="submit">Log in</Button>`. Add a `disabled` property to this button and you'll see the new styles for the primary button type. View all of the button variants in their disabled state:
    - secondary
    - ghost (change the background of the containing Box to '#000')
    - subtle
    - minimal
    - outlined
    - circular
    - circularSubtle
    I didn't see "quiet" used anywhere so didn't do anything with this one.
- View the DistrictBuilder map view in Firefox, Safari and Chrome to ensure that the table in the sidebar doesn't get a horizontal scrollbar.


Closes #335, closes #311 
