### PR TITLE
Add ability to tune health check grace period for ECS service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend Jenkins pipeline to support production releases [#325](https://github.com/PublicMapping/districtbuilder/pull/325)
 - Add support for Rollbar [#338](https://github.com/PublicMapping/districtbuilder/pull/338)
 - Provide math for scaling task memory with additional states [#309](https://github.com/PublicMapping/districtbuilder/pull/309)
+- Add ability to tune health check grace period for ECS service [#393](https://github.com/PublicMapping/districtbuilder/pull/393)
 
 ### Changed
 - Migrate DNS records to districtbuilder.org hosted zones [#360](https://github.com/PublicMapping/districtbuilder/pull/360)

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -152,6 +152,8 @@ resource "aws_ecs_service" "app" {
   deployment_minimum_healthy_percent = var.fargate_app_deployment_min_percent
   deployment_maximum_percent         = var.fargate_app_deployment_max_percent
 
+  health_check_grace_period_seconds = var.districtbuilder_state_count * var.health_check_grace_period_per_state
+
   launch_type      = "FARGATE"
   platform_version = var.fargate_platform_version
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -246,6 +246,10 @@ variable "fargate_app_deployment_max_percent" {
   type    = number
 }
 
+variable "health_check_grace_period_per_state" {
+  type = number
+}
+
 variable "districtbuilder_state_count" {
   type = number
 }


### PR DESCRIPTION
## Overview

To resolve failed ECS health checks due to the application not being ready I've added a parameter to allow us to set a base grace period for health checks that gets multiplied by the number of states were loading.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

Resolves #392 

## Testing Instructions

Adjust the `health_check_grace_period_per_state` in the staging tfvars file and then see the resulting Terraform plan.

```bash
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-5.0# export GIT_COMMIT=6d9dec8 
bash-5.0# ./scripts/infra plan
. . .
Terraform will perform the following actions:

  # aws_ecs_service.app will be updated in-place
  ~ resource "aws_ecs_service" "app" {
        cluster                            = "arn:aws:ecs:us-east-1:273766372266:cluster/ecsStagingCluster"
        deployment_maximum_percent         = 200
        deployment_minimum_healthy_percent = 100
        desired_count                      = 1
        enable_ecs_managed_tags            = false
      ~ health_check_grace_period_seconds  = 0 -> 180
        iam_role                           = "aws-service-role"
        id                                 = "arn:aws:ecs:us-east-1:273766372266:service/StagingApp"
        launch_type                        = "FARGATE"
        name                               = "StagingApp"
        platform_version                   = "1.4.0"
        propagate_tags                     = "NONE"
        scheduling_strategy                = "REPLICA"
        tags                               = {}
        task_definition                    = "arn:aws:ecs:us-east-1:273766372266:task-definition/StagingApp:142"

        deployment_controller {
            type = "ECS"
        }

        load_balancer {
            container_name   = "app"
            container_port   = 3005
            target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:273766372266:targetgroup/tgStagingApp/b72f8d0e6649a53b"
        }

        network_configuration {
            assign_public_ip = false
            security_groups  = [
                "sg-00b08b20f31addcc1",
            ]
            subnets          = [
                "subnet-0ae97fd3a9a28848e",
                "subnet-0cf1fe8bbae4e990d",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After applying these changes, see that they appear in the ECS console.

```bash
bash-5.0# ./scripts/infra apply
```

![image](https://user-images.githubusercontent.com/1774125/92608648-a3257500-f283-11ea-8afc-86b546e48455.png)
