### PR TITLE
Allow for selecting partially locked districts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Allow for selecting partially locked districts [#420](https://github.com/PublicMapping/districtbuilder/pull/420)
 
 ### Changed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -15,6 +15,7 @@ export const editSelectedGeounits = createAction("Edit selected geounits")<{
   readonly add?: GeoUnits;
   readonly remove?: GeoUnits;
 }>();
+export const setSelectedGeounits = createAction("Set selected geounits")<GeoUnits>();
 
 export const setHighlightedGeounits = createAction("Add highlighted geounit ids")<GeoUnits>();
 export const clearHighlightedGeounits = createAction("Clear highlighted geounit ids")();

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -69,6 +69,7 @@ const DefaultSelectionTool: ISelectionTool = {
         // Geounit is selected, so deselect it
         map.setFeatureState(featureStateGeoLevel(feature), { selected: false });
         store.dispatch(removeSelectedGeounits(geoUnits));
+        // eslint-disable-next-line
       } else {
         // Geounit is not selected, so select it, making sure to remove the selection on any child
         // geounits since the parent selection supercedes any child selections

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -15,7 +15,8 @@ import {
   FeatureId,
   GeoUnitIndices,
   IStaticMetadata,
-  LockedDistricts
+  LockedDistricts,
+  UintArrays
 } from "../../../shared/entities";
 
 /*
@@ -27,7 +28,8 @@ const DefaultSelectionTool: ISelectionTool = {
     geoLevelId: string,
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
-    lockedDistricts: LockedDistricts
+    lockedDistricts: LockedDistricts,
+    staticGeoLevels: UintArrays
   ) {
     /* eslint-disable */
     this.setCursor = () => (map.getCanvas().style.cursor = "pointer");
@@ -57,9 +59,10 @@ const DefaultSelectionTool: ISelectionTool = {
 
       const geoUnits = featuresToUnlockedGeoUnits(
         [feature],
-        staticMetadata.geoLevelHierarchy,
+        staticMetadata,
         districtsDefinition,
-        lockedDistricts
+        lockedDistricts,
+        staticGeoLevels
       );
       const geoUnitsForLevel = geoUnits[geoLevelId] || new Map();
       const addFeatures = () => {
@@ -71,9 +74,10 @@ const DefaultSelectionTool: ISelectionTool = {
         });
         const subGeoUnits = featuresToUnlockedGeoUnits(
           subFeatures,
-          staticMetadata.geoLevelHierarchy,
+          staticMetadata,
           districtsDefinition,
-          lockedDistricts
+          lockedDistricts,
+          staticGeoLevels
         );
         store.dispatch(
           editSelectedGeounits({

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -28,22 +28,24 @@ function areAllUnlockedChildGeoUnitsSelected(
   unlockedGeoUnits: GeoUnits,
   geoUnitForFeature: GeoUnitIndices | undefined,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays,
-  childGeoLevelId: string | undefined
+  staticGeoLevels: UintArrays
 ): boolean {
-  if (!geoUnitForFeature || !childGeoLevelId) {
+  if (!geoUnitForFeature) {
     return false;
   } else {
-    const childGeoUnits = getChildGeoUnits(geoUnitForFeature, staticMetadata, staticGeoLevels)
-      .childGeoUnits;
+    const { childGeoUnits, childGeoLevel } = getChildGeoUnits(
+      geoUnitForFeature,
+      staticMetadata,
+      staticGeoLevels
+    );
     return (
       childGeoUnits &&
       allGeoUnitIds(childGeoUnits)
-        .filter(featureId => unlockedGeoUnits[childGeoLevelId].has(featureId))
+        .filter(featureId => unlockedGeoUnits[childGeoLevel.id].has(featureId))
         .every(featureId =>
           isFeatureSelected(map, {
             id: featureId,
-            sourceLayer: childGeoLevelId
+            sourceLayer: childGeoLevel.id
           })
         )
     );
@@ -57,7 +59,6 @@ const DefaultSelectionTool: ISelectionTool = {
   enable: function(
     map: MapboxGL.Map,
     geoLevelId: string,
-    childGeoLevelId: string | undefined,
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
@@ -106,8 +107,7 @@ const DefaultSelectionTool: ISelectionTool = {
         unlockedGeoUnits,
         geoUnitForFeature,
         staticMetadata,
-        staticGeoLevels,
-        childGeoLevelId
+        staticGeoLevels
       );
       // eslint-disable-next-line
       if (isSelected) {

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -23,7 +23,7 @@ import {
   UintArrays
 } from "../../../shared/entities";
 
-function areAnyChildGeoUnitsSelected(
+function areAllUnlockedChildGeoUnitsSelected(
   map: MapboxGL.Map,
   unlockedGeoUnits: GeoUnits,
   geoUnitForFeature: GeoUnitIndices | undefined,
@@ -38,14 +38,14 @@ function areAnyChildGeoUnitsSelected(
     .childGeoUnits;
   return (
     childGeoUnits &&
-    allGeoUnitIds(childGeoUnits).some(
-      featureId =>
-        unlockedGeoUnits[childGeoLevelId].has(featureId) &&
+    allGeoUnitIds(childGeoUnits)
+      .filter(featureId => unlockedGeoUnits[childGeoLevelId].has(featureId))
+      .every(featureId =>
         isFeatureSelected(map, {
           id: featureId,
           sourceLayer: childGeoLevelId
         })
-    )
+      )
   );
 }
 
@@ -100,7 +100,7 @@ const DefaultSelectionTool: ISelectionTool = {
       const geoUnitForFeature = geoUnits[geoLevelId].get(feature.id as FeatureId);
       const unlockedGeoUnitForFeature = unlockedGeoUnits[geoLevelId].get(feature.id as FeatureId);
       const isPartiallyLocked = geoUnitForFeature && !unlockedGeoUnitForFeature;
-      const isPartiallySelected = areAnyChildGeoUnitsSelected(
+      const isPartiallySelected = areAllUnlockedChildGeoUnitsSelected(
         map,
         unlockedGeoUnits,
         geoUnitForFeature,

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -33,20 +33,21 @@ function areAllUnlockedChildGeoUnitsSelected(
 ): boolean {
   if (!geoUnitForFeature || !childGeoLevelId) {
     return false;
+  } else {
+    const childGeoUnits = getChildGeoUnits(geoUnitForFeature, staticMetadata, staticGeoLevels)
+      .childGeoUnits;
+    return (
+      childGeoUnits &&
+      allGeoUnitIds(childGeoUnits)
+        .filter(featureId => unlockedGeoUnits[childGeoLevelId].has(featureId))
+        .every(featureId =>
+          isFeatureSelected(map, {
+            id: featureId,
+            sourceLayer: childGeoLevelId
+          })
+        )
+    );
   }
-  const childGeoUnits = getChildGeoUnits(geoUnitForFeature, staticMetadata, staticGeoLevels)
-    .childGeoUnits;
-  return (
-    childGeoUnits &&
-    allGeoUnitIds(childGeoUnits)
-      .filter(featureId => unlockedGeoUnits[childGeoLevelId].has(featureId))
-      .every(featureId =>
-        isFeatureSelected(map, {
-          id: featureId,
-          sourceLayer: childGeoLevelId
-        })
-      )
-  );
 }
 
 /*

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -72,7 +72,6 @@ const DistrictsMap = ({
   const [b0, b1, b2, b3] = staticMetadata.bbox;
 
   const selectedGeolevel = getSelectedGeoLevel(staticMetadata.geoLevelHierarchy, geoLevelIndex);
-  const nextGeoLevel = getSelectedGeoLevel(staticMetadata.geoLevelHierarchy, geoLevelIndex + 1);
 
   const minZoom = Math.min(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.minZoom));
   const maxZoom = Math.max(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.maxZoom));
@@ -325,7 +324,6 @@ const DistrictsMap = ({
         DefaultSelectionTool.enable(
           map,
           selectedGeolevel.id,
-          nextGeoLevel ? nextGeoLevel.id : undefined,
           staticMetadata,
           project.districtsDefinition,
           lockedDistricts,
@@ -347,7 +345,6 @@ const DistrictsMap = ({
     map,
     selectionTool,
     selectedGeolevel,
-    nextGeoLevel,
     staticMetadata,
     staticDemographics,
     staticGeoLevels,

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -72,6 +72,7 @@ const DistrictsMap = ({
   const [b0, b1, b2, b3] = staticMetadata.bbox;
 
   const selectedGeolevel = getSelectedGeoLevel(staticMetadata.geoLevelHierarchy, geoLevelIndex);
+  const nextGeoLevel = getSelectedGeoLevel(staticMetadata.geoLevelHierarchy, geoLevelIndex + 1);
 
   const minZoom = Math.min(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.minZoom));
   const maxZoom = Math.max(...staticMetadata.geoLevelHierarchy.map(geoLevel => geoLevel.maxZoom));
@@ -324,6 +325,7 @@ const DistrictsMap = ({
         DefaultSelectionTool.enable(
           map,
           selectedGeolevel.id,
+          nextGeoLevel ? nextGeoLevel.id : undefined,
           staticMetadata,
           project.districtsDefinition,
           lockedDistricts,
@@ -345,6 +347,7 @@ const DistrictsMap = ({
     map,
     selectionTool,
     selectedGeolevel,
+    nextGeoLevel,
     staticMetadata,
     staticDemographics,
     staticGeoLevels,

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -245,7 +245,7 @@ const RectangleSelectionTool: ISelectionTool = {
           staticGeoLevels
         );
         // Deselect any child features as appropriate (this comes into a play when, for example, a
-        // blockground is selected and then the county _containing_ that blockgroup is selected)
+        // blockgroup is selected and then the county _containing_ that blockgroup is selected)
         Object.values(geoUnits).forEach(geoUnitsForLevel => {
           geoUnitsForLevel.forEach(geoUnitIndices => {
             // Ignore bottom two geolevels (base geounits can't have sub-features and base geounits

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -23,7 +23,8 @@ import {
   GeoUnits,
   GeoUnitIndices,
   IStaticMetadata,
-  LockedDistricts
+  LockedDistricts,
+  UintArrays
 } from "../../../shared/entities";
 
 const throttledSetHighlightedGeounits = throttle(
@@ -48,7 +49,8 @@ const RectangleSelectionTool: ISelectionTool = {
     geoLevelId: string,
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
-    lockedDistricts: LockedDistricts
+    lockedDistricts: LockedDistricts,
+    staticGeoLevels: UintArrays
   ) {
     map.boxZoom.disable();
     map.dragPan.disable();
@@ -114,9 +116,10 @@ const RectangleSelectionTool: ISelectionTool = {
       const features = getFeaturesInBoundingBox([start, current]);
       const geoUnits = featuresToUnlockedGeoUnits(
         features,
-        staticMetadata.geoLevelHierarchy,
+        staticMetadata,
         districtsDefinition,
-        lockedDistricts
+        lockedDistricts,
+        staticGeoLevels
       );
       const geoUnitsForLevel = geoUnits[geoLevelId] || new Map();
 
@@ -138,9 +141,10 @@ const RectangleSelectionTool: ISelectionTool = {
       if (prevFeatures) {
         const prevGeoUnits = featuresToUnlockedGeoUnits(
           prevFeatures,
-          staticMetadata.geoLevelHierarchy,
+          staticMetadata,
           districtsDefinition,
-          lockedDistricts
+          lockedDistricts,
+          staticGeoLevels
         );
         Array.from(prevGeoUnits[geoLevelId].keys())
           .filter(
@@ -159,9 +163,10 @@ const RectangleSelectionTool: ISelectionTool = {
 
       setOfInitiallySelectedFeatures = featuresToUnlockedGeoUnits(
         getFeaturesInBoundingBox().filter(feature => isFeatureSelected(map, feature)),
-        staticMetadata.geoLevelHierarchy,
+        staticMetadata,
         districtsDefinition,
-        lockedDistricts
+        lockedDistricts,
+        staticGeoLevels
       );
 
       // Capture the first xy coordinates
@@ -213,9 +218,10 @@ const RectangleSelectionTool: ISelectionTool = {
         const selectedFeatures = getFeaturesInBoundingBox(bbox);
         const geoUnits = featuresToUnlockedGeoUnits(
           selectedFeatures,
-          staticMetadata.geoLevelHierarchy,
+          staticMetadata,
           districtsDefinition,
-          lockedDistricts
+          lockedDistricts,
+          staticGeoLevels
         );
         const geoUnitsForLevel = geoUnits[geoLevelId] || new Map();
         const subFeatures = selectedFeatures.flatMap(feature => {
@@ -232,9 +238,10 @@ const RectangleSelectionTool: ISelectionTool = {
         });
         const subGeoUnits = featuresToUnlockedGeoUnits(
           subFeatures,
-          staticMetadata.geoLevelHierarchy,
+          staticMetadata,
           districtsDefinition,
-          lockedDistricts
+          lockedDistricts,
+          staticGeoLevels
         );
         store.dispatch(
           editSelectedGeounits({

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -139,11 +139,15 @@ const RectangleSelectionTool: ISelectionTool = {
         },
         geoUnits
       );
+      // Select new features
       setFeaturesSelectedFromGeoUnits(map, newGeoUnits, true);
+      // Deselect any child features as appropriate (this comes into a play when, for example, a
+      // blockground is selected and then the county _containing_ that blockgroup is selected)
       Object.values(newGeoUnits).forEach(geoUnitsForLevel => {
         geoUnitsForLevel.forEach(geoUnitIndices => {
           // Ignore bottom two geolevels (base geounits can't have sub-features and base geounits
           // also can't be selected at the same time as features from one geolevel up)
+          // eslint-disable-next-line
           if (geoUnitIndices.length <= staticMetadata.geoLevelHierarchy.length - 2) {
             const { childGeoUnits } = getChildGeoUnits(
               geoUnitIndices,

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -141,23 +141,6 @@ const RectangleSelectionTool: ISelectionTool = {
       );
       // Select new features
       setFeaturesSelectedFromGeoUnits(map, newGeoUnits, true);
-      // Deselect any child features as appropriate (this comes into a play when, for example, a
-      // blockground is selected and then the county _containing_ that blockgroup is selected)
-      Object.values(newGeoUnits).forEach(geoUnitsForLevel => {
-        geoUnitsForLevel.forEach(geoUnitIndices => {
-          // Ignore bottom two geolevels (base geounits can't have sub-features and base geounits
-          // also can't be selected at the same time as features from one geolevel up)
-          // eslint-disable-next-line
-          if (geoUnitIndices.length <= staticMetadata.geoLevelHierarchy.length - 2) {
-            const { childGeoUnits } = getChildGeoUnits(
-              geoUnitIndices,
-              staticMetadata,
-              staticGeoLevels
-            );
-            setFeaturesSelectedFromGeoUnits(map, childGeoUnits, false);
-          }
-        });
-      });
 
       throttledSetHighlightedGeounits(newGeoUnits);
 
@@ -248,6 +231,23 @@ const RectangleSelectionTool: ISelectionTool = {
           lockedDistricts,
           staticGeoLevels
         );
+        // Deselect any child features as appropriate (this comes into a play when, for example, a
+        // blockground is selected and then the county _containing_ that blockgroup is selected)
+        Object.values(geoUnits).forEach(geoUnitsForLevel => {
+          geoUnitsForLevel.forEach(geoUnitIndices => {
+            // Ignore bottom two geolevels (base geounits can't have sub-features and base geounits
+            // also can't be selected at the same time as features from one geolevel up)
+            // eslint-disable-next-line
+            if (geoUnitIndices.length <= staticMetadata.geoLevelHierarchy.length - 2) {
+              const { childGeoUnits } = getChildGeoUnits(
+                geoUnitIndices,
+                staticMetadata,
+                staticGeoLevels
+              );
+              setFeaturesSelectedFromGeoUnits(map, childGeoUnits, false);
+            }
+          });
+        });
         store.dispatch(setSelectedGeounits(mergedGeoUnits(geoUnits, initiallySelectedGeoUnits)));
       }
       store.dispatch(clearHighlightedGeounits());

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -170,7 +170,7 @@ const RectangleSelectionTool: ISelectionTool = {
       document.addEventListener("mouseup", onMouseUp);
 
       initiallySelectedGeoUnits = featuresToUnlockedGeoUnits(
-        getFeaturesInBoundingBox().filter(feature => isFeatureSelected(map, feature)),
+        getAllSelectedFeatures(),
         staticMetadata,
         districtsDefinition,
         lockedDistricts,
@@ -201,11 +201,21 @@ const RectangleSelectionTool: ISelectionTool = {
 
     function getFeaturesInBoundingBox(
       // eslint-disable-next-line
-      bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]
+      bbox: [MapboxGL.PointLike, MapboxGL.PointLike]
     ): readonly MapboxGL.MapboxGeoJSONFeature[] {
       return map.queryRenderedFeatures(bbox, {
         layers: [levelToSelectionLayerId(geoLevelId)]
       });
+    }
+
+    function getAllSelectedFeatures(): readonly MapboxGL.MapboxGeoJSONFeature[] {
+      return map
+        .queryRenderedFeatures(undefined, {
+          layers: staticMetadata.geoLevelHierarchy.map(geoLevel =>
+            levelToSelectionLayerId(geoLevel.id)
+          )
+        })
+        .filter(feature => isFeatureSelected(map, feature));
     }
 
     // eslint-disable-next-line

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -16,11 +16,11 @@ import {
   setFeaturesSelectedFromGeoUnits,
   getChildGeoUnits
 } from "./index";
+import { mergedGeoUnits } from "../../functions";
 
 import {
   DistrictsDefinition,
   GeoUnits,
-  MutableGeoUnits,
   IStaticMetadata,
   LockedDistricts,
   UintArrays
@@ -244,15 +244,7 @@ const RectangleSelectionTool: ISelectionTool = {
           lockedDistricts,
           staticGeoLevels
         );
-        const mergedGeoUnits: MutableGeoUnits = {};
-        Object.entries(geoUnits).forEach(([geoLevelId, geoUnitsForLevel]) => {
-          const mergedGeoUnitsForLevel = new Map(geoUnitsForLevel);
-          initiallySelectedGeoUnits[geoLevelId].forEach((geoUnitIndices, featureId) => {
-            mergedGeoUnitsForLevel.set(featureId, geoUnitIndices);
-          });
-          mergedGeoUnits[geoLevelId] = mergedGeoUnitsForLevel;
-        });
-        store.dispatch(setSelectedGeounits(mergedGeoUnits));
+        store.dispatch(setSelectedGeounits(mergedGeoUnits(geoUnits, initiallySelectedGeoUnits)));
       }
       store.dispatch(clearHighlightedGeounits());
     }

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -16,7 +16,7 @@ import {
   setFeaturesSelectedFromGeoUnits,
   getChildGeoUnits
 } from "./index";
-import { mergedGeoUnits } from "../../functions";
+import { mergeGeoUnits } from "../../functions";
 
 import {
   DistrictsDefinition,
@@ -258,7 +258,7 @@ const RectangleSelectionTool: ISelectionTool = {
             }
           });
         });
-        store.dispatch(setSelectedGeounits(mergedGeoUnits(geoUnits, initiallySelectedGeoUnits)));
+        store.dispatch(setSelectedGeounits(mergeGeoUnits(geoUnits, initiallySelectedGeoUnits)));
       }
       store.dispatch(clearHighlightedGeounits());
     }

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -208,6 +208,9 @@ const RectangleSelectionTool: ISelectionTool = {
       });
     }
 
+    /*
+     * Get all selected features for all geolevels.
+     */
     function getAllSelectedFeatures(): readonly MapboxGL.MapboxGeoJSONFeature[] {
       return map
         .queryRenderedFeatures(undefined, {

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -335,6 +335,9 @@ export function featuresToGeoUnits(
   }, {});
 }
 
+/*
+ * Return child geounits (direct descendents-only)
+ */
 export function getChildGeoUnits(
   geoUnitIndices: GeoUnitIndices,
   staticMetadata: IStaticMetadata,

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -262,7 +262,7 @@ function isGeoUnitLocked(
     : // Check if any district at this geolevel is locked
       districtsDefinition.some(districtId =>
         typeof districtId === "number"
-          ? // Whole district is assigned so it can be looked up direclty
+          ? // Whole district is assigned so it can be looked up directly
             lockedDistricts.has(districtId)
           : // District definition has more nesting so it must be followed further
             isGeoUnitLocked(districtId, lockedDistricts, geoUnitIndices)
@@ -348,22 +348,22 @@ export function getChildGeoUnits(
 ) {
   const childGeoLevelIdx = staticMetadata.geoLevelHierarchy.length - geoUnitIndices.length - 1;
   const childGeoLevel = staticMetadata.geoLevelHierarchy[childGeoLevelIdx];
-  // eslint-disable-next-line
   if (!childGeoLevel) {
     return {
       childGeoLevel,
       childGeoUnitIds: [],
       childGeoUnits: {}
     };
+  } else {
+    const geoUnitIdx = geoUnitIndices[0];
+    const childGeoUnitIds = getAllIndices(staticGeoLevels[childGeoLevelIdx], new Set([geoUnitIdx]));
+    const childGeoUnits = {
+      [childGeoLevel.id]: new Map(
+        childGeoUnitIds.map((id, index) => [id, [...geoUnitIndices, index]])
+      )
+    };
+    return { childGeoLevel, childGeoUnitIds, childGeoUnits };
   }
-  const geoUnitIdx = geoUnitIndices[0];
-  const childGeoUnitIds = getAllIndices(staticGeoLevels[childGeoLevelIdx], new Set([geoUnitIdx]));
-  const childGeoUnits = {
-    [childGeoLevel.id]: new Map(
-      childGeoUnitIds.map((id, index) => [id, [...geoUnitIndices, index]])
-    )
-  };
-  return { childGeoLevel, childGeoUnitIds, childGeoUnits };
 }
 
 export function onlyUnlockedGeoUnits(

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -342,6 +342,7 @@ export function getChildGeoUnits(
 ) {
   const childGeoLevelIdx = staticMetadata.geoLevelHierarchy.length - geoUnitIndices.length - 1;
   const childGeoLevel = staticMetadata.geoLevelHierarchy[childGeoLevelIdx];
+  // eslint-disable-next-line
   if (!childGeoLevel) {
     return {
       childGeoLevel,

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -260,8 +260,12 @@ function isGeoUnitLocked(
     ? // Check if this specific district is locked
       lockedDistricts.has(districtsDefinition)
     : // Check if any district at this geolevel is locked
-      districtsDefinition.some(
-        districtId => typeof districtId === "number" && lockedDistricts.has(districtId)
+      districtsDefinition.some(districtId =>
+        typeof districtId === "number"
+          ? // Whole district is assigned so it can be looked up direclty
+            lockedDistricts.has(districtId)
+          : // District definition has more nesting so it must be followed further
+            isGeoUnitLocked(districtId, lockedDistricts, geoUnitIndices)
       );
 }
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -315,7 +315,6 @@ export function featuresToGeoUnits(
     // the same set). Here the feature id is used as the key which we also want
     // to keep track of for map management. Note that if keys are duplicated the
     // value set last will be used (thus achieving the uniqueness of sets).
-    // eslint-disable-next-line
     return {
       ...geounitData,
       [geoLevelId]: new Map(

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -207,7 +207,7 @@ export function destructureResource<T extends object>(
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
 }
 
-export function mergedGeoUnits(geoUnitsA: GeoUnits, geoUnitsB: GeoUnits): GeoUnits {
+export function mergeGeoUnits(geoUnitsA: GeoUnits, geoUnitsB: GeoUnits): GeoUnits {
   const mergedGeoUnits: MutableGeoUnits = {};
   Object.entries(geoUnitsA).forEach(([geoLevelId, geoUnitsForLevel]) => {
     const mergedGeoUnitsForLevel = new Map(geoUnitsForLevel);

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -10,7 +10,8 @@ import {
   GeoUnitIndices,
   GeoUnitHierarchy,
   IStaticMetadata,
-  NestedArray
+  NestedArray,
+  MutableGeoUnits
 } from "../shared/entities";
 import { Resource } from "./resource";
 import { getDemographics as getDemographicsBase } from "../shared/functions";
@@ -204,4 +205,16 @@ export function destructureResource<T extends object>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any | undefined {
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
+}
+
+export function mergedGeoUnits(a: GeoUnits, b: GeoUnits): GeoUnits {
+  const mergedGeoUnits: MutableGeoUnits = {};
+  Object.entries(a).forEach(([geoLevelId, geoUnitsForLevel]) => {
+    const mergedGeoUnitsForLevel = new Map(geoUnitsForLevel);
+    b[geoLevelId].forEach((geoUnitIndices, featureId) => {
+      mergedGeoUnitsForLevel.set(featureId, geoUnitIndices);
+    });
+    mergedGeoUnits[geoLevelId] = mergedGeoUnitsForLevel;
+  });
+  return mergedGeoUnits;
 }

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -207,13 +207,14 @@ export function destructureResource<T extends object>(
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
 }
 
-export function mergedGeoUnits(a: GeoUnits, b: GeoUnits): GeoUnits {
+export function mergedGeoUnits(geoUnitsA: GeoUnits, geoUnitsB: GeoUnits): GeoUnits {
   const mergedGeoUnits: MutableGeoUnits = {};
-  Object.entries(a).forEach(([geoLevelId, geoUnitsForLevel]) => {
+  Object.entries(geoUnitsA).forEach(([geoLevelId, geoUnitsForLevel]) => {
     const mergedGeoUnitsForLevel = new Map(geoUnitsForLevel);
-    b[geoLevelId].forEach((geoUnitIndices, featureId) => {
+    geoUnitsB[geoLevelId].forEach((geoUnitIndices, featureId) => {
       mergedGeoUnitsForLevel.set(featureId, geoUnitIndices);
     });
+    // eslint-disable-next-line
     mergedGeoUnits[geoLevelId] = mergedGeoUnitsForLevel;
   });
   return mergedGeoUnits;

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -10,8 +10,7 @@ import {
   GeoUnitIndices,
   GeoUnitHierarchy,
   IStaticMetadata,
-  NestedArray,
-  MutableGeoUnits
+  NestedArray
 } from "../shared/entities";
 import { Resource } from "./resource";
 import { getDemographics as getDemographicsBase } from "../shared/functions";
@@ -211,15 +210,11 @@ export function destructureResource<T extends object>(
   return "resource" in resourceT ? resourceT.resource[key] : undefined;
 }
 
-export function mergeGeoUnits(geoUnitsA: GeoUnits, geoUnitsB: GeoUnits): GeoUnits {
-  const mergedGeoUnits: MutableGeoUnits = {};
-  Object.entries(geoUnitsA).forEach(([geoLevelId, geoUnitsForLevel]) => {
-    const mergedGeoUnitsForLevel = new Map(geoUnitsForLevel);
-    geoUnitsB[geoLevelId].forEach((geoUnitIndices, featureId) => {
-      mergedGeoUnitsForLevel.set(featureId, geoUnitIndices);
-    });
-    // eslint-disable-next-line
-    mergedGeoUnits[geoLevelId] = mergedGeoUnitsForLevel;
-  });
-  return mergedGeoUnits;
+export function mergeGeoUnits(a: GeoUnits, b: GeoUnits): GeoUnits {
+  const geoLevels = [...new Set([...Object.keys(a), ...Object.keys(b)])];
+  return Object.fromEntries(
+    geoLevels.map(geoLevelId => {
+      return [geoLevelId, new Map([...(a[geoLevelId] || []), ...(b[geoLevelId] || [])])];
+    })
+  );
 }

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -73,6 +73,10 @@ export function allGeoUnitIndices(geoUnits: GeoUnits) {
   return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.values()));
 }
 
+export function allGeoUnitIds(geoUnits: GeoUnits) {
+  return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.keys()));
+}
+
 // Aggregate all demographics that are included in the selection
 function getTotalSelectedDemographicsBase(
   staticMetadata: IStaticMetadata,

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -13,6 +13,7 @@ import {
   setHighlightedGeounits,
   setSelectedDistrictId,
   setSelectionTool,
+  setSelectedGeounits,
   showAdvancedEditingModal,
   toggleDistrictLocked
 } from "../actions/districtDrawing";
@@ -127,6 +128,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
           action.payload.add,
           action.payload.remove
         )
+      };
+    case getType(setSelectedGeounits):
+      return {
+        ...state,
+        selectedGeounits: action.payload
       };
     case getType(clearSelectedGeounits):
       return {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -131,8 +131,12 @@ export type FeatureId = number;
 export type GeoUnitsForLevel = ReadonlyMap<FeatureId, GeoUnitIndices>;
 
 export interface GeoUnits {
+  readonly [geoLevelId: string]: GeoUnitsForLevel;
+}
+
+export interface MutableGeoUnits {
   // eslint-disable-next-line
-  [geoLevelId: string]: GeoUnitsForLevel;
+  [geoLevelId: string]: Map<FeatureId, GeoUnitIndices>;
 }
 
 export type CompactnessScore = number | null | "non-contiguous";


### PR DESCRIPTION
## Overview
Allow for selecting partially locked districts.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
Selecting/deselecting locked counties
![db_partially_locked_final](https://user-images.githubusercontent.com/2926237/93124548-c68f5c00-f697-11ea-8869-4e83ae78a2ab.gif)

Partial selection with locked blocks (messaging will be added to improve the UX of this in https://github.com/PublicMapping/districtbuilder/issues/417)
![db_partially_locked_selection_ui_weirdness](https://user-images.githubusercontent.com/2926237/93124660-ee7ebf80-f697-11ea-923b-d1c6cb1a1902.gif)

### Notes
There were a couple of existing bugs that I ran into which had to be smoothed out to get everything working:
* For the rectangle selection tool, `getFeaturesInBoundingBox` only returned features at the currently selected geolevel, though since we made the change to allow for working with multiple levels at once, we need to get all features from all levels (that's what the new `getAllSelectedFeatures` does)
* `isGeoUnitLocked` wasn't quite working as advertised and would quit recursing too early if the district definition was jagged which could result in incorrect behavior

Much of the meat of the changes was to `onlyUnlockedGeoUnits` which needed to be modified to break out a geounit such as a county into its constituent unlocked sub-geounits. I kept things imperative-style since the `Map` API is imperative, for better or for worse. I'm not totally sure about the name `removeLockedGeoUnits` since it removes geounits that are partially locked and _adds_ the unlocked child geounits, but I think it does get the idea across and there is a docstring to try to explain it.

There is a good amount of complexity within the selection tools. There already was a good amount of complexity to the rectangle selection tool, though it didn't have to change all that much (complexity stayed about the same). The default selection tool did need to become significantly more complex because it needed to support the selection _and_ deselection of partially locked geounits. I added quite a few comments there to make that as clear as I could.

I ended up adding a helper function `getChildGeoUnits` which is used liberally for implementing this functionality. It returns child geounits but no further (no grandchildren). This seems fine for now since we're only dealing with breaking up counties into blockgroups at the moment. This function is also now used instead of the now defunct `findSelectedSubFeatures` which queried the Mapbox map. Given the limitations around Mapbox only returning features within the current viewport it seems preferable to use our own static metadata for feature querying whenever possible (and I would think it would be faster though I'm not sure about that).

## Testing Instructions
* Select a blockgroup and assign it to a district
* Lock that district
* Using the default selection tool, select the county containing the locked blockgroup
* Ensure all non-locked blockgroups are selected
* Deselect the county and all of the blockgroups should be deselected
* Select a single blockgroup and then select the whole county containing the blockgroup
* Ensure the single blockgroup is not double-selected
* Assign a block to the locked district
* Try to select the blockgroup which contains it (nothing should happen)
* Try to select the county which contains the blockgroup (all the blockgroups except the one containing the locked block should be selected)

Closes #323 
