### PR TITLE
Fix tooltip persisting on hover away

### DIFF
--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -64,14 +64,23 @@ const MapTooltip = ({
     : undefined;
 
   useEffect(() => {
-    const throttledSetFeature = throttle((point, geoLevel) => {
-      const features =
-        map &&
-        map.queryRenderedFeatures(point, {
-          layers: [levelToLineLayerId(geoLevel), levelToSelectionLayerId(geoLevel)]
-        });
-      features && setFeature(features[0]);
-    }, SET_FEATURE_DELAY);
+    const throttledSetFeature = throttle(
+      (point: MapboxGL.Point | undefined, geoLevel: string | undefined) => {
+        // eslint-disable-next-line
+        if (!point || !geoLevel) {
+          setFeature(undefined);
+          // eslint-disable-next-line
+        } else {
+          const features =
+            map &&
+            map.queryRenderedFeatures(point, {
+              layers: [levelToLineLayerId(geoLevel), levelToSelectionLayerId(geoLevel)]
+            });
+          features && setFeature(features[0]);
+        }
+      },
+      SET_FEATURE_DELAY
+    );
 
     const onMouseMoveThrottled = throttle((e: MapboxGL.MapMouseEvent) => {
       // eslint-disable-next-line
@@ -85,7 +94,9 @@ const MapTooltip = ({
       }
     }, 5);
 
-    const onMouseOut = throttle(() => setFeature(undefined), 5);
+    const onMouseOut = throttle(() => {
+      throttledSetFeature(undefined, undefined);
+    }, 5);
 
     const onDrag = (e: MapboxGL.MapMouseEvent) => {
       setPoint({ x: e.originalEvent.offsetX, y: e.originalEvent.offsetY });


### PR DESCRIPTION
## Overview

When hovering away from the map, the tooltip was still persisting. This fixes it.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Peek 2020-09-11 17-00](https://user-images.githubusercontent.com/6386/92972588-77a3b580-f450-11ea-928a-0af8aed00d06.gif)


### Notes

The reason this was happening seemed to stem from the fact that `setFeature` was being called directly in this case rather than through `throttledSetFeature`, and there was a race condition where a throttled request would come through afterwards and make the tooltip visible. The fix here routes everything through `throttledSetFeature` so this won't happen.

## Testing Instructions

- Load up a project
- Zoom in so the extent of the geounits is flush with the map bounds (this is how to reproduce the bug)
- Hover over the map and outside of the map and verify that the tooltip disappears when it should