### PR TITLE
Add basemap

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -93,6 +93,7 @@ const DistrictsMap = ({
       return;
     }
 
+    // eslint-disable-next-line
     MapboxGL.accessToken =
       "pk.eyJ1IjoiZGlzdHJpY3RidWlsZGVyIiwiYSI6ImNrZXZzeXlvMjIxb2QycW1yeGpuMDJ2ZGwifQ.FdOGNk3y1BPkGvF_yCjjGQ";
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -23,11 +23,9 @@ import { areAnyGeoUnitsSelected, getSelectedGeoLevel } from "../../functions";
 import { getAllIndices } from "../../../shared/functions";
 import {
   GEOLEVELS_SOURCE_ID,
-  DISTRICTS_PLACEHOLDER_LAYER_ID,
   DISTRICTS_SOURCE_ID,
-  DISTRICTS_LAYER_ID,
   featureStateDistricts,
-  getMapboxStyle,
+  generateMapLayers,
   getGeoLevelVisibility,
   levelToLabelLayerId,
   levelToLineLayerId,
@@ -95,14 +93,12 @@ const DistrictsMap = ({
       return;
     }
 
+    MapboxGL.accessToken =
+      "pk.eyJ1IjoiZGlzdHJpY3RidWlsZGVyIiwiYSI6ImNrZXZzeXlvMjIxb2QycW1yeGpuMDJ2ZGwifQ.FdOGNk3y1BPkGvF_yCjjGQ";
+
     const map = new MapboxGL.Map({
       container: mapRef.current,
-      style: getMapboxStyle(
-        project.regionConfig.s3URI,
-        staticMetadata.geoLevelHierarchy,
-        minZoom,
-        maxZoom
-      ),
+      style: "mapbox://styles/districtbuilder/ckexc26lz0d3k19owrswhxz9o",
       bounds: [b0, b1, b2, b3],
       fitBoundsOptions: { padding: 20 },
       minZoom: minZoom,
@@ -126,35 +122,14 @@ const DistrictsMap = ({
     const onMapLoad = () => {
       setMap(map);
 
-      map.addSource(DISTRICTS_SOURCE_ID, {
-        type: "geojson",
-        data: geojson
-      });
-      map.addLayer(
-        {
-          id: DISTRICTS_LAYER_ID,
-          type: "fill",
-          source: DISTRICTS_SOURCE_ID,
-          layout: {},
-          paint: {
-            "fill-color": { type: "identity", property: "color" },
-            "fill-opacity": 1
-          }
-        },
-        DISTRICTS_PLACEHOLDER_LAYER_ID
-      );
-      map.addLayer(
-        {
-          id: "districts-locked",
-          type: "fill",
-          source: DISTRICTS_SOURCE_ID,
-          layout: {},
-          paint: {
-            "fill-pattern": "circle-1",
-            "fill-opacity": ["case", ["boolean", ["feature-state", "locked"], false], 1, 0]
-          }
-        },
-        DISTRICTS_PLACEHOLDER_LAYER_ID
+      generateMapLayers(
+        project.regionConfig.s3URI,
+        project.regionConfig.regionCode,
+        staticMetadata.geoLevelHierarchy,
+        minZoom,
+        maxZoom,
+        map,
+        geojson
       );
 
       map.resize();

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -79,8 +79,10 @@ export function generateMapLayers(
   geoLevels: readonly GeoLevelInfo[],
   minZoom: number,
   maxZoom: number,
+  /* eslint-disable */
   map: any,
   geojson: any
+  /* eslint-enable */
 ) {
   map.addSource(DISTRICTS_SOURCE_ID, {
     type: "geojson",

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -318,15 +318,12 @@ export function featuresToGeoUnits(
         .filter(feature => feature.sourceLayer === geoLevelId)
         .map((feature: MapboxGeoJSONFeature) => [
           feature.id as FeatureId,
-          geoLevelHierarchyKeys.reduce(
-            (geounitData, key) => {
-              const geounitId = feature.properties && feature.properties[key];
-              return geounitId !== undefined && geounitId !== null
-                ? [geounitId, ...geounitData]
-                : geounitData;
-            },
-            [] as readonly number[]
-          )
+          geoLevelHierarchyKeys.reduce((geounitData, key) => {
+            const geounitId = feature.properties && feature.properties[key];
+            return geounitId !== undefined && geounitId !== null
+              ? [geounitId, ...geounitData]
+              : geounitData;
+          }, [] as readonly number[])
         ])
     );
     return geounitData;


### PR DESCRIPTION
## Overview

Adds a custom basemap from Mapbox Studio.

### Demo

![Screen Shot 2020-09-10 at 6 06 00 PM](https://user-images.githubusercontent.com/1809908/92814098-9773a480-f390-11ea-9457-7f94d67e5913.png)

![Screen Shot 2020-09-10 at 6 08 42 PM](https://user-images.githubusercontent.com/1809908/92814150-afe3bf00-f390-11ea-82ac-2473092e14ee.png)

![Screen Shot 2020-09-10 at 6 07 31 PM](https://user-images.githubusercontent.com/1809908/92814157-b2deaf80-f390-11ea-9429-b04bcea05708.png)

### Notes

To use a Mapbox Studio basemap, I had to change the way we define a style in the application. Instead of generating a style json, we are now using a style from Mapbox Studio, and we use `addSource` and `addLayer` to add additional elements. We were using that technique in some places already, so now it is more consistent. I made a `generateMapLayers` function to move this outside of the crowded `Map.tsx` file, but let me know if you'd prefer a different approach.

I am using a filter to only show labels for the selected region. Right now this will work for any state, but when we support other types of regions, we'll need to make some minor changes. I figure there are a lot of little things like that.

I think this is in a good enough place to launch, but I hope to continue to refine it over time. That being said, let me know if you see anything super weird. 

In the future, I want to allow users to have more control over which layers they see. 

## Testing Instructions

- Open a project from 3 different states
- For each state, zoom around, check out counties, blockgroups, and blocks
- Let me know if anything looks super messed up
- Confirm that you only see city/poi labels from the selected state

Connected to #111
