### PR TITLE
Add microcopy to Create Project fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Microcopy to Create Map and description props to text and select fields [#467](https://github.com/PublicMapping/districtbuilder/pull/467)
 - Project page sharing & read-only mode [#449](https://github.com/PublicMapping/districtbuilder/pull/449)
 - Set keep-alive timeout higher than ALB idle timeout [#448](https://github.com/PublicMapping/districtbuilder/pull/448)
 - Add basic k6 load test for PA/50 district project [#448](https://github.com/PublicMapping/districtbuilder/pull/448)

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -44,12 +44,14 @@ export default function Field<D, R>({
 
 interface InputFieldProps<D, R> extends FieldProps<D, R> {
   readonly label: string | React.ReactElement;
+  readonly description?: string | React.ReactElement;
   readonly inputProps: RefAttributes<HTMLInputElement> & InputProps;
 }
 
 export function InputField<D, R>({
   field,
   label,
+  description,
   resource,
   inputProps
 }: InputFieldProps<D, R>): React.ReactElement {
@@ -57,10 +59,18 @@ export function InputField<D, R>({
     <Field field={field} resource={resource}>
       {hasErrors => (
         <React.Fragment>
-          <span sx={{ display: "block" }}>{label}</span>
+          <Label htmlFor={field.toString()} sx={{ display: "block" }}>
+            {label}
+          </Label>
+          {description && (
+            <span id={`description-${field.toString()}`} sx={{ display: "block" }}>
+              {description}
+            </span>
+          )}
           <Input
             {...inputProps}
             id={field.toString()}
+            aria-describedby={description ? `description-${field.toString()}` : undefined}
             sx={{ borderColor: hasErrors ? "warning" : undefined }}
           />
         </React.Fragment>
@@ -72,12 +82,14 @@ export function InputField<D, R>({
 interface SelectFieldProps<D, R> extends FieldProps<D, R> {
   readonly children: React.ReactNode;
   readonly label: string | React.ReactElement;
+  readonly description?: string | React.ReactElement;
   readonly selectProps: RefAttributes<HTMLSelectElement> & SelectProps;
 }
 
 export function SelectField<D, R>({
   field,
   label,
+  description,
   resource,
   children,
   selectProps
@@ -86,10 +98,18 @@ export function SelectField<D, R>({
     <Field field={field} resource={resource}>
       {hasErrors => (
         <React.Fragment>
-          <span sx={{ display: "block" }}>{label}</span>
+          <Label htmlFor={field.toString()} sx={{ display: "block" }}>
+            {label}
+          </Label>
+          {description && (
+            <span id={`description-${field.toString()}`} sx={{ display: "block" }}>
+              {description}
+            </span>
+          )}
           <Select
             {...selectProps}
             id={field.toString()}
+            aria-describedby={description ? `description-${field.toString()}` : undefined}
             sx={{ borderColor: hasErrors ? "warning" : undefined }}
           >
             {children}

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -147,8 +147,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
     },
     legend: {
       paddingInlineStart: "0",
-      paddingInlineEnd: "0",
-      marginBottom: "0"
+      paddingInlineEnd: "0"
     },
     fieldset: {
       border: "none",
@@ -277,95 +276,101 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
               </SelectField>
             </Card>
             {data.regionConfig ? (
-              <Card sx={{ variant: "card.flat", display: "flex", flexWrap: "wrap" }}>
+              <Card sx={{ variant: "card.flat" }}>
                 <fieldset sx={style.fieldset}>
-                  <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
-                    Districts
-                  </legend>
-                  <Box
-                    id="description-districts"
-                    as="span"
-                    sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
-                  >
-                    How many districts do you want to map? Choose a federal or state legislative
-                    chamber or define your own.
-                  </Box>
-                  {data.regionConfig &&
-                    [...data.regionConfig.chambers]
-                      .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
-                      .map(chamber => (
-                        <Label
-                          key={chamber.id}
-                          sx={{
-                            display: "inline-flex",
-                            "@media screen and (min-width: 750px)": {
-                              flex: "0 0 48%",
-                              "&:nth-of-type(even)": {
-                                mr: "2%"
+                  <Flex sx={{ flexWrap: "wrap" }}>
+                    <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
+                      Districts
+                    </legend>
+                    <Box
+                      id="description-districts"
+                      as="span"
+                      sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
+                    >
+                      How many districts do you want to map? Choose a federal or state legislative
+                      chamber or define your own.
+                    </Box>
+                    {data.regionConfig &&
+                      [...data.regionConfig.chambers]
+                        .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
+                        .map(chamber => (
+                          <Label
+                            key={chamber.id}
+                            sx={{
+                              display: "inline-flex",
+                              "@media screen and (min-width: 750px)": {
+                                flex: "0 0 48%",
+                                "&:nth-of-type(even)": {
+                                  mr: "2%"
+                                }
                               }
-                            }
-                          }}
-                        >
-                          <Radio
-                            name="project-district"
-                            value={chamber.id}
-                            onChange={onDistrictChanged}
-                            aria-describedby="description-districts"
-                          />
-                          <Flex
-                            as="span"
-                            sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                            }}
                           >
-                            <div sx={style.radioHeading}>{chamber.name}</div>
-                            <div sx={style.radioSubHeading}>
-                              {chamber.numberOfDistricts} districts
-                            </div>
-                          </Flex>
-                        </Label>
-                      ))
-                      .concat(
-                        <div
-                          sx={{
-                            flex: "0 0 50%",
-                            "@media screen and (max-width: 770px)": {
-                              flex: "0 0 100%"
-                            }
-                          }}
-                          key="custom"
-                        >
-                          <Label>
-                            <Radio name="project-district" value="" onChange={onDistrictChanged} />
-                            <Flex as="span" sx={{ flexDirection: "column" }}>
-                              <div sx={style.radioHeading}>Custom</div>
+                            <Radio
+                              name="project-district"
+                              value={chamber.id}
+                              onChange={onDistrictChanged}
+                              aria-describedby="description-districts"
+                            />
+                            <Flex
+                              as="span"
+                              sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                            >
+                              <div sx={style.radioHeading}>{chamber.name}</div>
                               <div sx={style.radioSubHeading}>
-                                Define a custom number of districts
+                                {chamber.numberOfDistricts} districts
                               </div>
                             </Flex>
                           </Label>
-                        </div>
-                      )}
-                  {data.isCustom ? (
-                    <Box sx={style.customInputContainer}>
-                      <InputField
-                        field="numberOfDistricts"
-                        label="Number of districts"
-                        resource={createProjectResource}
-                        inputProps={{
-                          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                            const value = parseInt(e.currentTarget.value, 10);
-                            const numberOfDistricts = isNaN(value) ? null : value;
-                            setCreateProjectResource({
-                              data: {
-                                ...data,
-                                numberOfDistricts,
-                                isCustom: true
+                        ))
+                        .concat(
+                          <div
+                            sx={{
+                              flex: "0 0 50%",
+                              "@media screen and (max-width: 770px)": {
+                                flex: "0 0 100%"
                               }
-                            });
-                          }
-                        }}
-                      />
-                    </Box>
-                  ) : null}
+                            }}
+                            key="custom"
+                          >
+                            <Label>
+                              <Radio
+                                name="project-district"
+                                value=""
+                                onChange={onDistrictChanged}
+                              />
+                              <Flex as="span" sx={{ flexDirection: "column" }}>
+                                <div sx={style.radioHeading}>Custom</div>
+                                <div sx={style.radioSubHeading}>
+                                  Define a custom number of districts
+                                </div>
+                              </Flex>
+                            </Label>
+                          </div>
+                        )}
+                    {data.isCustom ? (
+                      <Box sx={style.customInputContainer}>
+                        <InputField
+                          field="numberOfDistricts"
+                          label="Number of districts"
+                          resource={createProjectResource}
+                          inputProps={{
+                            onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                              const value = parseInt(e.currentTarget.value, 10);
+                              const numberOfDistricts = isNaN(value) ? null : value;
+                              setCreateProjectResource({
+                                data: {
+                                  ...data,
+                                  numberOfDistricts,
+                                  isCustom: true
+                                }
+                              });
+                            }
+                          }}
+                        />
+                      </Box>
+                    ) : null}
+                  </Flex>
                 </fieldset>
               </Card>
             ) : (

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -223,8 +223,8 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                 }
                 description={
                   <Box as="span" sx={style.cardHint}>
-                    e.g. ‘Arizona House of Representatives’. This will distinguish maps from one
-                    another on the landing page.
+                    e.g. ‘Arizona House of Representatives’. Make it specific to help tell your maps
+                    apart.
                   </Box>
                 }
                 resource={createProjectResource}

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -2,7 +2,18 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Box, Button, Card, Flex, Heading, jsx, Label, Radio, ThemeUIStyleObject } from "theme-ui";
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  jsx,
+  Label,
+  Radio,
+  ThemeUIStyleObject,
+  Styled
+} from "theme-ui";
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
@@ -103,6 +114,13 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
       textTransform: "none",
       variant: "text.h4",
       display: "block",
+      mb: 1
+    },
+    cardHint: {
+      display: "block",
+      textTransform: "none",
+      fontWeight: "normal",
+      fontSize: 1,
       mb: 4
     },
     radioHeading: {
@@ -126,6 +144,14 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
       pt: 4,
       borderTop: "1px solid",
       borderColor: "gray.2"
+    },
+    fieldset: {
+      border: "none",
+      marginInlineStart: "0",
+      marginInlineEnd: "0",
+      paddingInlineStart: "0",
+      paddingInlineEnd: "0",
+      paddingBlockEnd: "0"
     }
   };
 
@@ -140,7 +166,17 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
     >
       <Flex sx={style.header}>
         <Box as="h1" sx={{ lineHeight: "0", mr: 3 }}>
-          <Link to="/">
+          <Link
+            to="/"
+            sx={{
+              lineHeight: "0",
+              borderRadius: "small",
+              "&:focus": {
+                outline: "none",
+                boxShadow: "focus"
+              }
+            }}
+          >
             <Logo sx={{ width: "2rem" }} />
           </Link>
         </Box>
@@ -181,6 +217,12 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                     Map name
                   </Box>
                 }
+                description={
+                  <Box as="span" sx={style.cardHint}>
+                    e.g. ‘Arizona House of Representatives’. This will distinguish maps from one
+                    another on the landing page.
+                  </Box>
+                }
                 resource={createProjectResource}
                 inputProps={{
                   onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -198,6 +240,12 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                     State
                   </Box>
                 }
+                description={
+                  <Box as="span" sx={style.cardHint}>
+                    What state do you want to map? If you don’t see it in the list,{" "}
+                    <Styled.a href="mailto:support@districtbuilder.org">let us know!</Styled.a>
+                  </Box>
+                }
                 resource={createProjectResource}
                 selectProps={{
                   onChange:
@@ -213,7 +261,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                       : undefined
                 }}
               >
-                <option>Select region</option>
+                <option>Select...</option>
                 {"resource" in regionConfigs
                   ? regionConfigs.resource.map(regionConfig => (
                       <option key={regionConfig.id} value={regionConfig.id}>
@@ -225,82 +273,93 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
             </Card>
             {data.regionConfig ? (
               <Card sx={{ variant: "card.flat", display: "flex", flexWrap: "wrap" }}>
-                <Label sx={style.cardLabel}>Districts</Label>
-                {data.regionConfig &&
-                  [...data.regionConfig.chambers]
-                    .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
-                    .map(chamber => (
-                      <Label
-                        key={chamber.id}
-                        sx={{
-                          display: "inline-flex",
-                          "@media screen and (min-width: 750px)": {
-                            flex: "0 0 48%",
-                            "&:nth-of-type(even)": {
-                              mr: "2%"
+                <fieldset sx={style.fieldset}>
+                  <legend sx={{ ...style.cardLabel, ...{ flex: "0 0 100%" } }}>Districts</legend>
+                  <Box
+                    id="description-districts"
+                    as="span"
+                    sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
+                  >
+                    How many districts do you want to map? Choose a federal or state legislative
+                    chamber or define your own.
+                  </Box>
+                  {data.regionConfig &&
+                    [...data.regionConfig.chambers]
+                      .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
+                      .map(chamber => (
+                        <Label
+                          key={chamber.id}
+                          sx={{
+                            display: "inline-flex",
+                            "@media screen and (min-width: 750px)": {
+                              flex: "0 0 48%",
+                              "&:nth-of-type(even)": {
+                                mr: "2%"
+                              }
                             }
-                          }
-                        }}
-                      >
-                        <Radio
-                          name="project-district"
-                          value={chamber.id}
-                          onChange={onDistrictChanged}
-                        />
-                        <Flex
-                          as="span"
-                          sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                          }}
                         >
-                          <div sx={style.radioHeading}>{chamber.name}</div>
-                          <div sx={style.radioSubHeading}>
-                            {chamber.numberOfDistricts} districts
-                          </div>
-                        </Flex>
-                      </Label>
-                    ))
-                    .concat(
-                      <div
-                        sx={{
-                          flex: "0 0 50%",
-                          "@media screen and (max-width: 770px)": {
-                            flex: "0 0 100%"
-                          }
-                        }}
-                        key="custom"
-                      >
-                        <Label>
-                          <Radio name="project-district" value="" onChange={onDistrictChanged} />
-                          <Flex as="span" sx={{ flexDirection: "column" }}>
-                            <div sx={style.radioHeading}>Custom</div>
+                          <Radio
+                            name="project-district"
+                            value={chamber.id}
+                            onChange={onDistrictChanged}
+                            aria-describedby="description-districts"
+                          />
+                          <Flex
+                            as="span"
+                            sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                          >
+                            <div sx={style.radioHeading}>{chamber.name}</div>
                             <div sx={style.radioSubHeading}>
-                              Define a custom number of districts
+                              {chamber.numberOfDistricts} districts
                             </div>
                           </Flex>
                         </Label>
-                      </div>
-                    )}
-                {data.isCustom ? (
-                  <Box sx={style.customInputContainer}>
-                    <InputField
-                      field="numberOfDistricts"
-                      label="Number of districts"
-                      resource={createProjectResource}
-                      inputProps={{
-                        onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                          const value = parseInt(e.currentTarget.value, 10);
-                          const numberOfDistricts = isNaN(value) ? null : value;
-                          setCreateProjectResource({
-                            data: {
-                              ...data,
-                              numberOfDistricts,
-                              isCustom: true
+                      ))
+                      .concat(
+                        <div
+                          sx={{
+                            flex: "0 0 50%",
+                            "@media screen and (max-width: 770px)": {
+                              flex: "0 0 100%"
                             }
-                          });
-                        }
-                      }}
-                    />
-                  </Box>
-                ) : null}
+                          }}
+                          key="custom"
+                        >
+                          <Label>
+                            <Radio name="project-district" value="" onChange={onDistrictChanged} />
+                            <Flex as="span" sx={{ flexDirection: "column" }}>
+                              <div sx={style.radioHeading}>Custom</div>
+                              <div sx={style.radioSubHeading}>
+                                Define a custom number of districts
+                              </div>
+                            </Flex>
+                          </Label>
+                        </div>
+                      )}
+                  {data.isCustom ? (
+                    <Box sx={style.customInputContainer}>
+                      <InputField
+                        field="numberOfDistricts"
+                        label="Number of districts"
+                        resource={createProjectResource}
+                        inputProps={{
+                          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                            const value = parseInt(e.currentTarget.value, 10);
+                            const numberOfDistricts = isNaN(value) ? null : value;
+                            setCreateProjectResource({
+                              data: {
+                                ...data,
+                                numberOfDistricts,
+                                isCustom: true
+                              }
+                            });
+                          }
+                        }}
+                      />
+                    </Box>
+                  ) : null}
+                </fieldset>
               </Card>
             ) : (
               undefined

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -145,6 +145,11 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
       borderTop: "1px solid",
       borderColor: "gray.2"
     },
+    legend: {
+      paddingInlineStart: "0",
+      paddingInlineEnd: "0",
+      marginBottom: "0"
+    },
     fieldset: {
       border: "none",
       marginInlineStart: "0",
@@ -274,7 +279,9 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
             {data.regionConfig ? (
               <Card sx={{ variant: "card.flat", display: "flex", flexWrap: "wrap" }}>
                 <fieldset sx={style.fieldset}>
-                  <legend sx={{ ...style.cardLabel, ...{ flex: "0 0 100%" } }}>Districts</legend>
+                  <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
+                    Districts
+                  </legend>
                   <Box
                     id="description-districts"
                     as="span"


### PR DESCRIPTION
## Overview
This PR adds some descriptive copy underneath labels on the Create Map page.

### Checklist
- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
<img width="1581" alt="Screen Shot 2020-10-09 at 8 40 34 AM" src="https://user-images.githubusercontent.com/5672295/95556374-206f1180-0a0b-11eb-9365-74d23937f477.png">


### Notes
- I made these descriptions accessible using `aria-describedby` rather than putting them directly in the label and tested with Mac OS's [Voiceover](https://webaim.org/articles/voiceover/) software.
- Fixed an accessibility issue with the radio selects by adding a fieldset container around them and changing their label to `<legend>`.

## Testing Instructions
- `git pull`
- Log in, click "New map" button
- Note new descriptive copy under each label

Closes #430
