### PR TITLE
Make it possible to swap out the RDS DB parameter group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Microcopy to Create Map and description props to text and select fields [#467](https://github.com/PublicMapping/districtbuilder/pull/467)
-
 - Add product tour [#471](https://github.com/PublicMapping/districtbuilder/pull/471)
 - Update data tooling [#468](https://github.com/PublicMapping/districtbuilder/pull/468)
 - Find unassigned menu [#476](https://github.com/PublicMapping/districtbuilder/pull/476)
@@ -19,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates to project page sharing & read-only mode [#469](https://github.com/PublicMapping/districtbuilder/pull/469)
 - Specify max-old-space-size on server [#470](https://github.com/PublicMapping/districtbuilder/pull/470)
 - Fix formatting of population counts [#474](https://github.com/PublicMapping/districtbuilder/pull/474)
+- Make it possible to swap out the RDS DB parameter group [#478](https://github.com/PublicMapping/districtbuilder/pull/478)
 
 ### Fixed
 

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_parameter_group" "default" {
-  name        = var.rds_database_identifier
+  name_prefix = var.rds_database_identifier
   description = "Parameter group for the RDS instances"
   family      = var.rds_parameter_group_family
 
@@ -62,6 +62,10 @@ resource "aws_db_parameter_group" "default" {
     Name        = "dbpgDatabaseServer"
     Project     = var.project
     Environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Overview

Add support for [name_prefix](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#name_prefix) and the [create_before_destroy](https://www.terraform.io/docs/configuration/resources.html#create_before_destroy) lifecycle customization so that a new parameter group is created and applied before disposing of the old one when making modifications that require a new resource.

Connects #340 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

I bumped the `rds_engine_version` and `rds_parameter_group_family` variables in the `.tfvars` file. Then, I ran Terraform to create a new parameter group to use in the PostgreSQL 12 upgrade.

<details>
<summary>Details</summary>

```bash
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
+/- create replacement and then destroy

Terraform will perform the following actions:

  # aws_db_parameter_group.default must be replaced
+/- resource "aws_db_parameter_group" "default" {
      ~ arn         = "arn:aws:rds:us-east-1:273766372266:pg:districtbuilder-staging" -> (known after apply)
        description = "Parameter group for the RDS instances"
      ~ family      = "postgres11" -> "postgres12" # forces replacement
      ~ id          = "districtbuilder-staging" -> (known after apply)
      ~ name        = "districtbuilder-staging" -> (known after apply)
      + name_prefix = "districtbuilder-staging" # forces replacement
        tags        = {
            "Environment" = "Staging"
            "Name"        = "dbpgDatabaseServer"
            "Project"     = "DistrictBuilder"
        }

        parameter {
            apply_method = "immediate"
            name         = "log_autovacuum_min_duration"
            value        = "250"
        }
        parameter {
            apply_method = "immediate"
            name         = "log_connections"
            value        = "0"
        }
        parameter {
            apply_method = "immediate"
            name         = "log_disconnections"
            value        = "0"
        }
        parameter {
            apply_method = "immediate"
            name         = "log_lock_waits"
            value        = "1"
        }
        parameter {
            apply_method = "immediate"
            name         = "log_min_duration_statement"
            value        = "500"
        }
        parameter {
            apply_method = "immediate"
            name         = "log_temp_files"
            value        = "500"
        }
        parameter {
            apply_method = "immediate"
            name         = "random_page_cost"
            value        = "1"
        }
        parameter {
            apply_method = "immediate"
            name         = "seq_page_cost"
            value        = "1"
        }
    }

  # module.database.aws_db_instance.postgresql will be updated in-place
  ~ resource "aws_db_instance" "postgresql" {
        address                               = "districtbuilder-staging.cim5i6nhca55.us-east-1.rds.amazonaws.com"
        allocated_storage                     = 32
        arn                                   = "arn:aws:rds:us-east-1:273766372266:db:districtbuilder-staging"
        auto_minor_version_upgrade            = true
        availability_zone                     = "us-east-1a"
        backup_retention_period               = 30
        backup_window                         = "04:00-04:30"
        ca_cert_identifier                    = "rds-ca-2019"
        copy_tags_to_snapshot                 = true
        db_subnet_group_name                  = "districtbuilder-staging"
        delete_automated_backups              = true
        deletion_protection                   = false
        enabled_cloudwatch_logs_exports       = [
            "postgresql",
            "upgrade",
        ]
        endpoint                              = "districtbuilder-staging.cim5i6nhca55.us-east-1.rds.amazonaws.com:5432"
        engine                                = "postgres"
      ~ engine_version                        = "11.5" -> "12.4"
        final_snapshot_identifier             = "districtbuilder-rds-snapshot"
        hosted_zone_id                        = "Z2R2ITUGPM61AM"
        iam_database_authentication_enabled   = false
        id                                    = "districtbuilder-staging"
        identifier                            = "districtbuilder-staging"
        instance_class                        = "db.t3.micro"
        iops                                  = 0
        license_model                         = "postgresql-license"
        maintenance_window                    = "sun:04:30-sun:05:30"
        max_allocated_storage                 = 0
        monitoring_interval                   = 0
        multi_az                              = false
        name                                  = "districtbuilder"
        option_group_name                     = "default:postgres-11"
      ~ parameter_group_name                  = "districtbuilder-staging" -> (known after apply)
        password                              = (sensitive value)
        performance_insights_enabled          = false
        performance_insights_retention_period = 0
        port                                  = 5432
        publicly_accessible                   = false
        replicas                              = []
        resource_id                           = "db-HATFABSIDOHJ3NE7QA47EH34WQ"
        security_group_names                  = []
        skip_final_snapshot                   = false
        status                                = "available"
        storage_encrypted                     = false
        storage_type                          = "gp2"
        tags                                  = {
            "Environment" = "Staging"
            "Name"        = "DatabaseServer"
            "Project"     = "DistrictBuilder"
        }
        username                              = "districtbuilder"
        vpc_security_group_ids                = [
            "sg-0e686707fb85d39f7",
        ]
    }

Plan: 1 to add, 1 to change, 1 to destroy.

------------------------------------------------------------------------
```

</details>

The actual upgrade didn't happen here, since [`allow_major_version_upgrade`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#allow_major_version_upgrade) is not set.

<details>
<summary>Details</summary>

```bash
Error: Error modifying DB Instance districtbuilder-staging: InvalidParameterCombination: The AllowMajorVersionUpgrade flag must be present when upgrading to a new major version.
        status code: 400, request id: 299dedfe-4b1e-4746-8b2a-5c562d9f8c89
```

</details>

I upgraded the DB instance via the AWS Console, with the new parameter group, and ran Terraform to clean up the deposed parameter group.

<details>
<summary>Details</summary>

```bash
------------------------------------------------------------------------                                                                                                                                                                                          

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_db_parameter_group.default (deposed object 3e01dd18) will be destroyed
  - resource "aws_db_parameter_group" "default" {
      - arn         = "arn:aws:rds:us-east-1:273766372266:pg:districtbuilder-staging" -> null
      - description = "Parameter group for the RDS instances" -> null
      - family      = "postgres11" -> null
      - id          = "districtbuilder-staging" -> null
      - name        = "districtbuilder-staging" -> null
      - tags        = {
          - "Environment" = "Staging"
          - "Name"        = "dbpgDatabaseServer"
          - "Project"     = "DistrictBuilder"
        } -> null

      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_autovacuum_min_duration" -> null
          - value        = "250" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_connections" -> null
          - value        = "0" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_disconnections" -> null
          - value        = "0" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_lock_waits" -> null
          - value        = "1" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_min_duration_statement" -> null
          - value        = "500" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "log_temp_files" -> null
          - value        = "500" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "random_page_cost" -> null
          - value        = "1" -> null
        }
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "seq_page_cost" -> null
          - value        = "1" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------
```

</details>
