### PR TITLE
Set keep-alive timeout higher than ALB idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Project page sharing & read-only mode [#449](https://github.com/PublicMapping/districtbuilder/pull/449)
-- Set keep-alive timeout higher than ALB idle timeout[#448](https://github.com/PublicMapping/districtbuilder/pull/448)
+- Set keep-alive timeout higher than ALB idle timeout [#448](https://github.com/PublicMapping/districtbuilder/pull/448)
+- Add basic k6 load test for PA/50 district project [#448](https://github.com/PublicMapping/districtbuilder/pull/448)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Project page sharing & read-only mode [#449](https://github.com/PublicMapping/districtbuilder/pull/449)
+- Set keep-alive timeout higher than ALB idle timeout[#448](https://github.com/PublicMapping/districtbuilder/pull/448)
 
 ### Changed
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,58 @@
+# Load Testing
+
+This [k6](https://k6.io/) based load testing project is focused on automating
+user requests that are known to stress parts of the application. All of the
+components necessary to execute a load test are encapsulated in this directory.
+
+## Variables
+
+- `JWT_AUTH_TOKEN`: A DistrictBuilder JWT authentication token
+- `DB_PROJECT_ID`: A DistrictBuilder project UUID (PA; 50 districts)
+- `DB_DOMAIN`: The DistrictBuilder instance domain where the project above resides
+
+## Running
+
+Below is an example of how to invoke an instance of the load test with Docker
+Compose:
+
+```console
+$ export DB_JWT_AUTH_TOKEN="..."
+$ export DB_PROJECT_ID="f1824edc-588c-43d9-a094-1b914470910d"
+$ export DB_DOMAIN="app.staging.districtbuilder.org"
+$ docker-compose run --rm k6
+
+          /\      |‾‾| /‾‾/   /‾‾/
+     /\  /  \     |  |/  /   /  /
+    /  \/    \    |     (   /   ‾‾\
+   /          \   |  |\  \ |  (‾)  |
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: /scripts/pa-50-districts.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 20 max VUs, 3m30s max duration (incl. graceful stop):
+           * default: 20 looping VUs for 3m0s (gracefulStop: 30s)
+
+
+running (3m26.9s), 00/20 VUs, 60 complete and 0 interrupted iterations
+default ✓ [======================================] 20 VUs  3m0s
+
+    █ Picking PA districts
+
+    data_received..............: 386 MB 1.9 MB/s
+    data_sent..................: 1.9 MB 9.3 kB/s
+    group_duration.............: avg=1m5s     min=57.16s  med=1m4s     max=1m15s   p(90)=1m14s    p(95)=1m14s
+    http_req_blocked...........: avg=1.38ms   min=100ns   med=200ns    max=92.56ms p(90)=500ns    p(95)=600ns
+    http_req_connecting........: avg=211.51µs min=0s      med=0s       max=16ms    p(90)=0s       p(95)=0s
+    http_req_duration..........: avg=2.98s    min=32.23ms med=2.34s    max=15.69s  p(90)=5.78s    p(95)=8.22s
+    http_req_receiving.........: avg=519.78ms min=14.3µs  med=268.25µs max=10.05s  p(90)=1.69s    p(95)=2.42s
+    http_req_sending...........: avg=83.68µs  min=21.9µs  med=72.95µs  max=985.8µs p(90)=130.32µs p(95)=142.11µs
+    http_req_tls_handshaking...: avg=871.29µs min=0s      med=0s       max=60.4ms  p(90)=0s       p(95)=0s
+    http_req_waiting...........: avg=2.46s    min=31.95ms med=1.61s    max=15.69s  p(90)=5.26s    p(95)=7.2s
+    http_reqs..................: 1320   6.379084/s
+    iteration_duration.........: avg=1m6s     min=58.16s  med=1m5s     max=1m16s   p(90)=1m15s    p(95)=1m15s
+    iterations.................: 60     0.289958/s
+    vus........................: 4      min=4  max=20
+    vus_max....................: 20     min=20 max=20
+```

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  k6:
+    image: loadimpact/k6
+    environment:
+      - DB_JWT_AUTH_TOKEN
+      - DB_PROJECT_ID
+      - DB_DOMAIN=${DB_DOMAIN:-app.staging.districtbuilder.org}
+    volumes:
+      - ./:/scripts/
+    command: run /scripts/pa-50-districts.js

--- a/load-tests/pa-50-districts.js
+++ b/load-tests/pa-50-districts.js
@@ -1,0 +1,454 @@
+import { fail, sleep, group } from "k6";
+import http from "k6/http";
+
+if (!__ENV.DB_JWT_AUTH_TOKEN) fail("DB_JWT_AUTH_TOKEN must be set!");
+if (!__ENV.DB_PROJECT_ID) fail("DB_PROJECT_ID must be set!");
+if (!__ENV.DB_DOMAIN) fail("DB_DOMAIN must be set!");
+
+export const options = {
+  maxRedirects: 0,
+  vus: 20,
+  duration: "3m",
+  thresholds: {
+    "failed requests": ["rate<0.1"],
+  },
+  discardResponseBodies: true,
+};
+
+export default function main() {
+  let response;
+
+  group("Picking PA districts", function () {
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"1c0f6-ns78/pffBdzM6rVVDt6j6JXZ/mo"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,1,0,0,0,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"21087-jtjfyP2jLCL5m84n8t+nXmxIb+4"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,0,0,0,0,0,0,0,0,3,0,3,0,0,0,3,0,0,0,1,0,0,0,3,1,0,2,0,0,0,0,0,3,0,0,0,3,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,1,0,0,0,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"2aed0-7EiNhf1DLs50nWLADSTVtmPqd+k"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,4,4,4,0,0,0,0,0,3,0,3,0,0,0,3,4,4,0,1,0,0,0,3,1,0,2,0,0,0,0,4,3,0,0,0,3,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,2,1,0,0,0,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"3e61f-KZxvos+nlyFHaW7MtSOjsh2EDC0"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,4,4,4,0,0,0,0,0,3,5,3,0,5,0,3,4,4,0,1,0,0,0,3,1,0,2,0,0,0,0,4,3,0,0,0,3,0,0,0,5,2,2,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,5,0,2,1,5,0,5,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"69d27-jkjxggxhGDLOoIhT87890TkXYjc"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,4,4,4,0,0,6,6,0,3,5,3,0,6,0,3,4,4,0,1,0,0,0,3,1,6,2,0,0,6,0,4,3,0,0,0,3,0,0,0,5,2,2,6,0,0,0,0,6,0,0,0,4,0,0,6,6,0,5,6,2,1,5,0,5,0,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"8b3ed-9n1nEuCsm9vcTF+B7UoiGudLboQ"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[0,4,4,4,7,0,6,6,0,3,5,3,0,6,0,3,4,4,7,1,0,0,0,3,1,6,2,7,7,6,7,4,3,7,0,0,3,0,0,7,5,2,2,6,0,0,7,0,6,0,0,0,4,0,7,6,6,7,5,6,2,1,5,0,5,7,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"af20b-5MA8MjXe61/beCHQdiFrA9DPqRE"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[8,4,4,4,7,0,6,6,0,3,5,3,8,6,0,3,4,4,7,1,8,8,0,3,1,6,2,7,7,6,7,4,3,7,8,0,3,0,0,7,5,2,2,6,8,0,7,0,6,8,0,0,4,8,7,6,6,7,5,6,2,1,5,8,5,7,0]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"c7c43-7pFXk1FDTv9OsCj4qRVzlMXSHsU"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[8,4,4,4,7,9,6,6,0,3,5,3,8,6,0,3,4,4,7,1,8,8,0,3,1,6,2,7,7,6,7,4,3,7,8,0,3,9,9,7,5,2,2,6,8,0,7,9,6,8,0,9,4,8,7,6,6,7,5,6,2,1,5,8,5,7,9]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"e62f0-oixPCWfh6+ra3UAgkUKbJn9Y82c"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[8,4,4,4,7,9,6,6,10,3,5,3,8,6,10,3,4,4,7,1,8,8,0,3,1,6,2,7,7,6,7,4,3,7,8,10,3,9,9,7,5,2,2,6,8,10,7,9,6,8,0,9,4,8,7,6,6,7,5,6,2,1,5,8,5,7,9]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"f244b-sbA3nDMGg74/EYe93IaFQVT1IvA"',
+        },
+      }
+    );
+
+    response = http.patch(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}`,
+      '{"districtsDefinition":[8,4,4,4,7,9,6,6,10,3,5,3,8,6,10,3,4,4,7,1,8,8,11,3,1,6,2,7,7,6,7,4,3,7,8,10,3,9,9,7,5,2,2,6,8,10,7,9,6,8,11,9,4,8,7,6,6,7,5,6,2,1,5,8,5,7,9]}',
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "content-type": "application/json;charset=UTF-8",
+          origin: `https://${__ENV.DB_DOMAIN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "Content-Type": "application/json;charset=UTF-8",
+        },
+      }
+    );
+
+    response = http.get(
+      `https://${__ENV.DB_DOMAIN}/api/projects/${__ENV.DB_PROJECT_ID}/export/geojson`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          dnt: "1",
+          authorization: `Bearer ${__ENV.DB_JWT_AUTH_TOKEN}`,
+          "sec-fetch-site": "same-origin",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-dest": "empty",
+          referer: `https://${__ENV.DB_DOMAIN}/projects/${__ENV.DB_PROJECT_ID}`,
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "if-none-match": 'W/"fd940-f/5GUFz3SiRRUF9xDQa7J7v5KHU"',
+        },
+      }
+    );
+  });
+
+  // Automatically added sleep
+  sleep(1);
+}

