### PR TITLE
Reduce noise in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for selecting partially locked districts [#420](https://github.com/PublicMapping/districtbuilder/pull/420)
 
 ### Changed
+- Reduce noise in log output [#399](https://github.com/PublicMapping/districtbuilder/pull/399)
 
 ### Fixed
 - Fix S3 permissions to allow CloudFront logging [#410](https://github.com/PublicMapping/districtbuilder/pull/410)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-399') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-399') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -56,6 +56,10 @@
       {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_access_token}"
+      },
+      {
+        "name": "NO_COLOR",
+        "value": "true"
       }
     ],
     "mountPoints": [],

--- a/src/server/ormconfig.js
+++ b/src/server/ormconfig.js
@@ -7,7 +7,7 @@ module.exports = {
   username: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
-  logging: true,
+  logging: process.env.NODE_ENV === "Development",
   synchronize: false,
   entities: ["dist/**/*.entity.js"],
   subscribers: ["dist/server/subscriber/*.js"],

--- a/src/server/src/main.ts
+++ b/src/server/src/main.ts
@@ -3,9 +3,12 @@ import { Reflector } from "@nestjs/core";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { BadRequestExceptionFilter } from "./common/bad-request-exception.filter";
+import { DEBUG } from "./common/constants";
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger: DEBUG ? ["debug", "verbose", "log", "warn", "error"] : ["log", "warn", "error"]
+  });
   app.useGlobalPipes(
     new ValidationPipe({
       exceptionFactory: errors => new BadRequestException(errors),


### PR DESCRIPTION
## Overview

Reduces the logging level, disables SQL query logging, and removes color from log output for non-development (i.e. ECS) environments.

### Notes

There is still a little apparent cruft from context like the `[Nest]` blocks. Because there are a few components that create logs in this application, I think the `[Nest]` blocks are actually helpful for distinguishing what are Nest application logs and what are not, like TypeORM logs.

The timestamps are actually extraneous here since ECS already timestamps logs, but we'd need to extend the NestJS logger and implement our own custom logger with our own logging format if we wanted to get rid of those. That's totally doable but felt like overkill in this situation.

Updated task definition has been deployed to staging when this PR was marked ready for review. It may need to be redeployed via Terraform if a `deploy` merge has happened since.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

[CloudWatch logs for staging task with reduced log output](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/logStagingApp/log-events/districtbuilder-app$252Fapp$252F20d5627a-3544-4f8e-b683-5b7e329f37a9)

## Testing Instructions

- Run `./scripts/update` and `./scripts/server` to bring up the server application in development mode locally. Examine the log output. It should be displayed in color, include debug logs, and include SQL query logs.
  - You can generate a debug log by signing up a new user and checking for a log of the validation email. Existing users can request for the validation email to be resent for the same log message.
- Examine the log output for a running ECS `app` task. It should not include color codes, should not include debug logs, and should not include SQL query logs.

Closes #143 
