### PR TITLE
Blocks button enabled by default

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -61,11 +61,9 @@ const style: ThemeUIStyleObject = {
 const buttonClassName = (isSelected: boolean) => `${isSelected ? "selected" : ""}`;
 
 const GeoLevelTooltip = ({
-  isGeoLevelHidden,
   areChangesPending,
   label
 }: {
-  readonly isGeoLevelHidden: boolean;
   readonly areChangesPending: boolean;
   readonly label: string;
 }) => {
@@ -73,14 +71,7 @@ const GeoLevelTooltip = ({
   return (
     <span>
       <strong>Disabled: </strong>
-      {isGeoLevelHidden && areChangesPending ? (
-        <span>{zoomText} and resolve changes</span>
-      ) : isGeoLevelHidden ? (
-        <span>{zoomText}</span>
-      ) : (
-        <strong>Resolve changes</strong>
-      )}
-      &nbsp;to edit {label.toLowerCase()}
+      Resolve changes to edit {label.toLowerCase()}
     </span>
   );
 };
@@ -104,7 +95,6 @@ const GeoLevelButton = ({
 }) => {
   const label = geoLevelLabel(value.id);
   const areGeoUnitsSelected = areAnyGeoUnitsSelected(selectedGeounits);
-  const isGeoLevelHidden = geoLevelVisibility[index] === false;
   const isBaseGeoLevelSelected = geoLevelIndex === geoLevelHierarchy.length - 1;
   const isCurrentLevelBaseGeoLevel = index === geoLevelHierarchy.length - 1;
   const areChangesPending =
@@ -115,7 +105,7 @@ const GeoLevelButton = ({
       (!isBaseGeoLevelSelected && isCurrentLevelBaseGeoLevel));
   // Always show the currently selected geolevel, even if it would otherwise be hidden
   const isCurrentLevelSelected = index === geoLevelIndex;
-  const isButtonDisabled = !isCurrentLevelSelected && (isGeoLevelHidden || areChangesPending);
+  const isButtonDisabled = !isCurrentLevelSelected && areChangesPending;
 
   return (
     <Box sx={{ display: "inline-block", position: "relative" }} className="button-wrapper">
@@ -123,11 +113,7 @@ const GeoLevelButton = ({
         key={index}
         content={
           isButtonDisabled ? (
-            <GeoLevelTooltip
-              isGeoLevelHidden={isGeoLevelHidden}
-              areChangesPending={areChangesPending}
-              label={label}
-            />
+            <GeoLevelTooltip areChangesPending={areChangesPending} label={label} />
           ) : (
             `Select ${label.toLowerCase()}`
           )

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -60,14 +60,7 @@ const style: ThemeUIStyleObject = {
 
 const buttonClassName = (isSelected: boolean) => `${isSelected ? "selected" : ""}`;
 
-const GeoLevelTooltip = ({
-  areChangesPending,
-  label
-}: {
-  readonly areChangesPending: boolean;
-  readonly label: string;
-}) => {
-  const zoomText = "Zoom in";
+const GeoLevelTooltip = ({ label }: { readonly label: string }) => {
   return (
     <span>
       <strong>Disabled: </strong>
@@ -81,7 +74,6 @@ const GeoLevelButton = ({
   value,
   geoLevelIndex,
   geoLevelHierarchy,
-  geoLevelVisibility,
   selectedGeounits,
   advancedEditingEnabled
 }: {
@@ -89,7 +81,6 @@ const GeoLevelButton = ({
   readonly value: GeoLevelInfo;
   readonly geoLevelIndex: number;
   readonly geoLevelHierarchy: GeoLevelHierarchy;
-  readonly geoLevelVisibility: readonly boolean[];
   readonly selectedGeounits: GeoUnits;
   readonly advancedEditingEnabled?: boolean;
 }) => {
@@ -112,11 +103,7 @@ const GeoLevelButton = ({
       <Tooltip
         key={index}
         content={
-          isButtonDisabled ? (
-            <GeoLevelTooltip areChangesPending={areChangesPending} label={label} />
-          ) : (
-            `Select ${label.toLowerCase()}`
-          )
+          isButtonDisabled ? <GeoLevelTooltip label={label} /> : `Select ${label.toLowerCase()}`
         }
       >
         <span>
@@ -149,7 +136,6 @@ const MapHeader = ({
   metadata,
   selectionTool,
   geoLevelIndex,
-  geoLevelVisibility,
   selectedGeounits,
   advancedEditingEnabled
 }: {
@@ -158,7 +144,6 @@ const MapHeader = ({
   readonly metadata?: IStaticMetadata;
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number;
-  readonly geoLevelVisibility: readonly boolean[];
   readonly selectedGeounits: GeoUnits;
   readonly advancedEditingEnabled?: boolean;
 }) => {
@@ -180,7 +165,6 @@ const MapHeader = ({
             value={val}
             geoLevelIndex={geoLevelIndex}
             geoLevelHierarchy={geoLevelHierarchy}
-            geoLevelVisibility={geoLevelVisibility}
             selectedGeounits={selectedGeounits}
             advancedEditingEnabled={advancedEditingEnabled}
           />

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -49,8 +49,8 @@ export function getGeolevelLinePaintStyle(geoLevel: string) {
 
   const mediumGeolevel = {
     "line-color": "#000",
-    "line-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.1, 14, 0.6],
-    "line-width": ["interpolate", ["linear"], ["zoom"], 6, 0.3, 14, 2.5]
+    "line-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.2, 14, 0.6],
+    "line-width": ["interpolate", ["linear"], ["zoom"], 6, 0.75, 14, 2.25]
   };
 
   const smallGeolevel = {
@@ -104,7 +104,8 @@ export function generateMapLayers(
       layout: {},
       paint: {
         "fill-color": { type: "identity", property: "color" },
-        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.66, 14, 0.45]
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 6, 0.66, 14, 0.45],
+        "fill-antialias": false
       }
     },
     DISTRICTS_PLACEHOLDER_LAYER_ID
@@ -147,7 +148,8 @@ export function generateMapLayers(
         "source-layer": level.id,
         paint: {
           "fill-color": "#000",
-          "fill-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 0.5, 0]
+          "fill-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 0.5, 0],
+          "fill-antialias": false
         }
       },
       HIGHLIGHTS_PLACEHOLDER_LAYER_ID
@@ -318,12 +320,15 @@ export function featuresToGeoUnits(
         .filter(feature => feature.sourceLayer === geoLevelId)
         .map((feature: MapboxGeoJSONFeature) => [
           feature.id as FeatureId,
-          geoLevelHierarchyKeys.reduce((geounitData, key) => {
-            const geounitId = feature.properties && feature.properties[key];
-            return geounitId !== undefined && geounitId !== null
-              ? [geounitId, ...geounitData]
-              : geounitData;
-          }, [] as readonly number[])
+          geoLevelHierarchyKeys.reduce(
+            (geounitData, key) => {
+              const geounitId = feature.properties && feature.properties[key];
+              return geounitId !== undefined && geounitId !== null
+                ? [geounitId, ...geounitData]
+                : geounitData;
+            },
+            [] as readonly number[]
+          )
         ])
     );
     return geounitData;

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -320,15 +320,12 @@ export function featuresToGeoUnits(
         .filter(feature => feature.sourceLayer === geoLevelId)
         .map((feature: MapboxGeoJSONFeature) => [
           feature.id as FeatureId,
-          geoLevelHierarchyKeys.reduce(
-            (geounitData, key) => {
-              const geounitId = feature.properties && feature.properties[key];
-              return geounitId !== undefined && geounitId !== null
-                ? [geounitId, ...geounitData]
-                : geounitData;
-            },
-            [] as readonly number[]
-          )
+          geoLevelHierarchyKeys.reduce((geounitData, key) => {
+            const geounitId = feature.properties && feature.properties[key];
+            return geounitId !== undefined && geounitId !== null
+              ? [geounitId, ...geounitData]
+              : geounitData;
+          }, [] as readonly number[])
         ])
     );
     return geounitData;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -132,7 +132,6 @@ const ProjectScreen = ({
             metadata={staticMetadata}
             selectionTool={districtDrawing.selectionTool}
             geoLevelIndex={districtDrawing.geoLevelIndex}
-            geoLevelVisibility={districtDrawing.geoLevelVisibility}
             selectedGeounits={districtDrawing.selectedGeounits}
             advancedEditingEnabled={project?.advancedEditingEnabled}
           />


### PR DESCRIPTION
## Overview

A user can enable block mode without zooming in. This makes it more clear that the block editing mode is available. Previously, when this button was disabled by default, it sent mixed signals—maybe this feature isn't built yet, or maybe I don't have access to it for a difficult-to-change reason. Depending on a tooltip to straighten that out wasn't enough.

Now a user can immediately click on the blocks button if they want. And they'll receive an appropriate warning to let them know the takeoffs of block editing. 

## Testing Instructions

- Create a new project
- In the new project, confirm that the "blocks" button visually appears enabled
- Click on the "blocks" button; you should see the blocks modal; click cancel
- Select a county on the map
- Confirm that the "blocks" button looks disabled
- Hover over the disabled "blocks" button; confirm that you see a tooltip that explains you need to resolve changes
- Resolve changes (click cancel or accept)
- Click on the "blocks" button and this time click "Start block editing"
- You should see a message overlay on the map that says you need to zoom in to edit blocks
- Zoom in; at some point, the message should disappear and you should see blocks!

Closes #407 
