### PR TITLE
Style pass on map tooltip

### DIFF
--- a/src/client/App.css
+++ b/src/client/App.css
@@ -16,3 +16,8 @@
 .mapboxgl-canvas {
   outline: none;
 }
+
+.tippy-box {
+  background-color: #141414 !important;
+  border-radius: 2px;
+}

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -9,15 +9,14 @@ const style: ThemeUIStyleObject = {
     textAlign: "left",
     py: 0,
     pr: 2,
-    textTransform: "capitalize",
-    fontSize: 1
+    textTransform: "capitalize"
   },
   number: {
     flex: "auto",
     textAlign: "right",
     fontVariant: "tabular-nums",
     py: 0,
-    fontSize: 1
+    fontWeight: "light"
   }
 };
 
@@ -72,7 +71,7 @@ const DemographicsTooltip = ({
   ));
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>
-      <Styled.table sx={{ margin: "0" }}>
+      <Styled.table sx={{ margin: "0", width: "100%" }}>
         <tbody>{rows}</tbody>
       </Styled.table>
     </Box>

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -18,9 +18,6 @@ import { State } from "../../reducers";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 
-const X_BUFFER = 300;
-const Y_BUFFER = 300;
-
 const getDemographics = memoize(getTotalSelectedDemographics);
 
 const style: ThemeUIStyleObject = {
@@ -38,7 +35,8 @@ const style: ThemeUIStyleObject = {
     p: 2,
     zIndex: 1,
     lineHeight: 1.3,
-    fontSize: 0
+    fontSize: 0,
+    willChange: "transform"
   }
 };
 
@@ -166,13 +164,8 @@ const MapTooltip = ({
           ).toLowerCase()}`
         : featureLabel();
 
-    const canvas = map.getCanvas();
-    const { width, height } = canvas;
-    const tooltipWidth = tooltipRef.current && tooltipRef.current.offsetWidth;
-    const tooltipHeight = tooltipRef.current && tooltipRef.current.offsetHeight;
-    const x = !tooltipWidth || width - point.x > X_BUFFER ? point.x : point.x - tooltipWidth - 40;
-    const y =
-      !tooltipHeight || height - point.y > Y_BUFFER ? point.y : point.y - tooltipHeight - 40;
+    const x = point.x;
+    const y = point.y;
 
     return demographics ? (
       <Box
@@ -196,7 +189,15 @@ const MapTooltip = ({
         )}
         <Grid gap={2} columns={[2, "1fr 2fr"]}>
           <Box>Pop.</Box>
-          <Box sx={{ fontVariant: "tabular-nums", ml: "7px", fontSize: 1, lineHeight: 1, fontWeight: "medium" }}>
+          <Box
+            sx={{
+              fontVariant: "tabular-nums",
+              ml: "7px",
+              fontSize: 1,
+              lineHeight: 1,
+              fontWeight: "medium"
+            }}
+          >
             {Number(demographics.population).toLocaleString()}
           </Box>
         </Grid>

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -32,11 +32,13 @@ const style: ThemeUIStyleObject = {
     height: "auto",
     borderRadius: "small",
     boxShadow: "small",
-    maxWidth: "160px",
+    width: "170px",
     overflow: "hidden",
     pointerEvents: "none",
     p: 2,
-    zIndex: 1
+    zIndex: 1,
+    lineHeight: 1.3,
+    fontSize: 0
   }
 };
 
@@ -179,11 +181,22 @@ const MapTooltip = ({
         sx={{ ...style.tooltip }}
       >
         {heading && (
-          <Heading sx={{ fontSize: 2, fontFamily: "heading", color: "muted" }}>{heading}</Heading>
+          <Heading
+            sx={{
+              fontSize: 1,
+              fontFamily: "heading",
+              color: "muted",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis"
+            }}
+          >
+            {heading}
+          </Heading>
         )}
         <Grid gap={2} columns={[2, "1fr 2fr"]}>
           <Box>Pop.</Box>
-          <Box sx={{ fontVariant: "tabular-nums", ml: "7px" }}>
+          <Box sx={{ fontVariant: "tabular-nums", ml: "7px", fontSize: 1, lineHeight: 1, fontWeight: "medium" }}>
             {Number(demographics.population).toLocaleString()}
           </Box>
         </Grid>

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -119,7 +119,7 @@ const theme: Theme & StyledSystemTheme = {
     medium: "750px",
     large: "1040px"
   },
-  fontSizes: [11, 13, 15, 18, 21, 31, 37, 54],
+  fontSizes: [12, 14, 16, 18, 21, 31, 37, 54],
   fontWeights: {
     light: 300,
     medium: 500,


### PR DESCRIPTION
## Overview

Style cleanup on the map tooltip. Tighten line-height to make it easier to compare bars in race chart, set fixed size so the size of the tooltip doesn't change as much, making it easier to quickly scan as it changes. I made the colors match for the map tool tips and tooltips that appear elsewhere in the application. I also removed the repositioning when the tooltip approaches the side of the screen (more on that in the notes).

### Demo

![Screen Shot 2020-09-13 at 5 15 01 PM](https://user-images.githubusercontent.com/1809908/93095571-43f3a600-f671-11ea-95e2-b721fcdbf001.png)

### Notes

@maurizi I removed the tooltip repositioning in this PR. I wanted to address that since the repositioning was a feature I had requested and I believe you implemented. While this feature made sense to me in abstract, in practice I found it annoying to have the tooltip jump around unexpectedly. I think you did a great job implementing it, and I wanted to be clear that this isn't a knock on your code. Just one of those iterative moments where I realize one of my ideas doesn't work out as well as I had hoped.

## Testing Instructions

- Open a project
- Make sure the tooltip looks similar to the screenshot
- Confirm that when you look at the tooltip for many geounits, the width of the tooltip remains consistent
- When you move to the right side of the screen, the tooltip should no longer reposition itself

Closes #279
