### PR TITLE
Update Project Screen read-only view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updates to project page sharing & read-only mode [#469](https://github.com/PublicMapping/districtbuilder/pull/469)
+
 ### Fixed
 
 ## [1.1.0] - 2020-10-08

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -117,7 +117,7 @@ const GeoLevelButton = ({
             className={buttonClassName(geoLevelIndex === index)}
             onClick={() =>
               store.dispatch(
-                !isCurrentLevelBaseGeoLevel || (!isReadOnly && advancedEditingEnabled)
+                !isCurrentLevelBaseGeoLevel || isReadOnly || advancedEditingEnabled
                   ? setGeoLevelIndex(index)
                   : showAdvancedEditingModal(true)
               )
@@ -180,26 +180,28 @@ const MapHeader = ({
   return (
     <Flex sx={style.header}>
       <Flex>
-        <Flex sx={{ ...style.buttonGroup, mr: 3 }}>
-          <Tooltip content="Point-and-click selection">
-            <Button
-              sx={{ ...style.selectionButton }}
-              className={buttonClassName(selectionTool === SelectionTool.Default)}
-              onClick={() => store.dispatch(setSelectionTool(SelectionTool.Default))}
-            >
-              <Icon name="hand-pointer" />
-            </Button>
-          </Tooltip>
-          <Tooltip content="Rectangle selection">
-            <Button
-              sx={{ ...style.selectionButton }}
-              className={buttonClassName(selectionTool === SelectionTool.Rectangle)}
-              onClick={() => store.dispatch(setSelectionTool(SelectionTool.Rectangle))}
-            >
-              <Icon name="draw-square" />
-            </Button>
-          </Tooltip>
-        </Flex>
+        {!isReadOnly && (
+          <Flex sx={{ ...style.buttonGroup, mr: 3 }}>
+            <Tooltip content="Point-and-click selection">
+              <Button
+                sx={{ ...style.selectionButton }}
+                className={buttonClassName(selectionTool === SelectionTool.Default)}
+                onClick={() => store.dispatch(setSelectionTool(SelectionTool.Default))}
+              >
+                <Icon name="hand-pointer" />
+              </Button>
+            </Tooltip>
+            <Tooltip content="Rectangle selection">
+              <Button
+                sx={{ ...style.selectionButton }}
+                className={buttonClassName(selectionTool === SelectionTool.Rectangle)}
+                onClick={() => store.dispatch(setSelectionTool(SelectionTool.Rectangle))}
+              >
+                <Icon name="draw-square" />
+              </Button>
+            </Tooltip>
+          </Flex>
+        )}
         <Flex>{geoLevelOptions}</Flex>
       </Flex>
       <Box sx={{ lineHeight: "1" }}>

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
-import { Box, Button, Flex, jsx, Text, ThemeUIStyleObject } from "theme-ui";
+import { Box, Button, Flex, jsx, Styled, Text, ThemeUIStyleObject } from "theme-ui";
 import { IProject } from "../../shared/entities";
 import { undo, redo } from "../actions/districtDrawing";
 import { heights } from "../theme";
@@ -45,10 +45,6 @@ const HeaderDivider = () => {
   );
 };
 
-interface SupportProps {
-  readonly invert?: boolean;
-}
-
 interface StateProps {
   readonly undoHistory: UndoHistory;
 }
@@ -56,8 +52,13 @@ interface StateProps {
 const ProjectHeader = ({
   map,
   project,
+  isReadOnly,
   undoHistory
-}: { readonly map?: MapboxGL.Map; readonly project?: IProject } & SupportProps & StateProps) => (
+}: {
+  readonly map?: MapboxGL.Map;
+  readonly project?: IProject;
+  readonly isReadOnly: boolean;
+} & StateProps) => (
   <Flex sx={style.projectHeader}>
     <Flex sx={{ variant: "header.left" }}>
       <Link
@@ -78,30 +79,51 @@ const ProjectHeader = ({
         }}
       >
         <Text as="h1" sx={{ variant: "header.title", m: 0 }}>
-          {project ? project.name : "..."}
+          {project && isReadOnly
+            ? `${project.name} by ${project.user.name}`
+            : project
+            ? project.name
+            : "..."}
         </Text>
       </Flex>
     </Flex>
     <Flex sx={{ variant: "header.right" }}>
-      {map && (
+      {!isReadOnly ? (
         <React.Fragment>
-          <Button
-            sx={style.undoRedo}
-            disabled={undoHistory.past.length === 0}
-            onClick={() => store.dispatch(undo(map))}
-          >
-            <Icon name="undo" />
-          </Button>
-          <Button
-            sx={{ ...style.undoRedo, pr: 4 }}
-            disabled={undoHistory.future.length === 0}
-            onClick={() => store.dispatch(redo(map))}
-          >
-            <Icon name="redo" />
-          </Button>
+          {map && (
+            <React.Fragment>
+              <Button
+                sx={style.undoRedo}
+                disabled={undoHistory.past.length === 0}
+                onClick={() => store.dispatch(undo(map))}
+              >
+                <Icon name="undo" />
+              </Button>
+              <Button
+                sx={{ ...style.undoRedo, pr: 4 }}
+                disabled={undoHistory.future.length === 0}
+                onClick={() => store.dispatch(redo(map))}
+              >
+                <Icon name="redo" />
+              </Button>
+            </React.Fragment>
+          )}
+          <ShareMenu invert={true} />
+          <SupportMenu invert={true} />
         </React.Fragment>
+      ) : (
+        <Styled.a
+          as={Link}
+          to="/"
+          sx={{
+            color: "muted",
+            fontWeight: "normal",
+            "&:active": { color: "muted" }
+          }}
+        >
+          Made with DistrictBuilder
+        </Styled.a>
       )}
-      <SupportMenu invert={true} />
     </Flex>
   </Flex>
 );

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -127,7 +127,8 @@ const ProjectSidebar = ({
   highlightedGeounits,
   geoUnitHierarchy,
   lockedDistricts,
-  saving
+  saving,
+  isReadOnly
 }: {
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
@@ -138,6 +139,7 @@ const ProjectSidebar = ({
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly lockedDistricts: LockedDistricts;
   readonly saving: SavingState;
+  readonly isReadOnly: boolean;
 } & LoadingProps) => {
   return (
     <Flex sx={style.sidebar}>
@@ -189,6 +191,7 @@ const ProjectSidebar = ({
                 highlightedGeounits={highlightedGeounits}
                 lockedDistricts={lockedDistricts}
                 saving={saving}
+                isReadOnly={isReadOnly}
               />
             )}
           </tbody>
@@ -252,7 +255,8 @@ const SidebarRow = memo(
     demographics,
     deviation,
     districtId,
-    isDistrictLocked
+    isDistrictLocked,
+    isReadOnly
   }: {
     readonly district: DistrictGeoJSON;
     readonly selected: boolean;
@@ -261,6 +265,7 @@ const SidebarRow = memo(
     readonly deviation: number;
     readonly districtId: number;
     readonly isDistrictLocked?: boolean;
+    readonly isReadOnly: boolean;
   }) => {
     const [isHovered, setHover] = useState(false);
     const selectedDifference = selectedPopulationDifference || 0;
@@ -353,7 +358,7 @@ const SidebarRow = memo(
                 <Icon name="lock-locked" color="#131f28" size={0.75} />
               </Button>
             </Tooltip>
-          ) : (
+          ) : !isReadOnly ? (
             <Tooltip content="Lock this district">
               <Button
                 variant="icon"
@@ -364,7 +369,7 @@ const SidebarRow = memo(
                 <Icon name="lock-unlocked" size={0.75} />
               </Button>
             </Tooltip>
-          )}
+          ) : null}
         </Styled.td>
       </Styled.tr>
     );
@@ -380,6 +385,7 @@ interface SidebarRowsProps {
   readonly highlightedGeounits: GeoUnits;
   readonly lockedDistricts: LockedDistricts;
   readonly saving: SavingState;
+  readonly isReadOnly: boolean;
 }
 
 const SidebarRows = ({
@@ -389,7 +395,8 @@ const SidebarRows = ({
   selectedDistrictId,
   selectedGeounits,
   highlightedGeounits,
-  lockedDistricts
+  lockedDistricts,
+  isReadOnly
 }: SidebarRowsProps) => {
   // Results of the asynchronous demographics calculation. The two calculations have been
   // combined into a single object here, because we want both updates to the state to happen
@@ -482,6 +489,7 @@ const SidebarRows = ({
             key={districtId}
             isDistrictLocked={lockedDistricts.has(districtId)}
             districtId={districtId}
+            isReadOnly={isReadOnly}
           />
         );
       })}

--- a/src/client/components/ProjectSidebarHeader.tsx
+++ b/src/client/components/ProjectSidebarHeader.tsx
@@ -50,14 +50,13 @@ const ProjectSidebarHeader = ({
         <Flex sx={{ alignItems: "center", justifyContent: "center" }}>
           <Spinner variant="spinner.small" />
         </Flex>
-      ) : areAnyGeoUnitsSelected(selectedGeounits) ? (
+      ) : isReadOnly ? null : areAnyGeoUnitsSelected(selectedGeounits) ? (
         <Flex sx={{ variant: "header.right" }}>
           <Tooltip
             placement="top-start"
             content={
               <span>
-                <strong>{!isReadOnly ? "Cancel" : "Clear"} changes</strong> to revert to{" "}
-                {!isReadOnly ? "your" : "the"} previously saved map
+                <strong>Cancel changes</strong> to revert to your previously saved map
               </span>
             }
           >
@@ -68,29 +67,27 @@ const ProjectSidebarHeader = ({
                 store.dispatch(clearSelectedGeounits(true));
               }}
             >
-              {!isReadOnly ? "Cancel" : "Clear"}
+              Cancel
             </Button>
           </Tooltip>
-          {!isReadOnly && (
-            <Tooltip
-              placement="top-start"
-              content={
-                <span>
-                  <strong>Accept changes</strong> to save your map
-                </span>
-              }
+          <Tooltip
+            placement="top-start"
+            content={
+              <span>
+                <strong>Accept changes</strong> to save your map
+              </span>
+            }
+          >
+            <Button
+              variant="circular"
+              onClick={() => {
+                store.dispatch(updateDistrictsDefinition());
+              }}
             >
-              <Button
-                variant="circular"
-                onClick={() => {
-                  store.dispatch(updateDistrictsDefinition());
-                }}
-              >
-                <Icon name="check" />
-                Accept
-              </Button>
-            </Tooltip>
-          )}
+              <Icon name="check" />
+              Accept
+            </Button>
+          </Tooltip>
         </Flex>
       ) : saving === "saved" ? (
         <Tooltip placement="top-start" content={<span>Your map is saved</span>}>

--- a/src/client/components/map/AdvancedEditingModal.tsx
+++ b/src/client/components/map/AdvancedEditingModal.tsx
@@ -37,13 +37,11 @@ const style: ThemeUIStyleObject = {
 const AdvancedEditingModal = ({
   id,
   geoLevels,
-  showModal,
-  isReadOnly
+  showModal
 }: {
   readonly id: ProjectId;
   readonly geoLevels: readonly GeoLevelInfo[];
   readonly showModal: boolean;
-  readonly isReadOnly: boolean;
 }) => {
   const [isPending, setIsPending] = useState(false);
   const geoLevel = geoLevels[0].id;
@@ -89,10 +87,8 @@ const AdvancedEditingModal = ({
               you when you zoom back in!)
             </li>
             <li>
-              Once you select one or more {geoLevel}s, you will need to{" "}
-              {!isReadOnly ? "resolve" : "clear"} pending changes
-              {isReadOnly || " (click Accept or Cancel) "} before you can leave {geoLevelTitle}{" "}
-              Editing.
+              Once you select one or more {geoLevel}s, you will need to resolve pending changes
+              (click Accept or Cancel before you can leave {geoLevelTitle} Editing.
             </li>
           </ul>
         </Box>
@@ -107,21 +103,15 @@ const AdvancedEditingModal = ({
           <Button
             disabled={isPending}
             onClick={() => {
-              if (isReadOnly) {
-                store.dispatch(setGeoLevelIndex(geoLevels.length - 1));
-                hideModal();
-                return;
-              } else {
-                setIsPending(true);
-                patchProject(id, { advancedEditingEnabled: true })
-                  .then(() => {
-                    store.dispatch(setGeoLevelIndex(geoLevels.length - 1));
-                    store.dispatch(projectFetch(id));
-                    hideModal();
-                  })
-                  .finally(() => setIsPending(false));
-                return;
-              }
+              setIsPending(true);
+              patchProject(id, { advancedEditingEnabled: true })
+                .then(() => {
+                  store.dispatch(setGeoLevelIndex(geoLevels.length - 1));
+                  store.dispatch(projectFetch(id));
+                  hideModal();
+                })
+                .finally(() => setIsPending(false));
+              return;
             }}
           >
             Start {geoLevel} editing

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -47,6 +47,7 @@ interface Props {
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number;
   readonly lockedDistricts: LockedDistricts;
+  readonly isReadOnly: boolean;
   readonly label?: string;
   readonly map?: MapboxGL.Map;
   // eslint-disable-next-line
@@ -63,6 +64,7 @@ const DistrictsMap = ({
   selectionTool,
   geoLevelIndex,
   lockedDistricts,
+  isReadOnly,
   label,
   map,
   setMap
@@ -321,7 +323,7 @@ const DistrictsMap = ({
       DefaultSelectionTool.disable(map);
       RectangleSelectionTool.disable(map);
       // Enable appropriate tool
-      if (selectionTool === SelectionTool.Default) {
+      if (!isReadOnly && selectionTool === SelectionTool.Default) {
         DefaultSelectionTool.enable(
           map,
           selectedGeolevel.id,
@@ -330,7 +332,7 @@ const DistrictsMap = ({
           lockedDistricts,
           staticGeoLevels
         );
-      } else if (selectionTool === SelectionTool.Rectangle) {
+      } else if (!isReadOnly && selectionTool === SelectionTool.Rectangle) {
         RectangleSelectionTool.enable(
           map,
           selectedGeolevel.id,
@@ -349,7 +351,8 @@ const DistrictsMap = ({
     staticMetadata,
     staticGeoLevels,
     project,
-    lockedDistricts
+    lockedDistricts,
+    isReadOnly
   ]);
 
   return (

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -99,7 +99,7 @@ const ProjectScreen = ({
     <Redirect to={"/login"} />
   ) : (
     <Flex sx={{ height: "100%", flexDirection: "column" }}>
-      <ProjectHeader map={map} project={project} />
+      <ProjectHeader map={map} project={project} isReadOnly={isReadOnly} />
       <Flex sx={{ flex: 1, overflowY: "auto" }}>
         <ProjectSidebar
           project={project}
@@ -112,6 +112,7 @@ const ProjectScreen = ({
           geoUnitHierarchy={geoUnitHierarchy}
           lockedDistricts={districtDrawing.undoHistory.present.lockedDistricts}
           saving={districtDrawing.saving}
+          isReadOnly={isReadOnly}
         />
         <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>
           <MapHeader
@@ -136,15 +137,17 @@ const ProjectScreen = ({
                 selectionTool={districtDrawing.selectionTool}
                 geoLevelIndex={districtDrawing.undoHistory.present.geoLevelIndex}
                 lockedDistricts={districtDrawing.undoHistory.present.lockedDistricts}
+                isReadOnly={isReadOnly}
                 label={label}
                 map={map}
                 setMap={setMap}
               />
-              <AdvancedEditingModal
-                id={project.id}
-                geoLevels={staticMetadata.geoLevelHierarchy}
-                isReadOnly={isReadOnly}
-              />
+              {!isReadOnly && (
+                <AdvancedEditingModal
+                  id={project.id}
+                  geoLevels={staticMetadata.geoLevelHierarchy}
+                />
+              )}
             </React.Fragment>
           ) : null}
         </Flex>

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -23,7 +23,7 @@ import {
 import { FeatureCollection } from "geojson";
 
 import { MakeDistrictsErrors } from "../../../../shared/constants";
-import { ProjectId } from "../../../../shared/entities";
+import { ProjectId, PublicUserProperties } from "../../../../shared/entities";
 import { TopologyService } from "../../districts/services/topology.service";
 
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
@@ -50,7 +50,7 @@ import { RegionConfigsService } from "../../region-configs/services/region-confi
         eager: true
       },
       user: {
-        allow: ["id"],
+        allow: ["id", "name"] as PublicUserProperties[],
         eager: true
       }
     }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -1,5 +1,7 @@
 export type UserId = string;
 
+export type PublicUserProperties = "id" | "name";
+
 export interface IUser {
   readonly id: UserId;
   readonly email: string;
@@ -96,7 +98,7 @@ export interface IProject {
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
   readonly districtsDefinition: DistrictsDefinition;
-  readonly user: Pick<IUser, "id">;
+  readonly user: Pick<IUser, PublicUserProperties>;
   readonly advancedEditingEnabled: boolean;
 }
 


### PR DESCRIPTION
## Overview

Updates the UX of the project screen when in readonly mode, as per issue #455 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_projects_2feb7761-1a80-421b-abd1-dd05fde6bdb9](https://user-images.githubusercontent.com/4432106/95519769-d0a13380-0993-11eb-8663-4545383cdecb.png)


## Testing Instructions

- `scripts/server`
- The project page should continue to function as normal when editing your own project
- The project page should match the changes outlined in #455 when viewing someone else's project, whether or not you are logged in

Closes #455
