### PR TITLE
Use web workers for real-time demographic updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
           "allowTernary": true,
         }
       ],
+      "react/display-name": "off",
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project page sharing & read-only mode [#449](https://github.com/PublicMapping/districtbuilder/pull/449)
 - Set keep-alive timeout higher than ALB idle timeout [#448](https://github.com/PublicMapping/districtbuilder/pull/448)
 - Add basic k6 load test for PA/50 district project [#448](https://github.com/PublicMapping/districtbuilder/pull/448)
+- Use web workers for real-time demographic updates [#452](https://github.com/PublicMapping/districtbuilder/pull/452)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tippyjs/react": "^4.1.0",
     "@types/jwt-decode": "2.2.1",
     "axios": "0.19.0",
+    "json-stable-stringify": "^1.0.1",
     "jwt-decode": "2.2.0",
     "lodash": "^4.17.19",
     "mapbox-gl": "1.6.1",
@@ -58,6 +59,7 @@
   },
   "devDependencies": {
     "@types/jest": "24.0.22",
+    "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash": "^4.14.158",
     "@types/mapbox-gl": "1.6.1",
     "@types/memoizee": "^0.4.4",
@@ -82,6 +84,12 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "http-proxy-middleware": "0.20.0",
-    "prettier": "1.19.1"
+    "prettier": "1.19.1",
+    "workerize-loader": "^1.3.0"
+  },
+  "jest": {
+     "moduleNameMapper": {
+       "workerize-loader!./worker":"<rootDir>/src/client/worker.mock.js"
+    }
   }
 }

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -1,25 +1,22 @@
 /** @jsx jsx */
-import React, { useState, Fragment } from "react";
+import React, { memo, useEffect, useState, Fragment } from "react";
 import { Box, Button, Flex, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
-  UintArrays,
   CompactnessScore,
-  DistrictsDefinition,
+  DemographicCounts,
   GeoUnitHierarchy,
-  GeoUnitIndices,
   GeoUnits,
   IProject,
   IStaticMetadata,
   LockedDistricts
 } from "../../shared/entities";
 import { DistrictGeoJSON, DistrictsGeoJSON, SavingState } from "../types";
+import { areAnyGeoUnitsSelected, assertNever, mergeGeoUnits } from "../functions";
 import {
-  allGeoUnitIndices,
-  assertNever,
-  getDemographics,
+  getSavedDistrictSelectedDemographics,
   getTotalSelectedDemographics
-} from "../functions";
+} from "../worker-functions";
 import {
   getDistrictColor,
   negativeChangeColor,
@@ -125,9 +122,9 @@ const ProjectSidebar = ({
   geojson,
   isLoading,
   staticMetadata,
-  staticDemographics,
   selectedDistrictId,
   selectedGeounits,
+  highlightedGeounits,
   geoUnitHierarchy,
   lockedDistricts,
   saving
@@ -135,9 +132,9 @@ const ProjectSidebar = ({
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
   readonly staticMetadata?: IStaticMetadata;
-  readonly staticDemographics?: UintArrays;
   readonly selectedDistrictId: number;
   readonly selectedGeounits: GeoUnits;
+  readonly highlightedGeounits: GeoUnits;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly lockedDistricts: LockedDistricts;
   readonly saving: SavingState;
@@ -182,15 +179,14 @@ const ProjectSidebar = ({
             </Styled.tr>
           </thead>
           <tbody>
-            {project && geojson && staticMetadata && staticDemographics && geoUnitHierarchy && (
+            {project && geojson && staticMetadata && geoUnitHierarchy && (
               <SidebarRows
                 project={project}
                 geojson={geojson}
                 staticMetadata={staticMetadata}
-                staticDemographics={staticDemographics}
                 selectedDistrictId={selectedDistrictId}
                 selectedGeounits={selectedGeounits}
-                geoUnitHierarchy={geoUnitHierarchy}
+                highlightedGeounits={highlightedGeounits}
                 lockedDistricts={lockedDistricts}
                 saving={saving}
               />
@@ -247,194 +243,141 @@ function getCompactnessDisplay(compactness: CompactnessScore) {
   );
 }
 
-const SidebarRow = ({
-  district,
-  selected,
-  selectedPopulationDifference,
-  demographics,
-  deviation,
-  districtId,
-  isDistrictLocked
-}: {
-  readonly district: DistrictGeoJSON;
-  readonly selected: boolean;
-  readonly selectedPopulationDifference: number;
-  readonly demographics: { readonly [id: string]: number };
-  readonly deviation: number;
-  readonly districtId: number;
-  readonly isDistrictLocked?: boolean;
-}) => {
-  const [isHovered, setHover] = useState(false);
-
-  const showPopulationChange = selectedPopulationDifference !== 0;
-  const textColor = showPopulationChange
-    ? selectedPopulationDifference > 0
-      ? positiveChangeColor
-      : negativeChangeColor
-    : "inherit";
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  const intermediatePopulation = district.properties.population + selectedPopulationDifference;
-  const intermediateDeviation = deviation + selectedPopulationDifference;
-  const populationDisplay = intermediatePopulation.toLocaleString();
-  const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
-    intermediateDeviation
-  ).toLocaleString()}`;
-  const compactnessDisplay =
-    districtId === 0 ? (
-      <span sx={style.blankValue}>{BLANK_VALUE}</span>
-    ) : (
-      getCompactnessDisplay(district.properties.compactness)
-    );
-  const toggleHover = () => setHover(!isHovered);
-  const toggleLocked = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    store.dispatch(toggleDistrictLocked(districtId));
-  };
-  return (
-    <Styled.tr
-      sx={{ bg: selected ? selectedDistrictColor : "inherit", cursor: "pointer" }}
-      onClick={() => {
-        store.dispatch(setSelectedDistrictId(district.id as number));
-      }}
-      onMouseOver={toggleHover}
-      onMouseOut={toggleHover}
-    >
-      <Styled.td sx={style.td}>
-        <Flex sx={{ alignItems: "center" }}>
-          {district.id ? (
-            <Fragment>
-              <div sx={{ ...style.districtColor, ...{ bg: getDistrictColor(district.id) } }}></div>
-              <span>{district.id}</span>
-            </Fragment>
-          ) : (
-            <Fragment>
-              <div sx={{ ...style.districtColor, ...style.unassignedColor }}></div>
-              <span>∅</span>
-            </Fragment>
-          )}
-        </Flex>
-      </Styled.td>
-      <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-        {populationDisplay}
-      </Styled.td>
-      <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-        {deviationDisplay}
-      </Styled.td>
-      <Styled.td sx={style.td}>
-        <Tooltip
-          placement="top-start"
-          content={
-            demographics.population > 0 ? (
-              <DemographicsTooltip demographics={demographics} />
+// Memoizing the SidebarRow provides a large performance enhancement
+const SidebarRow = memo(
+  ({
+    district,
+    selected,
+    selectedPopulationDifference,
+    demographics,
+    deviation,
+    districtId,
+    isDistrictLocked
+  }: {
+    readonly district: DistrictGeoJSON;
+    readonly selected: boolean;
+    readonly selectedPopulationDifference?: number;
+    readonly demographics: { readonly [id: string]: number };
+    readonly deviation: number;
+    readonly districtId: number;
+    readonly isDistrictLocked?: boolean;
+  }) => {
+    const [isHovered, setHover] = useState(false);
+    const selectedDifference = selectedPopulationDifference || 0;
+    const showPopulationChange = selectedDifference !== 0;
+    const textColor = showPopulationChange
+      ? selectedDifference > 0
+        ? positiveChangeColor
+        : negativeChangeColor
+      : "inherit";
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    const intermediatePopulation = district.properties.population + selectedDifference;
+    const intermediateDeviation = deviation + selectedDifference;
+    const populationDisplay = intermediatePopulation.toLocaleString();
+    const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
+      intermediateDeviation
+    ).toLocaleString()}`;
+    const compactnessDisplay =
+      districtId === 0 ? (
+        <span sx={style.blankValue}>{BLANK_VALUE}</span>
+      ) : (
+        getCompactnessDisplay(district.properties.compactness)
+      );
+    const toggleHover = () => setHover(!isHovered);
+    const toggleLocked = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      store.dispatch(toggleDistrictLocked(districtId));
+    };
+    return (
+      <Styled.tr
+        sx={{ bg: selected ? selectedDistrictColor : "inherit", cursor: "pointer" }}
+        onClick={() => {
+          store.dispatch(setSelectedDistrictId(district.id as number));
+        }}
+        onMouseOver={toggleHover}
+        onMouseOut={toggleHover}
+      >
+        <Styled.td sx={style.td}>
+          <Flex sx={{ alignItems: "center" }}>
+            {district.id ? (
+              <Fragment>
+                <div
+                  sx={{ ...style.districtColor, ...{ bg: getDistrictColor(district.id) } }}
+                ></div>
+                <span>{district.id}</span>
+              </Fragment>
             ) : (
-              <em>
-                <strong>Empty district.</strong> Add people to this district to view the race chart
-              </em>
-            )
-          }
-        >
-          <span>
-            <DemographicsChart demographics={demographics} />
-          </span>
-        </Tooltip>
-      </Styled.td>
-      <Styled.td sx={{ ...style.td, ...style.number }}>{compactnessDisplay}</Styled.td>
-      <Styled.td>
-        {isDistrictLocked ? (
+              <Fragment>
+                <div sx={{ ...style.districtColor, ...style.unassignedColor }}></div>
+                <span>∅</span>
+              </Fragment>
+            )}
+          </Flex>
+        </Styled.td>
+        <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
+          {populationDisplay}
+        </Styled.td>
+        <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
+          {deviationDisplay}
+        </Styled.td>
+        <Styled.td sx={style.td}>
           <Tooltip
+            placement="top-start"
             content={
-              <span>
-                <strong>Locked.</strong> Areas from this district cannot be selected
-              </span>
+              demographics.population > 0 ? (
+                <DemographicsTooltip demographics={demographics} />
+              ) : (
+                <em>
+                  <strong>Empty district.</strong> Add people to this district to view the race
+                  chart
+                </em>
+              )
             }
           >
-            <Button variant="icon" onClick={toggleLocked} sx={style.lockButton}>
-              <Icon name="lock-locked" color="#131f28" size={0.75} />
-            </Button>
+            <span>
+              <DemographicsChart demographics={demographics} />
+            </span>
           </Tooltip>
-        ) : (
-          <Tooltip content="Lock this district">
-            <Button
-              variant="icon"
-              style={{ visibility: isHovered ? "visible" : "hidden" }}
-              onClick={toggleLocked}
-              sx={style.lockButton}
+        </Styled.td>
+        <Styled.td sx={{ ...style.td, ...style.number }}>{compactnessDisplay}</Styled.td>
+        <Styled.td>
+          {isDistrictLocked ? (
+            <Tooltip
+              content={
+                <span>
+                  <strong>Locked.</strong> Areas from this district cannot be selected
+                </span>
+              }
             >
-              <Icon name="lock-unlocked" size={0.75} />
-            </Button>
-          </Tooltip>
-        )}
-      </Styled.td>
-    </Styled.tr>
-  );
-};
-
-// Drill into the district definition and collect the base geounits for
-// every district that's part of the selection
-const getSavedDistrictSelectedDemographics = (
-  project: IProject,
-  staticMetadata: IStaticMetadata,
-  staticDemographics: UintArrays,
-  selectedGeounits: GeoUnits,
-  geoUnitHierarchy: GeoUnitHierarchy
-) => {
-  /* eslint-disable */
-  // Note: not using Array.fill to populate these, because the empty array in memory gets shared
-  const mutableDistrictGeounitAccum: number[][] = [];
-  for (let i = 0; i <= project.numberOfDistricts; i = i + 1) {
-    mutableDistrictGeounitAccum[i] = [];
+              <Button variant="icon" onClick={toggleLocked} sx={style.lockButton}>
+                <Icon name="lock-locked" color="#131f28" size={0.75} />
+              </Button>
+            </Tooltip>
+          ) : (
+            <Tooltip content="Lock this district">
+              <Button
+                variant="icon"
+                style={{ visibility: isHovered ? "visible" : "hidden" }}
+                onClick={toggleLocked}
+                sx={style.lockButton}
+              >
+                <Icon name="lock-unlocked" size={0.75} />
+              </Button>
+            </Tooltip>
+          )}
+        </Styled.td>
+      </Styled.tr>
+    );
   }
-  /* eslint-enable */
-
-  // Collect all base geounits found in the selection
-  const accumulateGeounits = (
-    subIndices: GeoUnitIndices,
-    subDefinition: DistrictsDefinition | number,
-    subHierarchy: GeoUnitHierarchy | number
-  ) => {
-    if (typeof subHierarchy === "number" && typeof subDefinition === "number") {
-      // The base case: we made it to the bottom of the trees and need to assign this
-      // base geonunit to the district found in the district definition
-      // eslint-disable-next-line
-      mutableDistrictGeounitAccum[subDefinition].push(subHierarchy);
-      return;
-    } else if (subIndices.length === 0 && typeof subHierarchy !== "number") {
-      // We've exhausted the base indices. This means we ned to grab all the indices found
-      // at this level and accumulate them all
-      subHierarchy.forEach((_, ind) => accumulateGeounits([ind], subDefinition, subHierarchy));
-      return;
-    } else {
-      // Recurse by drilling into all three data structures:
-      // geounit indices, district definition, and geounit hierarchy
-      const currIndex = subIndices[0];
-      const currDefn =
-        typeof subDefinition === "number"
-          ? subDefinition
-          : (subDefinition[currIndex] as DistrictsDefinition);
-      const currHierarchy =
-        typeof subHierarchy === "number" ? subHierarchy : subHierarchy[currIndex];
-      accumulateGeounits(subIndices.slice(1), currDefn, currHierarchy);
-      return;
-    }
-  };
-
-  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices => {
-    accumulateGeounits(geoUnitIndices, project.districtsDefinition, geoUnitHierarchy);
-  });
-
-  return mutableDistrictGeounitAccum.map(baseGeounitIdsForDistrict =>
-    getDemographics(baseGeounitIdsForDistrict, staticMetadata, staticDemographics)
-  );
-};
+);
 
 interface SidebarRowsProps {
   readonly project: IProject;
   readonly geojson: DistrictsGeoJSON;
   readonly staticMetadata: IStaticMetadata;
-  readonly staticDemographics: UintArrays;
   readonly selectedDistrictId: number;
   readonly selectedGeounits: GeoUnits;
-  readonly geoUnitHierarchy: GeoUnitHierarchy;
+  readonly highlightedGeounits: GeoUnits;
   readonly lockedDistricts: LockedDistricts;
   readonly saving: SavingState;
 }
@@ -443,28 +386,60 @@ const SidebarRows = ({
   project,
   geojson,
   staticMetadata,
-  staticDemographics,
   selectedDistrictId,
   selectedGeounits,
-  geoUnitHierarchy,
+  highlightedGeounits,
   lockedDistricts
 }: SidebarRowsProps) => {
-  // Aggregated demographics for the geounit selection
-  const totalSelectedDemographics = getTotalSelectedDemographics(
-    staticMetadata,
-    geoUnitHierarchy,
-    staticDemographics,
-    selectedGeounits
-  );
+  // Results of the asynchronous demographics calculation. The two calculations have been
+  // combined into a single object here, because we want both updates to the state to happen
+  // at the same time to prevent sidebar value flickering.
+  const [selectedDemographics, setSelectedDemographics] = useState<
+    | { readonly total: DemographicCounts; readonly savedDistrict: readonly DemographicCounts[] }
+    | undefined
+  >(undefined);
 
-  // The demographic composition of the selection for each saved district
-  const savedDistrictSelectedDemographics = getSavedDistrictSelectedDemographics(
-    project,
-    staticMetadata,
-    staticDemographics,
-    selectedGeounits,
-    geoUnitHierarchy
-  );
+  // Asynchronously recalculate demographics on state changes with web workers
+  useEffect(() => {
+    // eslint-disable-next-line
+    let outdated = false;
+
+    async function getData() {
+      // Combine selected and highlighted to show calculations in real time
+      const combinedSelection = mergeGeoUnits(selectedGeounits, highlightedGeounits);
+
+      // Aggregated demographics for the geounit selection
+      const selectedTotals = await getTotalSelectedDemographics(
+        staticMetadata,
+        project.regionConfig.s3URI,
+        combinedSelection
+      );
+      // The demographic composition of the selection for each saved district
+      const districtTotals = await getSavedDistrictSelectedDemographics(
+        project,
+        staticMetadata,
+        combinedSelection
+      );
+
+      // Don't overwrite current results with outdated ones
+      !outdated &&
+        setSelectedDemographics({
+          total: selectedTotals,
+          savedDistrict: districtTotals
+        });
+    }
+
+    // When there aren't any geounits highlighted or selected, there is no need to run the
+    // asynchronous calculation; it can simply be cleared out. This additional logic prevents
+    // the sidebar values from flickering after save.
+    areAnyGeoUnitsSelected(selectedGeounits) || areAnyGeoUnitsSelected(highlightedGeounits)
+      ? void getData()
+      : setSelectedDemographics(undefined);
+
+    return () => {
+      outdated = true;
+    };
+  }, [project, staticMetadata, selectedGeounits, highlightedGeounits]);
 
   // The target population is based on the average population of all districts,
   // not including the unassigned district, so we use the number of districts,
@@ -481,24 +456,29 @@ const SidebarRows = ({
         const districtId = typeof feature.id === "number" ? feature.id : 0;
         const selected = districtId === selectedDistrictId;
         const demographics = feature.properties;
-        const selectedPopulation = savedDistrictSelectedDemographics[districtId].population;
-        const selectedPopulationDifference = selected
-          ? totalSelectedDemographics.population - selectedPopulation
-          : -1 * selectedPopulation;
+        const selectedPopulation = selectedDemographics?.savedDistrict?.[districtId]?.population;
+        const totalSelectedDemographics = selectedDemographics?.total;
+        const selectedPopulationDifference =
+          selectedPopulation !== undefined && totalSelectedDemographics !== undefined && selected
+            ? totalSelectedDemographics.population - selectedPopulation
+            : selectedPopulation !== undefined
+            ? -1 * selectedPopulation
+            : undefined;
+
+        // The population goal for the unassigned district is 0,
+        // so it's deviation is equal to its population
+        const deviation =
+          districtId === 0
+            ? feature.properties.population
+            : feature.properties.population - averagePopulation;
 
         return (
           <SidebarRow
             district={feature}
             selected={selected}
-            selectedPopulationDifference={selectedPopulationDifference}
+            selectedPopulationDifference={selectedPopulationDifference || 0}
             demographics={demographics}
-            deviation={
-              // The population goal for the unassigned district is 0,
-              // so it's deviation is equal to its population
-              districtId === 0
-                ? feature.properties.population
-                : feature.properties.population - averagePopulation
-            }
+            deviation={deviation}
             key={districtId}
             isDistrictLocked={lockedDistricts.has(districtId)}
             districtId={districtId}

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -41,7 +41,6 @@ interface Props {
   readonly project: IProject;
   readonly geojson: DistrictsGeoJSON;
   readonly staticMetadata: IStaticMetadata;
-  readonly staticDemographics: UintArrays;
   readonly staticGeoLevels: UintArrays;
   readonly selectedGeounits: GeoUnits;
   readonly selectedDistrictId: number;
@@ -55,7 +54,6 @@ const DistrictsMap = ({
   project,
   geojson,
   staticMetadata,
-  staticDemographics,
   staticGeoLevels,
   selectedGeounits,
   selectedDistrictId,
@@ -345,7 +343,6 @@ const DistrictsMap = ({
     selectionTool,
     selectedGeolevel,
     staticMetadata,
-    staticDemographics,
     staticGeoLevels,
     project,
     lockedDistricts

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -1,24 +1,17 @@
 /** @jsx jsx */
 import throttle from "lodash/throttle";
 import MapboxGL from "mapbox-gl";
-import memoize from "memoizee";
 import { useEffect, useRef, useState } from "react";
 import { connect } from "react-redux";
 import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 
-import { UintArrays, GeoUnits, GeoUnitHierarchy, IStaticMetadata } from "../../../shared/entities";
-import {
-  areAnyGeoUnitsSelected,
-  destructureResource,
-  geoLevelLabel,
-  getTotalSelectedDemographics
-} from "../../functions";
+import { DemographicCounts, GeoUnits, IProject, IStaticMetadata } from "../../../shared/entities";
+import { areAnyGeoUnitsSelected, destructureResource, geoLevelLabel } from "../../functions";
+import { getTotalSelectedDemographics } from "../../worker-functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
-
-const getDemographics = memoize(getTotalSelectedDemographics);
 
 const style: ThemeUIStyleObject = {
   tooltip: {
@@ -40,23 +33,35 @@ const style: ThemeUIStyleObject = {
   }
 };
 
+interface Data {
+  readonly demographics: DemographicCounts;
+  readonly heading: React.ReactElement | string;
+}
+
+const throttledDataSetter = throttle(
+  function<T>(setData: (arg0: T) => void, data: T) {
+    setData(data);
+  },
+  100,
+  { leading: true }
+);
+
 const MapTooltip = ({
   geoLevelIndex,
   highlightedGeounits,
-  staticDemographics,
   staticMetadata,
-  geoUnitHierarchy,
+  project,
   map
 }: {
   readonly geoLevelIndex: number;
   readonly highlightedGeounits: GeoUnits;
-  readonly staticDemographics?: UintArrays;
   readonly staticMetadata?: IStaticMetadata;
-  readonly geoUnitHierarchy?: GeoUnitHierarchy;
+  readonly project?: IProject;
   readonly map?: MapboxGL.Map;
 }) => {
   const [point, setPoint] = useState({ x: 0, y: 0 });
   const [feature, setFeature] = useState<MapboxGL.MapboxGeoJSONFeature | undefined>(undefined);
+  const [data, setData] = useState<Data | undefined>(undefined);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const invertedGeoLevelIndex = staticMetadata
@@ -76,7 +81,7 @@ const MapTooltip = ({
             map.queryRenderedFeatures(point, {
               layers: [levelToLineLayerId(geoLevel), levelToSelectionLayerId(geoLevel)]
             });
-          features && setFeature(features[0]);
+          setFeature(features && features[0]);
         }
       },
       SET_FEATURE_DELAY
@@ -122,58 +127,75 @@ const MapTooltip = ({
     return clearHandlers;
   }, [map, staticMetadata, invertedGeoLevelIndex]);
 
+  useEffect(() => {
+    // eslint-disable-next-line
+    let outdated = false;
+    async function getData() {
+      // eslint-disable-next-line
+      if (staticMetadata && project && invertedGeoLevelIndex !== undefined) {
+        const geoLevelId = staticMetadata.geoLevelHierarchy[invertedGeoLevelIndex].id;
+
+        const selectedGeounits = areAnyGeoUnitsSelected(highlightedGeounits)
+          ? highlightedGeounits
+          : feature && featuresToGeoUnits([feature], staticMetadata.geoLevelHierarchy);
+        const demographics =
+          selectedGeounits &&
+          (await getTotalSelectedDemographics(
+            staticMetadata,
+            project.regionConfig.s3URI,
+            selectedGeounits
+          ));
+
+        const featureLabel = () => (
+          <span sx={{ textTransform: "capitalize" }}>
+            {feature && feature.properties && typeof feature.properties.name === "string" ? (
+              feature.properties.name
+            ) : feature ? (
+              <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
+            ) : (
+              ""
+            )}
+          </span>
+        );
+        const highlightedGeounitsForLevel = highlightedGeounits[geoLevelId];
+        const heading =
+          feature &&
+          highlightedGeounitsForLevel &&
+          highlightedGeounitsForLevel?.size === 1 &&
+          [...highlightedGeounitsForLevel.keys()][0] === feature.id
+            ? featureLabel()
+            : highlightedGeounitsForLevel?.size === 1
+            ? `1 ${geoLevelId}`
+            : highlightedGeounitsForLevel?.size > 1
+            ? `${Number(highlightedGeounitsForLevel.size).toLocaleString()} ${geoLevelLabel(
+                geoLevelId
+              ).toLowerCase()}`
+            : featureLabel();
+
+        // Only set data if it is for the most recent version requested, to
+        // avoid overwriting fresh data with stale data
+        !outdated && throttledDataSetter(setData, demographics && { demographics, heading });
+      }
+    }
+    void getData();
+
+    return () => {
+      outdated = true;
+    };
+  }, [highlightedGeounits, feature, staticMetadata, project, invertedGeoLevelIndex]);
+
   // eslint-disable-next-line
-  if (
-    map &&
-    staticMetadata &&
-    geoUnitHierarchy &&
-    staticDemographics &&
-    invertedGeoLevelIndex !== undefined
-  ) {
-    const geoLevelId = staticMetadata.geoLevelHierarchy[invertedGeoLevelIndex].id;
-    const selectedGeounits = areAnyGeoUnitsSelected(highlightedGeounits)
-      ? highlightedGeounits
-      : feature && featuresToGeoUnits([feature], staticMetadata.geoLevelHierarchy);
-    const demographics =
-      selectedGeounits &&
-      getDemographics(staticMetadata, geoUnitHierarchy, staticDemographics, selectedGeounits);
-
-    const featureLabel = () => (
-      <span sx={{ textTransform: "capitalize" }}>
-        {feature && feature.properties && typeof feature.properties.name === "string" ? (
-          feature.properties.name
-        ) : feature ? (
-          <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
-        ) : (
-          ""
-        )}
-      </span>
-    );
-    const highlightedGeounitsForLevel = highlightedGeounits[geoLevelId];
-    const heading =
-      feature &&
-      highlightedGeounitsForLevel &&
-      highlightedGeounitsForLevel?.size === 1 &&
-      [...highlightedGeounitsForLevel.keys()][0] === feature.id
-        ? featureLabel()
-        : highlightedGeounitsForLevel?.size === 1
-        ? `1 ${geoLevelId}`
-        : highlightedGeounitsForLevel?.size > 1
-        ? `${Number(highlightedGeounitsForLevel.size).toLocaleString()} ${geoLevelLabel(
-            geoLevelId
-          ).toLowerCase()}`
-        : featureLabel();
-
+  if (map && data !== undefined) {
     const x = point.x;
     const y = point.y;
 
-    return demographics ? (
+    return (
       <Box
         ref={tooltipRef}
         style={{ transform: `translate3d(${x}px, ${y}px, 0)` }}
         sx={{ ...style.tooltip }}
       >
-        {heading && (
+        {data.heading && (
           <Heading
             sx={{
               fontSize: 1,
@@ -184,7 +206,7 @@ const MapTooltip = ({
               textOverflow: "ellipsis"
             }}
           >
-            {heading}
+            {data.heading}
           </Heading>
         )}
         <Grid gap={2} columns={[2, "1fr 2fr"]}>
@@ -198,15 +220,15 @@ const MapTooltip = ({
               fontWeight: "medium"
             }}
           >
-            {Number(demographics.population).toLocaleString()}
+            {Number(data.demographics.population).toLocaleString()}
           </Box>
         </Grid>
         <Divider sx={{ my: 1, borderColor: "gray.6" }} />
         <Box sx={{ width: "100%" }}>
-          <DemographicsTooltip demographics={demographics} />
+          <DemographicsTooltip demographics={data.demographics} />
         </Box>
       </Box>
-    ) : null;
+    );
   }
   return null;
 };
@@ -215,9 +237,8 @@ function mapStateToProps(state: State) {
   return {
     geoLevelIndex: state.project.geoLevelIndex,
     highlightedGeounits: state.project.highlightedGeounits,
-    staticDemographics: destructureResource(state.project.staticData, "staticDemographics"),
-    staticMetadata: destructureResource(state.project.staticData, "staticMetadata"),
-    geoUnitHierarchy: destructureResource(state.project.staticData, "geoUnitHierarchy")
+    project: destructureResource(state.project.projectData, "project"),
+    staticMetadata: destructureResource(state.project.staticData, "staticMetadata")
   };
 }
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -34,7 +34,7 @@ export const LINES_PLACEHOLDER_LAYER_ID = "line-placeholder";
 export const LABELS_PLACEHOLDER_LAYER_ID = "label-placeholder";
 
 // Delay used to throttle calls to set the current feature(s), in milliseconds
-export const SET_FEATURE_DELAY = 100;
+export const SET_FEATURE_DELAY = 300;
 
 // Layers in the Mapbox Studio project that we filter to only show the active region.
 const filteredLabelLayers = [

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,69 +1,16 @@
-import memoize from "memoizee";
 import { toast } from "react-toastify";
 import { cloneDeep } from "lodash";
 
 import {
-  DemographicCounts,
   DistrictsDefinition,
   MutableGeoUnitCollection,
   GeoLevelHierarchy,
   GeoUnits,
   GeoUnitIndices,
   GeoUnitHierarchy,
-  IStaticMetadata,
   NestedArray
 } from "../shared/entities";
 import { Resource } from "./resource";
-import { getDemographics as getDemographicsBase } from "../shared/functions";
-
-// TODO: merge this function with shared/functions once the ability to import
-// third party dependencies into the shared module is fixed
-export const getDemographics = memoize(getDemographicsBase, {
-  normalizer: args => JSON.stringify([[...args[0]].sort(), args[1]]),
-  primitive: true
-});
-
-/*
- * Return all base indices for this subset of the geounit hierarchy.
- */
-// eslint-disable-next-line
-function accumulateBaseIndices(geoUnitHierarchy: GeoUnitHierarchy): number[] {
-  // eslint-disable-next-line
-  const baseIndices: number[] = [];
-  geoUnitHierarchy.forEach(currentIndices =>
-    // eslint-disable-next-line
-    baseIndices.push(
-      ...(typeof currentIndices === "number"
-        ? [currentIndices]
-        : accumulateBaseIndices(currentIndices))
-    )
-  );
-  return baseIndices;
-}
-
-/*
- * Return all corresponding base indices (i.e. smallest geounit, eg. blocks) for a given geounit.
- */
-function baseIndicesForGeoUnit(
-  geoUnitHierarchy: GeoUnitHierarchy,
-  geoUnitIndices: GeoUnitIndices
-  // eslint-disable-next-line
-): number[] {
-  const [geoUnitIndex, ...remainingGeoUnitIndices] = geoUnitIndices;
-  const indicesForGeoLevel: number | NestedArray<number> = geoUnitHierarchy[geoUnitIndex];
-  // eslint-disable-next-line
-  if (remainingGeoUnitIndices.length) {
-    // Need to recurse to find the geounit in question in the hierarchy
-    return baseIndicesForGeoUnit(indicesForGeoLevel as GeoUnitHierarchy, remainingGeoUnitIndices);
-  }
-  // We've reached the geounit we're after. Now we need to return all the base geounit ids below it
-  // eslint-disable-next-line
-  if (typeof indicesForGeoLevel === "number") {
-    // Must be working with base geounit. Wrap it in an array and return.
-    return [indicesForGeoLevel];
-  }
-  return accumulateBaseIndices(indicesForGeoLevel);
-}
 
 export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
   return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
@@ -76,31 +23,6 @@ export function allGeoUnitIndices(geoUnits: GeoUnits) {
 export function allGeoUnitIds(geoUnits: GeoUnits) {
   return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.keys()));
 }
-
-// Aggregate all demographics that are included in the selection
-function getTotalSelectedDemographicsBase(
-  staticMetadata: IStaticMetadata,
-  geoUnitHierarchy: GeoUnitHierarchy,
-  staticDemographics: ReadonlyArray<Uint8Array | Uint16Array | Uint32Array>,
-  selectedGeounits: GeoUnits
-): DemographicCounts {
-  // Build up set of blocks ids corresponding to selected geounits
-  // eslint-disable-next-line
-  const selectedBaseIndices: Set<number> = new Set();
-  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices =>
-    baseIndicesForGeoUnit(geoUnitHierarchy, geoUnitIndices).forEach(index =>
-      // eslint-disable-next-line
-      selectedBaseIndices.add(index)
-    )
-  );
-  // Aggregate all counts for selected blocks
-  return getDemographics(selectedBaseIndices, staticMetadata, staticDemographics);
-}
-
-export const getTotalSelectedDemographics = memoize(getTotalSelectedDemographicsBase, {
-  normalizer: args => JSON.stringify([args[0], [...allGeoUnitIndices(args[3])].sort()]),
-  primitive: true
-});
 
 /*
  * Assign nested geounit to district.

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -9,7 +9,7 @@ import {
   IStaticMetadata,
   S3URI
 } from "../shared/entities";
-import { StaticProjectData } from "./types";
+import { StaticProjectData, WorkerProjectData } from "./types";
 
 const s3Axios = axios.create();
 
@@ -72,14 +72,25 @@ export async function fetchAllStaticData(path: S3URI): Promise<StaticProjectData
       Promise.all([
         Promise.resolve(staticMetadata),
         fetchGeoUnitHierarchy(path),
-        fetchStaticFiles(path, staticMetadata.geoLevels),
-        fetchStaticFiles(path, staticMetadata.demographics)
+        fetchStaticFiles(path, staticMetadata.geoLevels)
       ])
     )
-    .then(([staticMetadata, geoUnitHierarchy, staticGeoLevels, staticDemographics]) => ({
+    .then(([staticMetadata, geoUnitHierarchy, staticGeoLevels]) => ({
       staticMetadata,
       geoUnitHierarchy,
-      staticGeoLevels,
-      staticDemographics
+      staticGeoLevels
     }));
+}
+
+export async function fetchWorkerStaticData(
+  path: S3URI,
+  staticMetadata: IStaticMetadata
+): Promise<WorkerProjectData> {
+  return Promise.all([
+    fetchGeoUnitHierarchy(path),
+    fetchStaticFiles(path, staticMetadata.demographics)
+  ]).then(([geoUnitHierarchy, staticDemographics]) => ({
+    geoUnitHierarchy,
+    staticDemographics
+  }));
 }

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect, useParams } from "react-router-dom";
 import { Flex, jsx, Spinner } from "theme-ui";
@@ -34,7 +34,6 @@ interface StateProps {
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
   readonly staticMetadata?: IStaticMetadata;
-  readonly staticDemographics?: UintArrays;
   readonly staticGeoLevels: UintArrays;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly districtDrawing: DistrictDrawingState;
@@ -47,7 +46,6 @@ const ProjectScreen = ({
   project,
   geojson,
   staticMetadata,
-  staticDemographics,
   staticGeoLevels,
   geoUnitHierarchy,
   districtDrawing,
@@ -89,35 +87,6 @@ const ProjectScreen = ({
     projectId && store.dispatch(projectDataFetch(projectId));
   }, [projectId, isLoggedIn]);
 
-  const sidebar = useMemo(
-    () => (
-      <ProjectSidebar
-        project={project}
-        geojson={geojson}
-        isLoading={isLoading}
-        staticMetadata={staticMetadata}
-        staticDemographics={staticDemographics}
-        selectedDistrictId={districtDrawing.selectedDistrictId}
-        selectedGeounits={districtDrawing.selectedGeounits}
-        geoUnitHierarchy={geoUnitHierarchy}
-        lockedDistricts={districtDrawing.lockedDistricts}
-        saving={districtDrawing.saving}
-      />
-    ),
-    [
-      project,
-      geojson,
-      isLoading,
-      staticMetadata,
-      staticDemographics,
-      districtDrawing.selectedDistrictId,
-      districtDrawing.selectedGeounits,
-      geoUnitHierarchy,
-      districtDrawing.lockedDistricts,
-      districtDrawing.saving
-    ]
-  );
-
   return isFirstLoadPending ? (
     <CenteredContent>
       <Flex sx={{ justifyContent: "center" }}>
@@ -130,7 +99,18 @@ const ProjectScreen = ({
     <Flex sx={{ height: "100%", flexDirection: "column" }}>
       <ProjectHeader project={project} />
       <Flex sx={{ flex: 1, overflowY: "auto" }}>
-        {sidebar}
+        <ProjectSidebar
+          project={project}
+          geojson={geojson}
+          isLoading={isLoading}
+          staticMetadata={staticMetadata}
+          selectedDistrictId={districtDrawing.selectedDistrictId}
+          selectedGeounits={districtDrawing.selectedGeounits}
+          highlightedGeounits={districtDrawing.highlightedGeounits}
+          geoUnitHierarchy={geoUnitHierarchy}
+          lockedDistricts={districtDrawing.lockedDistricts}
+          saving={districtDrawing.saving}
+        />
         <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>
           <MapHeader
             label={label}
@@ -142,13 +122,12 @@ const ProjectScreen = ({
             advancedEditingEnabled={project?.advancedEditingEnabled}
             isReadOnly={isReadOnly}
           />
-          {project && staticMetadata && staticDemographics && staticGeoLevels && geojson ? (
+          {project && staticMetadata && staticGeoLevels && geojson ? (
             <React.Fragment>
               <Map
                 project={project}
                 geojson={geojson}
                 staticMetadata={staticMetadata}
-                staticDemographics={staticDemographics}
                 staticGeoLevels={staticGeoLevels}
                 selectedGeounits={districtDrawing.selectedGeounits}
                 selectedDistrictId={districtDrawing.selectedDistrictId}
@@ -177,7 +156,6 @@ function mapStateToProps(state: State): StateProps {
     geojson: destructureResource(state.project.projectData, "geojson"),
     staticMetadata: destructureResource(state.project.staticData, "staticMetadata"),
     staticGeoLevels: destructureResource(state.project.staticData, "staticGeoLevels"),
-    staticDemographics: destructureResource(state.project.staticData, "staticDemographics"),
     geoUnitHierarchy: destructureResource(state.project.staticData, "geoUnitHierarchy"),
     districtDrawing: state.project,
     isLoading:

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -18,6 +18,10 @@ export interface DynamicProjectData {
 export interface StaticProjectData {
   readonly staticMetadata: IStaticMetadata;
   readonly staticGeoLevels: UintArrays;
+  readonly geoUnitHierarchy: GeoUnitHierarchy;
+}
+
+export interface WorkerProjectData {
   readonly staticDemographics: UintArrays;
   readonly geoUnitHierarchy: GeoUnitHierarchy;
 }

--- a/src/client/worker-functions.ts
+++ b/src/client/worker-functions.ts
@@ -1,0 +1,55 @@
+import stringify from "json-stable-stringify";
+import memoize from "memoizee";
+
+import { DemographicCounts, GeoUnits, IProject, IStaticMetadata, S3URI } from "../shared/entities";
+/* eslint import/no-webpack-loader-syntax: off */
+import createWorker from "workerize-loader!./worker";
+import * as WorkerType from "./worker";
+
+const worker = createWorker<typeof WorkerType>();
+
+// eslint-disable-next-line
+function replacer(key: string, value: any): any {
+  if (value instanceof Set) {
+    // eslint-disable-next-line
+    return [...value].sort();
+  } else if (value instanceof Map) {
+    return [...value.entries()].sort(([a], [b]) => (a === b ? 0 : a < b ? -1 : 1));
+  } else {
+    // eslint-disable-next-line
+    return value;
+  }
+}
+
+export const getTotalSelectedDemographics = memoize(
+  async (
+    staticMetadata: IStaticMetadata,
+    regionURI: S3URI,
+    selectedGeounits: GeoUnits
+  ): Promise<DemographicCounts> => {
+    return worker.getTotalSelectedDemographics(staticMetadata, regionURI, selectedGeounits);
+  },
+  {
+    normalizer: args => stringify([args[1], args[2]], { replacer }),
+    primitive: true
+  }
+);
+
+export const getSavedDistrictSelectedDemographics = memoize(
+  async (
+    project: IProject,
+    staticMetadata: IStaticMetadata,
+    selectedGeounits: GeoUnits
+  ): Promise<readonly DemographicCounts[]> => {
+    return worker.getSavedDistrictSelectedDemographics(
+      project,
+      staticMetadata,
+      project.regionConfig.s3URI,
+      selectedGeounits
+    );
+  },
+  {
+    normalizer: args => stringify([args[0], args[2]], { replacer }),
+    primitive: true
+  }
+);

--- a/src/client/worker.mock.js
+++ b/src/client/worker.mock.js
@@ -1,0 +1,2 @@
+// Stub mock for workerize-loader in order to get tests to pass
+module.exports = function() {};

--- a/src/client/worker.ts
+++ b/src/client/worker.ts
@@ -1,0 +1,164 @@
+import {
+  DemographicCounts,
+  DistrictsDefinition,
+  GeoUnits,
+  GeoUnitIndices,
+  GeoUnitHierarchy,
+  IProject,
+  IStaticMetadata,
+  NestedArray,
+  S3URI
+} from "../shared/entities";
+import { getDemographics as getDemographicsBase } from "../shared/functions";
+import { allGeoUnitIndices } from "./functions";
+import { fetchWorkerStaticData } from "./s3";
+import { WorkerProjectData } from "./types";
+
+interface RegionData {
+  readonly uri: S3URI;
+  readonly data: Promise<WorkerProjectData>;
+}
+
+// eslint-disable-next-line
+let regionData: RegionData | undefined;
+
+function fetchRegionData(regionURI: S3URI, staticMetadata: IStaticMetadata): RegionData {
+  // eslint-disable-next-line
+  if (!regionData || regionData.uri !== regionURI) {
+    regionData = {
+      uri: regionURI,
+      data: fetchWorkerStaticData(regionURI, staticMetadata)
+    };
+  }
+  return regionData;
+}
+
+async function getDemographics(
+  baseIndices: readonly number[] | ReadonlySet<number>,
+  staticMetadata: IStaticMetadata,
+  regionURI: S3URI
+): Promise<DemographicCounts> {
+  const data = await fetchRegionData(regionURI, staticMetadata).data;
+  return getDemographicsBase(baseIndices, staticMetadata, data.staticDemographics);
+}
+
+/*
+ * Return all corresponding base indices (i.e. smallest geounit, eg. blocks) for a given geounit.
+ */
+function baseIndicesForGeoUnit(
+  geoUnitHierarchy: GeoUnitHierarchy,
+  geoUnitIndices: GeoUnitIndices
+  // eslint-disable-next-line
+): number[] {
+  const [geoUnitIndex, ...remainingGeoUnitIndices] = geoUnitIndices;
+  const indicesForGeoLevel: number | NestedArray<number> = geoUnitHierarchy[geoUnitIndex];
+  // eslint-disable-next-line
+  if (remainingGeoUnitIndices.length) {
+    // Need to recurse to find the geounit in question in the hierarchy
+    return baseIndicesForGeoUnit(indicesForGeoLevel as GeoUnitHierarchy, remainingGeoUnitIndices);
+  }
+  // We've reached the geounit we're after. Now we need to return all the base geounit ids below it
+  // eslint-disable-next-line
+  if (typeof indicesForGeoLevel === "number") {
+    // Must be working with base geounit. Wrap it in an array and return.
+    return [indicesForGeoLevel];
+  }
+  return accumulateBaseIndices(indicesForGeoLevel);
+}
+
+/*
+ * Return all base indices for this subset of the geounit hierarchy.
+ */
+// eslint-disable-next-line
+function accumulateBaseIndices(geoUnitHierarchy: GeoUnitHierarchy): number[] {
+  // eslint-disable-next-line
+  const baseIndices: number[] = [];
+  geoUnitHierarchy.forEach(currentIndices =>
+    // eslint-disable-next-line
+    baseIndices.push(
+      ...(typeof currentIndices === "number"
+        ? [currentIndices]
+        : accumulateBaseIndices(currentIndices))
+    )
+  );
+  return baseIndices;
+}
+
+export async function getTotalSelectedDemographics(
+  staticMetadata: IStaticMetadata,
+  regionURI: S3URI,
+  selectedGeounits: GeoUnits
+): Promise<DemographicCounts> {
+  const data = await fetchRegionData(regionURI, staticMetadata).data;
+  // Build up set of blocks ids corresponding to selected geounits
+  // eslint-disable-next-line
+  const selectedBaseIndices: Set<number> = new Set();
+  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices =>
+    baseIndicesForGeoUnit(data.geoUnitHierarchy, geoUnitIndices).forEach(index =>
+      // eslint-disable-next-line
+      selectedBaseIndices.add(index)
+    )
+  );
+  // Aggregate all counts for selected blocks
+  return getDemographics(selectedBaseIndices, staticMetadata, regionURI);
+}
+
+// Drill into the district definition and collect the base geounits for
+// every district that's part of the selection
+export async function getSavedDistrictSelectedDemographics(
+  project: IProject,
+  staticMetadata: IStaticMetadata,
+  regionURI: S3URI,
+  selectedGeounits: GeoUnits
+): Promise<readonly DemographicCounts[]> {
+  const data = await fetchRegionData(regionURI, staticMetadata).data;
+  /* eslint-disable */
+  // Note: not using Array.fill to populate these, because the empty array in memory gets shared
+  const mutableDistrictGeounitAccum: number[][] = [];
+  for (let i = 0; i <= project.numberOfDistricts; i = i + 1) {
+    mutableDistrictGeounitAccum[i] = [];
+  }
+  /* eslint-enable */
+
+  // Collect all base geounits found in the selection
+  const accumulateGeounits = (
+    subIndices: GeoUnitIndices,
+    subDefinition: DistrictsDefinition | number,
+    subHierarchy: GeoUnitHierarchy | number
+  ) => {
+    if (typeof subHierarchy === "number" && typeof subDefinition === "number") {
+      // The base case: we made it to the bottom of the trees and need to assign this
+      // base geonunit to the district found in the district definition
+      // eslint-disable-next-line
+      mutableDistrictGeounitAccum[subDefinition].push(subHierarchy);
+      return;
+    } else if (subIndices.length === 0 && typeof subHierarchy !== "number") {
+      // We've exhausted the base indices. This means we ned to grab all the indices found
+      // at this level and accumulate them all
+      subHierarchy.forEach((_, ind) => accumulateGeounits([ind], subDefinition, subHierarchy));
+      return;
+    } else {
+      // Recurse by drilling into all three data structures:
+      // geounit indices, district definition, and geounit hierarchy
+      const currIndex = subIndices[0];
+      const currDefn =
+        typeof subDefinition === "number"
+          ? subDefinition
+          : (subDefinition[currIndex] as DistrictsDefinition);
+      const currHierarchy =
+        typeof subHierarchy === "number" ? subHierarchy : subHierarchy[currIndex];
+      accumulateGeounits(subIndices.slice(1), currDefn, currHierarchy);
+      return;
+    }
+  };
+
+  allGeoUnitIndices(selectedGeounits).forEach(geoUnitIndices => {
+    accumulateGeounits(geoUnitIndices, project.districtsDefinition, data.geoUnitHierarchy);
+  });
+
+  return Promise.all(
+    mutableDistrictGeounitAccum.map(baseGeounitIdsForDistrict =>
+      getDemographics(baseGeounitIdsForDistrict, staticMetadata, project.regionConfig.s3URI)
+    )
+  );
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="react-scripts" />
+
+declare module "workerize-loader!*" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type AnyFunction = (...args: readonly any[]) => any;
+  type Async<F extends AnyFunction> = (...args: Parameters<F>) => Promise<ReturnType<F>>;
+
+  type Workerized<T> = Worker & { [K in keyof T]: T[K] extends AnyFunction ? Async<T[K]> : never };
+
+  function createInstance<T>(): Workerized<T>;
+  export = createInstance;
+}

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -34,7 +34,7 @@ export function getAllBaseIndices(
 }
 
 export function getDemographics(
-  baseIndices: number[] | Set<number>, // eslint-disable-line
+  baseIndices: readonly number[] | ReadonlySet<number>,
   staticMetadata: IStaticMetadata,
   staticDemographics: readonly UintArray[]
 ): DemographicCounts {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext"
+      "esnext",
+      "webworker"
     ],
     "allowJs": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,6 +1920,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json-stable-stringify@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
+  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
+
 "@types/jwt-decode@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
@@ -7256,6 +7261,15 @@ loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -11906,6 +11920,13 @@ worker-rpc@^0.1.0:
   integrity sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
   dependencies:
     microevent.ts "~0.1.1"
+
+workerize-loader@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/workerize-loader/-/workerize-loader-1.3.0.tgz#4995cf2ff2b45dd6dc60e4411e63f5ae2c704d36"
+  integrity sha512-utWDc8K6embcICmRBUUkzanPgKBb8yM1OHfh6siZfiMsswE8wLCa9CWS+L7AARz0+Th4KH4ZySrqer/OJ9WuWw==
+  dependencies:
+    loader-utils "^2.0.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Overview

Calculate sidebar updates in real-time as rectangle tool is dragged, via use of web workers

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![web-workers-demo](https://user-images.githubusercontent.com/6386/94586056-c9b94900-024e-11eb-8859-c95b35304fdd.gif)

### Notes

 * This is based off of #395, and much of the base web worker setup has remained intact
 * Unfortunately, I needed to squash everything here down, since it was a long-running branch that weathered a large amount of PRs, and the constant rebasing and merging wreaked havoc on the commit log. However, I'll add some key notes here for various changes I needed to make.
    * Added short circuit to rectangle selection tool when features are exactly the same
    * ProjectSidebar memoization wasn't working correctly, because `useMemo` wasn't properly able to determine equality of the dependencies. I overrode a comparator here and used lodash's `isEqual`, which worked. But then I ended up instead moving the memoization down to the sidebar row layer, which is what really needed the memoization for performance.
    *  The memoization normalizer for saved selection was looking at the wrong arguments and causing strange behavior
    * The deviation display was broken and was showing all zeros most of the time
    * Increased the set feature throttle delay a bit, since it improves performance and I didn't notice any negative impact from a usage perspective
    * Added a mock for worker to make tests pass 
    * Fixed a bug where a combination of selection, canceling, and re-selecting was causing the map to not update correctly
    * Made a couple changes to eliminate sidebar flickering on save: combined state for the two calculations, and added special handling to not recalculate when no geounits are highlighted or selected
  * We discussed re-architecting the usage of web workers to flow through `redux-loop`. I started digging into it, but became a bit overwhelmed, and wasn't confident that it would even actually fix the flickering problem I was experiencing. I think that may be something we want to explore more down the road, but I'm happy enough with how it's working at the moment that I don't think the additional time is currently warranted.

## Testing Instructions

- `/scripts/update`, `./scripts/server`, and load up a project
- Use the app to build out some districts, and pay attention to the sidebar and tooltip
- Both should be updating in real time as the rectangle tool is dragged
- Verify that the performance while moving the rectangle is acceptable, and is at least as fast as what's currently on staging
- Verify that when saving districts, the sidebar values do not flicker

Closes #219
