### PR TITLE
Add the ability to query ALB logs with Athena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support menu on landing and project page [#435](https://github.com/PublicMapping/districtbuilder/pull/435)
 - Allow for selecting partially locked districts [#420](https://github.com/PublicMapping/districtbuilder/pull/420)
 - Show toast on errors [#437](https://github.com/PublicMapping/districtbuilder/pull/437)
+- Add the ability to query ALB logs with Athena [#441](https://github.com/PublicMapping/districtbuilder/pull/441)
 
 ### Changed
 
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2020-09-14
 
-- Initial release
+- Initial release.
 
 [unreleased]: https://github.com/publicmapping/districtbuilder/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/publicmapping/districtbuilder/compare/b9c63f4...0.1.0

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -30,11 +30,24 @@ resource "aws_lb" "app" {
   security_groups = [aws_security_group.alb.id]
   subnets         = module.vpc.public_subnet_ids
 
+  access_logs {
+    bucket  = aws_s3_bucket.logs.id
+    prefix  = "ALB/APP"
+    enabled = true
+  }
+
   tags = {
     Name        = "alb${var.environment}App"
     Project     = var.project
     Environment = var.environment
   }
+
+  # In order to enable access logging, the ELB service account needs S3 access.
+  # This is a "hidden" dependency that Terraform cannot automatically infer, so
+  # it must be declared explicitly.
+  depends_on = [
+    aws_s3_bucket_policy.alb_access_logging
+  ]
 }
 
 resource "aws_lb_target_group" "app" {

--- a/deployment/terraform/athena.tf
+++ b/deployment/terraform/athena.tf
@@ -1,0 +1,196 @@
+locals {
+  short_environment = var.environment == "Staging" ? "stg" : var.environment == "Production" ? "prd" : lower(var.environment)
+}
+
+# https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
+resource "aws_glue_catalog_table" "alb_logs" {
+  name          = "${local.short_environment}_alb_logs"
+  database_name = "default"
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.logs.id}/ALB/APP/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name                  = "${local.short_environment}_alb_logs"
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+
+      parameters = {
+        "serialization.format" = "1"
+        "input.regex"          = "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\\s]+?)\" \"([^\\s]+)\" \"([^ ]*)\" \"([^ ]*)\""
+      }
+    }
+
+    columns {
+      name = "type"
+      type = "string"
+    }
+
+    columns {
+      name = "time"
+      type = "string"
+    }
+
+    columns {
+      name = "elb"
+      type = "string"
+    }
+
+    columns {
+      name = "client_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "client_port"
+      type = "int"
+    }
+
+    columns {
+      name = "target_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "target_port"
+      type = "int"
+    }
+
+    columns {
+      name = "request_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "target_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "response_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "elb_status_code"
+      type = "string"
+    }
+
+    columns {
+      name = "target_status_code"
+      type = "string"
+    }
+
+    columns {
+      name = "received_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sent_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "request_verb"
+      type = "string"
+    }
+
+    columns {
+      name = "request_url"
+      type = "string"
+    }
+
+    columns {
+      name = "request_proto"
+      type = "string"
+    }
+
+    columns {
+      name = "user_agent"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "target_group_arn"
+      type = "string"
+    }
+
+    columns {
+      name = "trace_id"
+      type = "string"
+    }
+
+    columns {
+      name = "domain_name"
+      type = "string"
+    }
+
+    columns {
+      name = "chosen_cert_arn"
+      type = "string"
+    }
+
+    columns {
+      name = "matched_rule_priority"
+      type = "string"
+    }
+
+    columns {
+      name = "request_creation_time"
+      type = "string"
+    }
+
+    columns {
+      name = "actions_executed"
+      type = "string"
+    }
+
+    columns {
+      name = "redirect_url"
+      type = "string"
+    }
+
+    columns {
+      name = "lambda_error_reason"
+      type = "string"
+    }
+
+    columns {
+      name = "target_port_list"
+      type = "string"
+    }
+
+    columns {
+      name = "target_status_code_list"
+      type = "string"
+    }
+
+    columns {
+      name = "classification"
+      type = "string"
+    }
+
+    columns {
+      name = "classification_reason"
+      type = "string"
+    }
+  }
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -53,3 +53,27 @@ resource "aws_iam_role_policy" "scoped_email_sending" {
   role   = aws_iam_role.ecs_task_role.name
   policy = data.aws_iam_policy_document.scoped_email_sending.json
 }
+
+data "aws_elb_service_account" "main" {}
+
+data "aws_iam_policy_document" "alb_access_logging" {
+  statement {
+    effect = "Allow"
+
+    actions = ["s3:PutObject"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_elb_service_account.main.arn]
+    }
+
+    resources = [
+      "${aws_s3_bucket.logs.arn}/ALB/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_access_logging" {
+  bucket = aws_s3_bucket.logs.id
+  policy = data.aws_iam_policy_document.alb_access_logging.json
+}


### PR DESCRIPTION
## Overview

This PR adds the ability to query ALB logs with Athena by codifying the following AWS guides:

- [Access logs for your Application Load Balancer → Enable access logging](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#enable-access-logging)
- [Querying Application Load Balancer Logs → Create ALB Table](https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html#create-alb-table)

Connects #428 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

See that the results of this basic query look right (`client_ip` has been redacted).

```sql
SELECT *
FROM stg_alb_logs LIMIT 5;
```

[d2063156-1045-4c1a-86a8-238bef2c1db2.csv.zip](https://github.com/PublicMapping/districtbuilder/files/5270179/d2063156-1045-4c1a-86a8-238bef2c1db2.csv.zip)
