### PR TITLE
Cache new layers that are encountered after load

### DIFF
--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -44,11 +44,16 @@ export class TopologyService {
   }
 
   public async get(s3URI: S3URI): Promise<GeoUnitTopology | void> {
-    return s3URI in this._layers
-      ? this._layers[s3URI]
-      : this.fetchLayer(s3URI).catch(err => {
-          this.logger.error(err);
-        });
+    if (!(s3URI in this._layers)) {
+      // If we encounter a new layer (i.e. one added after the service has started),
+      // then store the results in the `_layers` object.
+      // @ts-ignore
+      // eslint-disable-next-line functional/immutable-data
+      this._layers[s3URI] = this.fetchLayer(s3URI).catch(err => {
+        this.logger.error(err);
+      });
+    }
+    return this._layers[s3URI];
   }
 
   private async fetchLayer(s3URI: S3URI): Promise<GeoUnitTopology | void> {


### PR DESCRIPTION
## Overview

S3 data was being cached on startup only. If a new region was added, it would still be selectable and would work, but the data needed to be pulled from S3 on each operation. This makes it so if we need to pull a new data layer, we cache it for later use.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

There are a couple different ways to test this PR, so do what you like best:
 * Process/publish a new region
 * or Manually insert a new region row into your db
 * or (fastest way) find the constructor in `topology.service.ts` and comment out all of the contents (lines 29-39), this is what does the initial cache.

Then load a project with a new region that will need to be pulled down. It'll be slow the first time, since it fetches it from S3. Then reload the page, or save districts, and it should be fast all subsequent times.