--- a/src/server/src/main.ts
+++ b/src/server/src/main.ts
@@ -17,6 +17,16 @@ async function bootstrap(): Promise<void> {
   );
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
   app.useGlobalFilters(new BadRequestExceptionFilter());
-  await app.listen(3005);
+
+  // Save the output of 'listen' to a variable, which is a Node http.Server
+  const server = await app.listen(3005);
+
+  // Ensure all inactive connections are terminated by the ALB, by setting this
+  // a few seconds higher than the ALB idle timeout
+  server.keepAliveTimeout = 65000; // eslint-disable-line functional/immutable-data
+
+  // Ensure the headersTimeout is set higher than the keepAliveTimeout due to
+  // this nodejs regression bug: https://github.com/nodejs/node/issues/27363
+  server.headersTimeout = 66000; // eslint-disable-line functional/immutable-data
 }
 bootstrap(); // eslint-disable-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
## Overview

> Keep-alive, when enabled, enables the load balancer to reuse back-end connections until the keep-alive timeout expires. To ensure that the load balancer is responsible for closing the connections to your instance, make sure that the value you set for the HTTP keep-alive time is greater than the idle timeout setting configured for your load balancer.

The [default keep-alive timeout](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for the Node http.Server is 5 seconds. The [default idle timeout](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#idle_timeout) for the ALB is 60 seconds. 

The ALB is opening connections for reuse, the Node http.Server closes that connection, and then the ALB tries to communicate over the closed connection which triggers a 502.

> **HTTP 502: Bad gateway**
>
> Possible causes:
> . . .
> The target closed the connection with a TCP RST or a TCP FIN while the load balancer had an outstanding request to the target. Check whether the keep-alive duration of the target is shorter than the idle timeout value of the load balancer.

We can see more evidence of this by looking at the ALB access logs with Athena:

<details>   
<summary>Details</summary>    

```sql
SELECT elb_status_code,
         request_processing_time,
         target_processing_time,
         response_processing_time,
         request_url
FROM stg_alb_logs
WHERE elb_status_code LIKE '5%';
```

<img width="1006" alt="Athena 2020-09-23 14-35-24" src="https://user-images.githubusercontent.com/1774125/94175520-cb58ca80-fe64-11ea-810c-4462094467ca.png">

</details>

> `response_processing_time` is set to -1 if the load balancer can't send the request to a target. This can happen if the target closes the connection before the idle timeout or if the client sends a malformed request.

This PR sets the keep-alive timeout to be higher than the ALB timeout so that the ALB is responsible for prompting the closure of individual TCP connections to the server.

See:
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-entry-syntax
- https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/ (Excellent deep dive into the problem)

Resolves #428 

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

I'm not sure how to replicate the failures we saw earlier. I've tried exercising the staging application and wasn't able to generate any 502s today before or after applying the fix (see the [Jenkins deploy](http://urbanappsci.internal.azavea.com/job/PublicMapping/job/districtbuilder/job/test%252Fjrb%252Fadjust-timeouts/2/console)). Additionally, the `prd_alb_logs` table in Athena does not contain any 502s.

I think the evidence makes it clear we should apply this either way, and we can be on the look out for more 502s as we're able to gather more data.