### PR TITLE
Temporarily remove share button

### DIFF
--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -101,7 +101,6 @@ const ProjectHeader = ({
           </Button>
         </React.Fragment>
       )}
-      <ShareMenu invert={true} />
       <SupportMenu invert={true} />
     </Flex>
   </Flex>


### PR DESCRIPTION
## Overview

We want to do a production release soon, but don't want to deploy the `Share` button, since we have some updates we want to make to it first. This removes the button from the page. We can revert this commit after deploying.

### Checklist

- ~~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~~

### Demo

![remove-share-button](https://user-images.githubusercontent.com/6386/95363251-34950080-089d-11eb-86ca-9588b7c84d5b.png)

## Testing Instructions

- Load the map page and ensure the `Share` button doesn't show up, and the page remains functional
