### PR TITLE
Whitelist a few exception types from being reported to Rollbar

### DIFF
--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -1,7 +1,24 @@
-import { ArgumentsHost, Catch, HttpException } from "@nestjs/common";
+import {
+  ArgumentsHost,
+  Catch,
+  HttpException,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException
+} from "@nestjs/common";
 import { BaseExceptionFilter } from "@nestjs/core";
 import { Request } from "express";
 import { RollbarService } from "./rollbar.service";
+
+function isWhitelisted(exception: HttpException) {
+  // Note that we don't need to whitelist BadRequestException as it has it's
+  // own exception filter already
+  return (
+    exception instanceof NotFoundException ||
+    exception instanceof ServiceUnavailableException ||
+    exception instanceof UnauthorizedException
+  );
+}
 
 @Catch()
 export class RollbarExceptionFilter extends BaseExceptionFilter {
@@ -10,11 +27,13 @@ export class RollbarExceptionFilter extends BaseExceptionFilter {
     super();
   }
 
-  catch(exception: HttpException, host: ArgumentsHost): void {
-    const ctx = host.switchToHttp();
-    const request = ctx.getRequest<Request>();
+  catch(exception: unknown, host: ArgumentsHost): void {
+    if (exception instanceof HttpException && !isWhitelisted(exception)) {
+      const ctx = host.switchToHttp();
+      const request = ctx.getRequest<Request>();
 
-    this.rollbar.error(exception, request);
+      this.rollbar.error(exception, request);
+    }
 
     // Delegate error messaging and response to default global exception filter
     super.catch(exception, host);


### PR DESCRIPTION
## Overview

These are "normal" exceptions that don't necessarily indicate an error with the website, and as such it would be wasteful to report them to Rollbar

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

I grepped the server codebase for all errors we're throwing to determine if we needed to whitelist any exception not already called out in #388 but I didn't see any.

## Testing Instructions

- I added a `console.log` above the call to `this.rollbar.error` to verify exceptions were being filtered appropriately

Closes #388