### PR TITLE
Compenetize menu avatar and add to map page

### DIFF
--- a/src/client/components/AvatarMenu.tsx
+++ b/src/client/components/AvatarMenu.tsx
@@ -1,0 +1,142 @@
+/** @jsx jsx */
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import Avatar from "react-avatar";
+import Icon from "./Icon";
+import { clearJWT, getJWT } from "../jwt";
+import store from "../store";
+import { jsx, ThemeUIStyleObject } from "theme-ui";
+import { resetState } from "../actions/root";
+import { Link } from "react-router-dom";
+import { UserState } from "../reducers/user";
+import * as H from "history";
+import React from "react";
+
+enum UserMenuKeys {
+  Logout = "logout"
+}
+
+const style: ThemeUIStyleObject = {
+  avatar: {
+    fontFamily: "heading",
+    cursor: "pointer",
+    ".sb-avatar__text": {
+      "&:hover": {
+        backgroundColor: "#395c78 !important"
+      },
+      "&:active": {
+        backgroundColor: "#2c485e !important"
+      }
+    }
+  },
+  menuButton: {
+    display: "flex",
+    alignItems: "center",
+    bg: "transparent",
+    p: 1,
+    borderRadius: "small",
+    "&:focus": {
+      outline: "none",
+      boxShadow: "focus"
+    }
+  },
+  menu: {
+    width: "100px",
+    position: "absolute",
+    mt: 0,
+    right: 2,
+    py: 1,
+    px: 1,
+    color: "white",
+    bg: "#395c78",
+    border: "1px solid",
+    borderColor: "gray.2",
+    boxShadow: "small",
+    borderRadius: "small"
+  },
+  menuList: {
+    p: "0",
+    m: "0",
+    listStyleType: "none"
+  },
+  menuListItem: {
+    borderRadius: "small",
+    py: 1,
+    px: 2,
+    color: "white",
+    "&:hover:not([disabled])": {
+      bg: "#2c485e",
+      cursor: "pointer"
+    },
+    "&[disabled]": {
+      color: "#2c485e",
+      cursor: "not-allowed"
+    },
+    "&:focus": {
+      bg: "#2c485e",
+      outline: "none",
+      boxShadow: "focus"
+    },
+    "&:active": {
+      bg: "#2c485e"
+    }
+  }
+};
+
+const logout = () => {
+  clearJWT();
+  store.dispatch(resetState());
+};
+
+const handleSelection = (history: H.History) => (key: string | number) => {
+  // eslint-disable-next-line
+  if (key === UserMenuKeys.Logout) {
+    logout();
+    history.push("/login");
+  }
+};
+
+const AvatarMenu = ({
+  user,
+  history
+}: {
+  readonly user: UserState;
+  readonly history: H.History;
+}) => {
+  return getJWT() === null ? (
+    <React.Fragment>
+      <Link to="/login" sx={{ p: 2 }}>
+        Login
+      </Link>{" "}
+      <Link to="/register" sx={{ p: 2 }}>
+        Register
+      </Link>
+    </React.Fragment>
+  ) : "resource" in user ? (
+    <Wrapper onSelection={handleSelection(history)}>
+      <MenuButton sx={style.menuButton}>
+        <Avatar
+          name={user.resource.name}
+          round={true}
+          size={"2.5rem"}
+          color={"#2c485e"}
+          maxInitials={3}
+          sx={style.avatar}
+        />
+        <div sx={{ ml: 2 }}>
+          <Icon name="chevron-down" />
+        </div>
+      </MenuButton>
+      <Menu sx={style.menu}>
+        <ul sx={style.menuList}>
+          <li key={UserMenuKeys.Logout}>
+            <MenuItem value={UserMenuKeys.Logout} sx={style.menuListItem}>
+              Logout
+            </MenuItem>
+          </li>
+        </ul>
+      </Menu>
+    </Wrapper>
+  ) : null;
+};
+
+export default AvatarMenu;

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -2,9 +2,11 @@
 import { Box, Flex, jsx, Text } from "theme-ui";
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
-
+import { UserState } from "../reducers/user";
+import * as H from "history";
 import { IProject } from "../../shared/entities";
 import { heights } from "../theme";
