### PR TITLE
Upgrade development database to PostgreSQL 12.2 and PostGIS 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reduce noise in log output [#399](https://github.com/PublicMapping/districtbuilder/pull/399)
+- Upgrade development database to PostgreSQL 12.2 and PostGIS 3 [#421](https://github.com/PublicMapping/districtbuilder/pull/421)
 
 ### Fixed
 - Fix S3 permissions to allow CloudFront logging [#410](https://github.com/PublicMapping/districtbuilder/pull/410)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:2.5-postgres11.5-slim
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
     environment:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder


### PR DESCRIPTION
## Overview

Upgrades the `docker-compose.yml` `database` service definition to use PostgreSQL 12.2 and PostGIS 3.

RDS supports PostgreSQL 12.2 and 12.3, so we'll be able to have version parity between development and staging / production.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

### To migrate an existing development database
- Run the following commands to backup the PostgreSQL 11 database and restore it to PostgreSQL 12:
  ```#bash
  # Use the Compose service definition for PostgreSQL 11
  git checkout develop
  # Create a logical backup 
  docker-compose exec -T database bash -c 'pg_dumpall -U $POSTGRES_USER' > dump.sql
  # Checkout this PR to use the Compose service definition for PostgreSQL 12
  git checkout feature/cek/postgresql-12-development
  # Recreate the database service with a new data volume
  docker-compose up -dV database
  # Import the logical backup
  docker-compose exec -T database bash -c 'psql -U $POSTGRES_USER' < dump.sql
  ```
- Run `./scripts/update` to build all of the application containers.
- Run `./scripts/migration` and confirm that no migrations need to be run.
- Run `./scripts/server` and verify that you are able to log in with your existing username and password.

### For a new development database
- Run `docker-compose up -dV` to disassociate the development database from its old data volume and recreate it with a new volume.
- Run `./scripts/update` to build all of the application containers.
- Run `./scripts/migration` to migrate the new database.
- Run `./scripts/server` and verify that you are able to register a new user and log in.

Closes #339
