### PR TITLE
Bigger click area and hover state for lock button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for selecting partially locked districts [#420](https://github.com/PublicMapping/districtbuilder/pull/420)
 
 ### Changed
+- Improved lock button UX [#436](https://github.com/PublicMapping/districtbuilder/pull/436)
 - Reduce noise in log output [#399](https://github.com/PublicMapping/districtbuilder/pull/399)
 - Upgrade development database to PostgreSQL 12.2 and PostGIS 3 [#421](https://github.com/PublicMapping/districtbuilder/pull/421)
 

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -39,7 +39,14 @@ interface SupportProps {
 const ProjectHeader = ({ project }: { readonly project?: IProject } & SupportProps) => (
   <Flex sx={style.projectHeader}>
     <Flex sx={{ variant: "header.left" }}>
-      <Link to="/" sx={{ lineHeight: "0" }}>
+      <Link
+        to="/"
+        sx={{
+          lineHeight: "0",
+          borderRadius: "small",
+          "&:focus": { outline: "none", boxShadow: "focus" }
+        }}
+      >
         <Logo sx={{ width: "1.75rem" }} />
       </Link>
       <HeaderDivider />

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -57,10 +57,15 @@ const style: ThemeUIStyleObject = {
     flexDirection: "column",
     flexShrink: 0,
     height: "100%",
-    minWidth: "415px",
+    minWidth: "430px",
     position: "relative",
     color: "gray.8",
     zIndex: 200
+  },
+  table: {
+    width: "calc(100% - 16px)",
+    mx: 2,
+    mb: 2
   },
   tooltip: {
     position: "absolute",
@@ -100,7 +105,7 @@ const style: ThemeUIStyleObject = {
     fontWeight: "body",
     color: "gray.8",
     fontSize: 1,
-    px: 2,
+    p: 2,
     textAlign: "left",
     verticalAlign: "bottom"
   },
@@ -116,6 +121,11 @@ const style: ThemeUIStyleObject = {
   },
   blankValue: {
     color: "gray.2"
+  },
+  lockButton: {
+    p: "6px",
+    display: "inline-block",
+    lineHeight: "0"
   }
 };
 
@@ -143,7 +153,7 @@ const ProjectSidebar = ({
     <Flex sx={style.sidebar}>
       <SidebarHeader selectedGeounits={selectedGeounits} isLoading={isLoading} />
       <Box sx={{ overflowY: "auto", flex: 1 }}>
-        <Styled.table sx={{ width: "calc(100% - 16px)", mx: 2, mb: 2 }}>
+        <Styled.table sx={style.table}>
           <thead>
             <Styled.tr>
               <Styled.th sx={style.th}>
@@ -383,19 +393,20 @@ const SidebarRow = ({
               </span>
             }
           >
-            <span onClick={toggleLocked} sx={{ display: "inline-block", lineHeight: "0" }}>
+            <Button variant="icon" onClick={toggleLocked} sx={style.lockButton}>
               <Icon name="lock-locked" color="#131f28" size={0.75} />
-            </span>
+            </Button>
           </Tooltip>
         ) : (
           <Tooltip content="Lock this district">
-            <span
+            <Button
+              variant="icon"
               style={{ visibility: isHovered ? "visible" : "hidden" }}
               onClick={toggleLocked}
-              sx={{ display: "inline-block", lineHeight: "0" }}
+              sx={style.lockButton}
             >
               <Icon name="lock-unlocked" size={0.75} />
-            </span>
+            </Button>
           </Tooltip>
         )}
       </Styled.td>

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -16,6 +16,7 @@ const appButtonStyles = {
   fontWeight: "medium",
   borderRadius: "3px",
   cursor: "pointer",
+  transition: "0.2s background ease-out, 0.2s background-color ease-out",
   "& > svg": {
     mr: 1
   },
@@ -328,6 +329,29 @@ const theme: Theme & StyledSystemTheme = {
         },
         "&:active": {
           bg: "gray.3"
+        }
+      }
+    },
+    icon: {
+      ...appButtonStyles,
+      ...{
+        p: 1,
+        bg: "transparent",
+        color: "gray.8",
+        borderRadius: "100%",
+        "> svg": {
+          mx: 0
+        },
+        "&:hover:not([disabled]):not(:active)": {
+          bg: "rgba(89, 89, 89, 0.1)"
+        },
+        "&[disabled]": {
+          bg: "transparent",
+          opacity: 0.25,
+          cursor: "not-allowed"
+        },
+        "&:active": {
+          bg: "rgba(89, 89, 89, 0.3)"
         }
       }
     }


### PR DESCRIPTION
## Overview
Makes a larger click area and adds a hover state to the lock button in the sidebar. I also added a slight transition for button hover states and applied our `:focus` state to the logo link in the project header. 


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![districtbuilder_hover_click_area](https://user-images.githubusercontent.com/5672295/93765777-59d30f00-fc0d-11ea-8a65-80ab42274730.gif)


### Notes
- I added a new `icon`button variant for these. 
- The width of the sidebar had to get a bit wider in order to fit the new width of the button.

## Testing Instructions
- `git pull`
- Enter a map
- Hover on rows in the sidebar. Notice that the lock icon appears.
- Hover on a lock icon to see its `:hover` state. Click to see the `:active` state.
- Note there is more padding about the the icon so it's easier to click.
- Take a look at this in Firefox. There shouldn't be a horizontal scroll bar in the sidebar.

Closes #424 
