### PR TITLE
Fix S3 permissions to allow CloudFront logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix S3 permissions to allow CloudFront logging [#410](https://github.com/PublicMapping/districtbuilder/pull/410)
 
 
 ## [0.1.0] - 2020-09-14

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.aws_region
-  version = "~> 3.1.0"
+  version = "~> 3.6.0"
 }
 
 terraform {

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,6 +1,19 @@
+data "aws_canonical_user_id" "current" {}
+
 resource "aws_s3_bucket" "logs" {
   bucket = "${lower(var.project)}-${lower(var.environment)}-logs-${var.aws_region}"
-  acl    = "private"
+
+  grant {
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+    id          = data.aws_canonical_user_id.current.id
+  }
+
+  grant {
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+    id          = var.aws_cloudfront_canonical_user_id
+  }
 
   tags = {
     Name        = "${lower(var.project)}-${lower(var.environment)}-logs-${var.aws_region}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -295,3 +295,8 @@ variable "aws_ecs_task_execution_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
   type    = string
 }
+
+variable "aws_cloudfront_canonical_user_id" {
+  default = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+  type    = string
+}


### PR DESCRIPTION
## Overview

It appears as though something changed with Terraform's ability to detect out-of-band grants, or perhaps a CloudFront service level change led to different behaviors than before (they recently added real-time logs). That's left us with a handful of CloudFront logs in S3 from May, but nothing between May and now.

When logging to S3 from CloudFront is configured via the AWS console, a specific set of grants that allow CloudFront to interact with an S3 bucket are added. These grants appear to get wiped away by Terraform unless they are explicitly defined in the Terraform configuration.

The changes in this PR aim to persist the two grants (one is the AWS canonical user ID, and the other is the CloudFront canonical user ID) in the Terraform project.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Disable CloudFront logging for the staging distribution via the [AWS console](https://console.aws.amazon.com/cloudfront/v2/home#/logs/E3QOQU5DX6A1SS)
- Execute a Terraform plan/apply cycle using `develop` and see that 2 grants are being removed from the `aws_s3_bucket.logs` resource
- Execute a Terraform plan/apply cycle using the changes in this branch and ensure that no grants are removed the the `aws_s3_bucket.logs` resource