### PR TITLE
Update for county suffixes

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -229,7 +229,7 @@ const SidebarHeader = ({
             }}
           >
             <Icon name="check" />
-            Approve
+            Accept
           </Button>
         </Flex>
       ) : null}

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -130,11 +130,7 @@ const MapTooltip = ({
     const featureLabel = () => (
       <span sx={{ textTransform: "capitalize" }}>
         {feature && feature.properties && typeof feature.properties.name === "string" ? (
-          feature.properties.name.endsWith("city") ? (
-            feature.properties.name
-          ) : (
-            `${feature.properties.name} ${geoLevelId}`
-          )
+          feature.properties.name
         ) : feature ? (
           <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
         ) : (

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -144,7 +144,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
           </Link>
         </Box>
         <Heading as="h2" sx={{ variant: "text.h4", color: "blue.0", my: 0 }}>
-          New Project
+          New Map
         </Heading>
       </Flex>
       <Flex as="main" sx={{ width: "100%" }}>
@@ -270,7 +270,9 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                           <Radio name="project-district" value="" onChange={onDistrictChanged} />
                           <Flex as="span" sx={{ flexDirection: "column" }}>
                             <div sx={style.radioHeading}>Custom</div>
-                            <div sx={style.radioSubHeading}>Define other types of districts</div>
+                            <div sx={style.radioSubHeading}>
+                              Define a custom number of districts
+                            </div>
                           </Flex>
                         </Label>
                       </div>
@@ -310,7 +312,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                   !("errorMessage" in createProjectResource)
                 }
               >
-                Create project
+                Create map
               </Button>
             </Box>
           </Flex>


### PR DESCRIPTION
## Overview

The data processing pipeline now passes through the "County" suffixes, so we no longer need to add them to the label after the fact. I also performed some additional minor text changes:
 * On map page, change button text from Approve to Accept for pending changes
 * On create map page, change button text from Create Project to Create Map
 * On create map page, change header text from New Project to New Map
 * On create map page, under Custom, change "Define other types of districts" to "Define a custom number of districts"

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![city-suffix](https://user-images.githubusercontent.com/6386/92656113-7cd1fa80-f2c0-11ea-8b90-aa91ad819def.png)

![county-suffix](https://user-images.githubusercontent.com/6386/92656115-7cd1fa80-f2c0-11ea-8f2a-9936469da0b9.png)

![text-canges](https://user-images.githubusercontent.com/6386/92656111-7c396400-f2c0-11ea-8294-82035c6931f2.png)

## Testing Instructions

- Make sure you have loaded one of the new region files that has county suffixes passed through
- Verify that you are not seeing doubled-up county suffixes
- Verify the minor text changes described in the overview are present
