### PR TITLE
Fix outlined button text on hover

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -38,18 +38,14 @@ const style: ThemeUIStyleObject = {
     }
   },
   rightCapButton: {
-    variant: "buttons.outlined",
-    py: 1,
     borderTopRightRadius: "0",
     borderBottomRightRadius: "0",
-    mr: "1px",
+    borderRight: "none",
     "& > svg": {
       mr: "0"
     }
   },
   leftCapButton: {
-    variant: "buttons.outlined",
-    py: 1,
     borderTopLeftRadius: "0",
     borderBottomLeftRadius: "0",
     "& > svg": {

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -91,17 +91,6 @@ const theme: Theme & StyledSystemTheme = {
       "#595959",
       "#2c2c2c",
       "#141414"
-    ],
-    peach: [
-      "#FFF7E8",
-      "#FFEDD1",
-      "#FFE0BB",
-      "#FFD4AA",
-      "#ffc08e",
-      "#DB9467",
-      "#B76C47",
-      "#93492D",
-      "#7A301B"
     ]
   },
   radii: {
@@ -282,9 +271,11 @@ const theme: Theme & StyledSystemTheme = {
         mr: 1
       },
       "&:hover:not([disabled]):not(:active)": {
+        color: "gray.7",
         bg: "gray.1"
       },
       "&:active": {
+        color: "gray.7",
         bg: "gray.2"
       },
       "&:focus": {


### PR DESCRIPTION
## Overview
Fix for outlined buttons on the map getting a weird button color on hover.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
<img width="1680" alt="Screen Shot 2020-09-12 at 7 15 29 PM" src="https://user-images.githubusercontent.com/5672295/93002141-7647bb00-f52c-11ea-80b2-272d50279db1.png">

![districtbuilder_map_buttons](https://user-images.githubusercontent.com/5672295/93002171-ba3ac000-f52c-11ea-8d48-a9965c7e16d0.gif)



### Notes
- I also removed some extraneous styles and put the icon buttons closer to one another (I'd had a 1px gap before that looked a little strange in retrospect).

## Testing Instructions
- `git pull`
- Go to the map page
- Interact with the outlined buttons in the toolbar, the text should remain gray and not turn white on hover / active.

Closes #XXX
