### PR TITLE
Fix problem with highlighted resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved lock button UX [#436](https://github.com/PublicMapping/districtbuilder/pull/436)
 - Allow for selecting partially locked districts [#420](https://github.com/PublicMapping/districtbuilder/pull/420)
 - Add "Saved" notification in sidebar when map is successfully saved to cloud [#439](https://github.com/PublicMapping/districtbuilder/pull/439)
-
-### Changed
-
 - Reduce noise in log output [#399](https://github.com/PublicMapping/districtbuilder/pull/399)
 - Upgrade development database to PostgreSQL 12.2 and PostGIS 3 [#421](https://github.com/PublicMapping/districtbuilder/pull/421)
 
 ### Fixed
 
 - Fix S3 permissions to allow CloudFront logging [#410](https://github.com/PublicMapping/districtbuilder/pull/410)
+- Fix problem with highlighted resetting [#442](https://github.com/PublicMapping/districtbuilder/pull/442)
 
 ## [0.1.0] - 2020-09-14
 


### PR DESCRIPTION
## Overview

A bug was introduced in PR #420 that caused the set of highlighted geounits to be continuously reset when dragging the rectangle, resulting in the tooltip never showing the aggregated counts of all highlighted geounits.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Before:

![rectangle-highlight-broken](https://user-images.githubusercontent.com/6386/94056220-01864380-fdac-11ea-8cc4-2e5236e0a96d.gif)


After: 

![rectangle-highlight-fixed](https://user-images.githubusercontent.com/6386/94056217-00edad00-fdac-11ea-8930-db5e77a943ea.gif)

## Testing Instructions

- Interact with the rectangle selection tool and ensure you see aggregated counts while you're dragging