### PR TITLE
Clear current project district definition & geojson data when adding a new undo state

### DIFF
--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -74,6 +74,8 @@ function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
 function pushState(state: ProjectState, undoState: UndoableState): ProjectState {
   return {
     ...state,
+    // Need to clear new project GeoJSON whenever clearing redo states
+    currentProjectData: undefined,
     undoHistory: {
       past: [...state.undoHistory.past, state.undoHistory.present],
       present: undoState,


### PR DESCRIPTION
## Overview

@tgilcrest noted this issue on Slack:
> Something else I noticed:
> Accept
> Undo Accept
> Make another selection
> Undo the selection
> Redo
> Undo
> Redo
> Redo (5) combines Select (3) and Accept (1) into the same action. So any subsequent undo/redo (6,7) will do both.
> I would expect redo (5) to just make the selection (3) again, and it should not be possible not be possible to Accept via redoing, > because the Accept (1) action should have been "overwritten" in the history of actions by the Select (3). (edited) 
> ![image](https://user-images.githubusercontent.com/4432106/95340680-70bb6780-0883-11eb-86f4-357492e9abd3.png)

This fixes it by clearing the stored project state when we replace the undo stack with `pushState`

### Checklist

- ~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~

## Testing Instructions

- Follow the directions above to recreate the original issue on `develop`
- Verify it no longer happens on this branch

Closes #463 