### PR TITLE
Update data tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Update data tooling [#468](https://github.com/PublicMapping/districtbuilder/pull/468)
+
 ### Changed
 
 - Updates to project page sharing & read-only mode [#469](https://github.com/PublicMapping/districtbuilder/pull/469)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ $ ./scripts/manage publish-region data/output-pa US PA Pennsylvania
 
 Once your data is published, you should be able to run the app and create a new project through the UI using that region and begin building districts.
 
+If instead you'd like to use the processed data to update S3 in-place (and not insert a new region into the database), you may instead run the command:
+
+```
+$ ./scripts/manage update-region data/output-pa s3://previous/location/of/the/published/region
+```
+
+Note: when doing this, you will need to restart your server to see the new data, since it's cached on startup
+
 ### Project Organization
 
 In order to allow for code-sharing across the frontend and backend in conjunction with an unejected Create React App (CRA), it was decided that the simplest and least error-prone way forward was to structure the code as such:

--- a/src/manage/README.md
+++ b/src/manage/README.md
@@ -18,7 +18,7 @@ $ npm install -g manage
 $ manage COMMAND
 running command...
 $ manage (-v|--version|version)
-manage/0.1.0 linux-x64 node-v12.13.0
+manage/0.1.0 linux-x64 node-v12.18.4
 $ manage --help [COMMAND]
 USAGE
   $ manage COMMAND
@@ -30,6 +30,7 @@ USAGE
 * [`manage help [COMMAND]`](#manage-help-command)
 * [`manage process-geojson FILE`](#manage-process-geojson-file)
 * [`manage publish-region STATICDATADIR COUNTRYCODE REGIONCODE REGIONNAME`](#manage-publish-region-staticdatadir-countrycode-regioncode-regionname)
+* [`manage update-region STATICDATADIR UPDATES3DIR`](#manage-update-region-staticdatadir-updates3dir)
 
 ## `manage help [COMMAND]`
 
@@ -64,13 +65,18 @@ OPTIONS
 
   -l, --levels=levels                  [default: block,blockgroup,county] Comma-separated geolevel hierarchy: smallest
                                        to largest
+                                       To use a different name for the layer ID from the GeoJSON property,
+                                       separate values by ':'
+                                       e.g. -l geoid:block,blockgroupuuid:blockgroup,county
 
   -n, --levelMinZoom=levelMinZoom      [default: 8,0,0] Comma-separated minimum zoom level per geolevel, must match # of
                                        levels
 
   -o, --outputDir=outputDir            [default: ./] Directory to output files
 
-  -s, --simplification=simplification  [default: 0.001] Topojson simplification amount (minWeight)
+  -s, --simplification=simplification  [default: 0.000000025] Topojson simplification amount (minWeight)
+
+  -u, --inputS3Dir=inputS3Dir          S3 directory for the previous run if we will be updating in-place
 
   -x, --levelMaxZoom=levelMaxZoom      [default: g,g,g] Comma-separated maximum zoom level per geolevel, must match # of
                                        levels
@@ -91,7 +97,7 @@ DESCRIPTION
 
 ## `manage publish-region STATICDATADIR COUNTRYCODE REGIONCODE REGIONNAME`
 
-describe the command here
+upload processed region files to S3
 
 ```
 USAGE
@@ -105,5 +111,18 @@ ARGUMENTS
 
 OPTIONS
   -b, --bucketName=bucketName  [default: global-districtbuilder-dev-us-east-1] Bucket to upload the files to
+```
+
+## `manage update-region STATICDATADIR UPDATES3DIR`
+
+update processed region files in-place on S3
+
+```
+USAGE
+  $ manage update-region STATICDATADIR UPDATES3DIR
+
+ARGUMENTS
+  STATICDATADIR  Directory of the region's static data (the output of `process-geojson`)
+  UPDATES3DIR    S3 directory to update in-place
 ```
 <!-- commandsstop -->

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -738,7 +738,6 @@ it when necessary (file sizes ~1GB+).
         const newProperties = newFeatures[i].properties;
         const prevProperties = prevFeatures[i].properties;
         const baseId = newProperties[baseLevel];
-
         for (const geoLevel of geoLevelIds) {
           const newProp = newProperties[geoLevel];
           const prevProp = prevProperties[geoLevel];

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -738,6 +738,7 @@ it when necessary (file sizes ~1GB+).
         const newProperties = newFeatures[i].properties;
         const prevProperties = prevFeatures[i].properties;
         const baseId = newProperties[baseLevel];
+
         for (const geoLevel of geoLevelIds) {
           const newProp = newProperties[geoLevel];
           const prevProp = prevProperties[geoLevel];

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -1,5 +1,6 @@
 import { Command, flags } from "@oclif/command";
 import { IArg } from "@oclif/parser/lib/args";
+import S3 from "aws-sdk/clients/s3";
 import cli from "cli-ux";
 import { mapSync } from "event-stream";
 import { createReadStream, createWriteStream, existsSync, readFileSync, writeFileSync } from "fs";
@@ -82,6 +83,12 @@ it when necessary (file sizes ~1GB+).
       char: "o",
       description: "Directory to output files",
       default: "./"
+    }),
+
+    inputS3Dir: flags.string({
+      char: "u",
+      description: "S3 directory for the previous run if we will be updating in-place",
+      default: ""
     })
   };
 
@@ -144,6 +151,21 @@ it when necessary (file sizes ~1GB+).
     }
 
     this.renameProps(baseGeoJson, geoLevels);
+
+    if (!flags.inputS3Dir) {
+      this.log("No inputS3Dir provided, no sorting needed");
+    } else {
+      cli.action.start("Pulling down previous GeoJSON for sorting");
+      const prevBaseGeoJson = await this.readGeoJsonFromS3(flags.inputS3Dir, geoLevelIds[0]);
+      cli.action.stop();
+
+      this.log("Sorting GeoJSON based on previous version");
+      const errorMessage = this.sortGeoJsonByPrev(baseGeoJson, prevBaseGeoJson, geoLevelIds);
+      if (errorMessage !== null) {
+        this.log(`Error encountered while sorting GeoJSON: "${errorMessage}"`);
+        return;
+      }
+    }
 
     const topoJsonHierarchy = this.mkTopoJsonHierarchy(
       baseGeoJson,
@@ -325,6 +347,30 @@ it when necessary (file sizes ~1GB+).
   async readBigGeoJson(path: string): Promise<FeatureCollection<Polygon, {}>> {
     return new Promise(resolve =>
       createReadStream(path, { encoding: "utf8" })
+        .pipe(parse("features"))
+        .pipe(
+          mapSync((features: any) => {
+            resolve({ type: "FeatureCollection", features });
+          })
+        )
+    );
+  }
+
+  // Reads a GeoJSON file from S3, given the S3 run directory and the geolevel id
+  async readGeoJsonFromS3(
+    inputS3Dir: string,
+    geoLevelId: string
+  ): Promise<FeatureCollection<Polygon, {}>> {
+    const uriComponents = inputS3Dir.split("/");
+    const bucket = uriComponents[2];
+    const key = `${uriComponents.slice(3).join("/")}${geoLevelId}.geojson`;
+    return new Promise(resolve =>
+      new S3()
+        .getObject({
+          Bucket: bucket,
+          Key: key
+        })
+        .createReadStream()
         .pipe(parse("features"))
         .pipe(
           mapSync((features: any) => {
@@ -663,6 +709,57 @@ it when necessary (file sizes ~1GB+).
           )
         )
       : childGeoms.map((childGeom: any) => childGeom.id);
+  }
+
+  // Sorts GeoJSON in the same order as a reference GeoJSON and performs structural checks
+  sortGeoJsonByPrev(
+    newGeoJson: FeatureCollection<Polygon, any>,
+    prevGeoJson: FeatureCollection<Polygon, any>,
+    geoLevelIds: readonly string[]
+  ): string | null {
+    const baseGeoLevelId = geoLevelIds[0];
+    const newFeatures = newGeoJson.features;
+    const prevFeatures = prevGeoJson.features;
+    if (newFeatures.length !== prevFeatures.length) {
+      return `feature count was: ${prevFeatures.length}, and is now: ${newFeatures.length}`;
+    }
+
+    // For the previous GeoJSON, create a map of base geounit id => index, so we can sort quickly
+    const prevIndexMap = prevFeatures.reduce(
+      (acc, feature, index) => acc.set(feature.properties[baseGeoLevelId], index),
+      new Map()
+    );
+
+    // Sort new GeoJSON using previous GeoJSON indices as a reference
+    newFeatures.sort((x, y) =>
+      prevIndexMap.get(x.properties[baseGeoLevelId]) >
+      prevIndexMap.get(y.properties[baseGeoLevelId])
+        ? 1
+        : -1
+    );
+
+    // Check that all geolevel attributes are the same between new and previous.
+    // Any differences indicate a change in structure, and we can't continue.
+    for (let i = 0; i < newFeatures.length; i++) {
+      const newProperties = newFeatures[i].properties;
+      const prevProperties = prevFeatures[i].properties;
+
+      // Checking the base geolevel here may seem superflous, since it's been sorted by that, but
+      // it'll catch the case where the number of features are the same, but may still be different.
+      // Example: block #998 is removed and replaced with a new block #999 feature.
+      // It's also a good sanity check to ensure sorting was performed correctly.
+      for (const level of geoLevelIds) {
+        const baseId = newProperties[baseGeoLevelId];
+        const newProp = newProperties[level];
+        const prevProp = prevProperties[level];
+        if (newProp !== prevProp) {
+          return `new ${level} is: ${newProp}, was: ${prevProp} for ${baseGeoLevelId}: ${baseId}`;
+        }
+      }
+    }
+
+    // A return of null means no errors have been encountered
+    return null;
   }
 }
 

--- a/src/manage/src/commands/publish-region.ts
+++ b/src/manage/src/commands/publish-region.ts
@@ -10,7 +10,7 @@ import { RegionConfig } from "../../../server/src/region-configs/entities/region
 import { connectionOptions } from "../lib/dbUtils";
 
 export default class PublishRegion extends Command {
-  static description = "describe the command here";
+  static description = "upload processed region files to S3";
 
   static flags = {
     bucketName: flags.string({

--- a/src/manage/src/commands/update-region.ts
+++ b/src/manage/src/commands/update-region.ts
@@ -1,0 +1,51 @@
+import { Command } from "@oclif/command";
+import { IArg } from "@oclif/parser/lib/args";
+import S3 from "aws-sdk/clients/s3";
+import cli from "cli-ux";
+import { createReadStream } from "fs";
+import { join } from "path";
+import readDir from "recursive-readdir";
+
+export default class UpdateRegion extends Command {
+  static description = "update processed region files in-place on S3";
+
+  static args: IArg[] = [
+    {
+      name: "staticDataDir",
+      description: "Directory of the region's static data (the output of `process-geojson`)",
+      required: true
+    },
+    {
+      name: "updateS3Dir",
+      description: "S3 directory to update in-place",
+      required: true
+    }
+  ];
+
+  async run(): Promise<void> {
+    const { args } = this.parse(UpdateRegion);
+
+    const filePaths = await readDir(args.staticDataDir);
+    if (filePaths.length === 0) {
+      this.log("no files found for updating, exiting");
+      return;
+    }
+
+    cli.action.start(`Updating ${filePaths.length} files`);
+    const uriComponents = args.updateS3Dir.split("/");
+    const keyPrefix = uriComponents.slice(3).join("/");
+    const s3Client = new S3();
+    const uploadPromises = filePaths.map(filePath => {
+      return s3Client
+        .upload({
+          Body: createReadStream(filePath),
+          Bucket: uriComponents[2],
+          Key: join(keyPrefix, filePath.substring(args.staticDataDir.length))
+        })
+        .promise();
+    });
+    const responses = await Promise.all(uploadPromises);
+    cli.action.stop();
+    this.log(`Received ${responses.length} responses`);
+  }
+}


### PR DESCRIPTION
## Overview

When we receive updates to the data, we'd like to be able to easily push updates to S3. In order to ensure this goes smoothly, the new data must be sorted in the exact order as the old data. In addition, any structural changes to the data (e.g. blocks shifting from one county to another) must signal an error, as this would cause a hierarchy difference which would require a more involved migration. The `process-geojson` command has been updated to take an optional published region reference, which will be pulled down and used to sort the new data and check for inconsistencies. A new command, `update-region` has also been added, which will push this processed data up to the desired S3 location without making any database changes.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

On the left is my project before updating the data. On the right is after updating the data by shifting the GeoJSON order around and updating a single block population from 0 to 500k. The target populations have increased, and the first district reflects the additional 500k population.

![update-data-tooling](https://user-images.githubusercontent.com/6386/95513963-2c19f400-0989-11eb-9a7d-7f97d61551f0.png)

## Testing Instructions

 - Choose a region that you'd like to test with -- Delaware will save you some time
 - First process the region as you normally would, and publish it (if you already have a region published that you'd like to test with, you can skip this step)
    - `./scripts/manage process-geojson data/input/DE.geojson -o data/output-de -n 12,4,4 -x 12,12,12`
    - `./scripts/manage publish-region data/output-de US DE Delaware`
- Either record the S3 directory of the region that's output in the publish step, or grab it from the `region_config` table in your database
- Create a project, open it up, and keep it in a tab
- Open up your input GeoJSON file and remove a row from it
- Run the `process-geojson` command with the new parameter, pointing to your reference S3 directory, e.g.:
    - `./scripts/manage process-geojson data/input/DE.geojson -o data/output-de -n 12,4,4 -x 12,12,12 -u s3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-10-08T20:22:10.423Z/`
- You should receive an error, since the number of features doesn't match up
- Undo the change to that file
- Make a different kind of structural change to the file: e.g. change the blockgroup of a feature 
- Run the same command again, and you should receive another error, since the structure has changed
- Undo that change
- Make some non-structural changes to the file. E.g.: move some features around in the file, so the sort order would be different. Also, update the population of a feature: I changed the population of a feature from 0 to 500k.
- Run the same command again
- Since there were no structural changes to the file, it should complete successfully this time
- Run the `update-region` command to push this new data to the reference S3 directory, e.g.:
    - `./scripts/manage update-region data/output-de s3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-10-08T20:22:10.423Z/`
- Restart your server. This is important if you've changed populations, because the server will have the cached population data, the vector tiles will have the updated data, and you may be very confused
- Reload your project page, and you should see that any property changes you made have taken effect

Closes #456