+import AvatarMenu from "../components/AvatarMenu";
 
 const HeaderDivider = () => {
   return (
@@ -19,7 +21,15 @@ const HeaderDivider = () => {
   );
 };
 
-const ProjectHeader = ({ project }: { readonly project?: IProject }) => (
+const ProjectHeader = ({
+  project,
+  user,
+  history
+}: {
+  readonly project?: IProject;
+  readonly user: UserState;
+  readonly history: H.History;
+}) => (
   <Flex
     sx={{
       variant: "header.app",
@@ -44,7 +54,9 @@ const ProjectHeader = ({ project }: { readonly project?: IProject }) => (
         </Text>
       </Flex>
     </Flex>
-    <Flex sx={{ variant: "header.right" }} />
+    <Flex sx={{ variant: "header.right" }}>
+      <AvatarMenu user={user} history={history} />
+    </Flex>
   </Flex>
 );
 

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -1,11 +1,12 @@
 /** @jsx jsx */
-import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
-import Avatar from "react-avatar";
 import React, { useEffect, useState } from "react";
+import { projectsFetch } from "../actions/projects";
+import { userFetch } from "../actions/user";
 import { connect } from "react-redux";
 import { Link, RouteComponentProps } from "react-router-dom";
-import * as H from "history";
 import Icon from "../components/Icon";
+import AvatarMenu from "../components/AvatarMenu";
+import store from "../store";
 import {
   Alert,
   Box,
@@ -21,30 +22,17 @@ import {
 import { ReactComponent as Logo } from "../media/logos/logo.svg";
 import { ReactComponent as NoMapsIllustration } from "../media/no-maps-illustration.svg";
 
-import { resetState } from "../actions/root";
-import { projectsFetch } from "../actions/projects";
-import { userFetch } from "../actions/user";
 import { resendConfirmationEmail } from "../api";
-import { clearJWT, getJWT } from "../jwt";
+import { getJWT } from "../jwt";
 import { State } from "../reducers";
 import { ProjectsState } from "../reducers/projects";
 import { UserState } from "../reducers/user";
 import { WriteResource } from "../resource";
-import store from "../store";
 
 interface StateProps {
   readonly projects: ProjectsState;
   readonly user: UserState;
 }
-
-enum UserMenuKeys {
-  Logout = "logout"
-}
-
-const logout = () => {
-  clearJWT();
-  store.dispatch(resetState());
-};
 
 const style: ThemeUIStyleObject = {
   header: {
@@ -62,68 +50,6 @@ const style: ThemeUIStyleObject = {
     "&:focus": {
       outline: "none",
       boxShadow: "focus"
-    }
-  },
-  avatar: {
-    fontFamily: "heading",
-    cursor: "pointer",
-    ".sb-avatar__text": {
-      "&:hover": {
-        backgroundColor: "#395c78 !important"
-      },
-      "&:active": {
-        backgroundColor: "#2c485e !important"
-      }
-    }
-  },
-  menuButton: {
-    display: "flex",
-    alignItems: "center",
-    bg: "transparent",
-    p: 1,
-    borderRadius: "small",
-    "&:focus": {
-      outline: "none",
-      boxShadow: "focus"
-    }
-  },
-  menu: {
-    width: "150px",
-    position: "absolute",
-    mt: 2,
-    right: 2,
-    bg: "muted",
-    py: 1,
-    px: 1,
-    border: "1px solid",
-    borderColor: "gray.2",
-    boxShadow: "small",
-    borderRadius: "small"
-  },
-  menuList: {
-    p: "0",
-    m: "0",
-    listStyleType: "none"
-  },
-  menuListItem: {
-    borderRadius: "small",
-    py: 1,
-    px: 2,
-    "&:hover:not([disabled])": {
-      bg: "gray.0",
-      cursor: "pointer"
-    },
-    "&[disabled]": {
-      color: "gray.3",
-      cursor: "not-allowed"
-    },
-    "&:focus": {
-      bg: "gray.0",
-      outline: "none",
-      boxShadow: "focus"
-    },
-    "&:active": {
-      bg: "gray.1"
     }
   },
   projectRow: {
@@ -208,41 +134,7 @@ const HomeScreen = ({ projects, user, history }: StateProps & RouteComponentProp
             <Logo sx={{ width: "15rem" }} />
           </Link>
         </Heading>
-        {!isLoggedIn ? (
-          <React.Fragment>
-            <Link to="/login" sx={{ p: 2 }}>
-              Login
-            </Link>{" "}
-            <Link to="/register" sx={{ p: 2 }}>
-              Register
-            </Link>
-          </React.Fragment>
-        ) : "resource" in user ? (
-          <Wrapper onSelection={handleSelection(history)}>
-            <MenuButton sx={style.menuButton}>
-              <Avatar
-                name={user.resource.name}
-                round={true}
-                size={"2.5rem"}
-                color={"#2c485e"}
-                maxInitials={3}
-                sx={style.avatar}
-              />
-              <div sx={{ ml: 2 }}>
-                <Icon name="chevron-down" />
-              </div>
-            </MenuButton>
-            <Menu sx={style.menu}>
-              <ul sx={style.menuList}>
-                <li key={UserMenuKeys.Logout}>
-                  <MenuItem value={UserMenuKeys.Logout} sx={style.menuListItem}>
-                    Logout
-                  </MenuItem>
-                </li>
-              </ul>
-            </Menu>
-          </Wrapper>
-        ) : null}
+        <AvatarMenu user={user} history={history} />
       </Flex>
       <Flex
         as="main"
@@ -317,14 +209,6 @@ const HomeScreen = ({ projects, user, history }: StateProps & RouteComponentProp
       </Flex>
     </Flex>
   );
-};
-
-const handleSelection = (history: H.History) => (key: string | number) => {
-  // eslint-disable-next-line
-  if (key === UserMenuKeys.Logout) {
-    logout();
-    history.push("/login");
-  }
 };
 
 function mapStateToProps(state: State): StateProps {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { useEffect, useMemo, useState } from "react";
 import { connect } from "react-redux";
-import { Redirect, useParams } from "react-router-dom";
+import { Redirect, useParams, RouteComponentProps } from "react-router-dom";
 import { Flex, jsx, Spinner } from "theme-ui";
 
 import { destructureResource } from "../functions";
@@ -49,8 +49,9 @@ const ProjectScreen = ({
   geoUnitHierarchy,
   districtDrawing,
   isLoading,
-  user
-}: StateProps) => {
+  user,
+  history
+}: StateProps & RouteComponentProps<"history">) => {
   const { projectId } = useParams();
   const [label, setMapLabel] = useState<string | undefined>(undefined);
 
@@ -105,7 +106,7 @@ const ProjectScreen = ({
   ) : (
     <Flex sx={{ height: "100%", flexDirection: "column" }}>
       <Toast />
-      <ProjectHeader project={project} />
+      <ProjectHeader project={project} user={user} history={history} />
       <Flex sx={{ flex: 1, overflowY: "auto" }}>
         {sidebar}
         <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>


### PR DESCRIPTION
## Overview

The menu avatar was only available on the home page. This converts it to a component and adds it to the map page.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![screenshot_6](https://user-images.githubusercontent.com/6386/92929676-ecee9680-f40e-11ea-8964-133ab4b14e94.png)

![screenshot_5](https://user-images.githubusercontent.com/6386/92929677-ecee9680-f40e-11ea-9ee9-75ae4bec19f3.png)

### Notes

The white background color didn't look right on the map page, so I switched it to a darker color, at least temporarily. I'm sure the design team will like to have a pass at this.

## Testing Instructions

- Try logging out on both the home page and map page

Closes #385
