### PR TITLE
Specify max-old-space-size on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updates to project page sharing & read-only mode [#469](https://github.com/PublicMapping/districtbuilder/pull/469)
+- Specify max-old-space-size on server [#470](https://github.com/PublicMapping/districtbuilder/pull/470)
 
 ### Fixed
 

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -31,7 +31,7 @@
       },
       {
         "name": "NODE_OPTIONS",
-        "value": "--max_old_space_size=${max_old_space_size}"
+        "value": "--max-old-space-size=${max_old_space_size}"
       },
       {
         "name": "AWS_REGION",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - POSTGRES_PASSWORD=districtbuilder
       - POSTGRES_DB=districtbuilder
       - NODE_ENV=Development
+      - NODE_OPTIONS=--max-old-space-size=14336
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - JWT_SECRET=insecure


### PR DESCRIPTION
## Overview

We set this in the CLI for processing files, in order to deal with processing large files in memory. When loading up Texas, we also
need this set on the server, or else it fails to load the topojson into memory.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![texas](https://user-images.githubusercontent.com/6386/95783263-807de600-0c9f-11eb-8ff2-fb84519262bd.png)

## Testing Instructions

 * Insert Texas into your DB
     * `./scripts/dbshell`
     * `INSERT INTO "region_config"("name", "country_code", "region_code", "s3_uri", "version") VALUES ('Texas','US','TX','s3://global-districtbuilder-dev-us-east-1/regions/US/TX/2020-10-12T16:56:43.962Z/','2020-10-12T16:56:43.962Z');`
 * `./scripts/server`
 * It may take a minute to load, but you shouldn't see any memory errors in the server log
 * You should be able to create a map with Texas data
