### PR TITLE
Add support for single county region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add product tour [#471](https://github.com/PublicMapping/districtbuilder/pull/471)
 - Update data tooling [#468](https://github.com/PublicMapping/districtbuilder/pull/468)
 - Find unassigned menu [#476](https://github.com/PublicMapping/districtbuilder/pull/476)
+- Add support for single county region [#479](https://github.com/PublicMapping/districtbuilder/pull/479)
 
 ### Changed
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
-import { areAnyGeoUnitsSelected, geoLevelLabel } from "../functions";
+import { areAnyGeoUnitsSelected, geoLevelLabel, isBaseGeoLevelAlwaysVisible } from "../functions";
 
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
@@ -90,9 +90,11 @@ const GeoLevelButton = ({
 }) => {
   const label = geoLevelLabel(value.id);
   const areGeoUnitsSelected = areAnyGeoUnitsSelected(selectedGeounits);
+  const isBaseLevelAlwaysVisible = isBaseGeoLevelAlwaysVisible(geoLevelHierarchy);
   const isBaseGeoLevelSelected = geoLevelIndex === geoLevelHierarchy.length - 1;
   const isCurrentLevelBaseGeoLevel = index === geoLevelHierarchy.length - 1;
   const areChangesPending =
+    !isBaseLevelAlwaysVisible &&
     areGeoUnitsSelected &&
     // block level selected, so disable all higher geolevels
     ((isBaseGeoLevelSelected && !isCurrentLevelBaseGeoLevel) ||
@@ -117,7 +119,10 @@ const GeoLevelButton = ({
             className={buttonClassName(geoLevelIndex === index)}
             onClick={() =>
               store.dispatch(
-                !isCurrentLevelBaseGeoLevel || isReadOnly || advancedEditingEnabled
+                !isCurrentLevelBaseGeoLevel ||
+                  isReadOnly ||
+                  advancedEditingEnabled ||
+                  isBaseLevelAlwaysVisible
                   ? setGeoLevelIndex(index)
                   : showAdvancedEditingModal(true)
               )

--- a/src/client/components/Tour.tsx
+++ b/src/client/components/Tour.tsx
@@ -31,12 +31,20 @@ class Tour extends Component<Props, State> {
       Math.round(getTargetPopulation(props.geojson, props.project))
     ).toLocaleString();
     const regionConfig = props.project.regionConfig.name;
-    const geoLevels = props.staticMetadata.geoLevelHierarchy
-      .map(geolevel => geoLevelLabel(geolevel.id).toLowerCase())
+    const geoLevelsSingular = props.staticMetadata.geoLevelHierarchy
+      .map(geolevel => geolevel.id)
       .reverse();
-    const availableGeolevels = `${geoLevels.slice(0, -1).join(", ")}, and ${
-      geoLevels[geoLevels.length - 1]
-    }`;
+    const largestGeoLevelSingular = geoLevelsSingular[0];
+    const geoLevelsPlural = geoLevelsSingular.map(label => geoLevelLabel(label).toLowerCase());
+    const largestGeoLevelPlural = geoLevelsPlural[0];
+    const availableGeolevelsText =
+      geoLevelsPlural.length > 2
+        ? `${geoLevelsPlural.slice(0, -1).join(", ")}, and ${
+            geoLevelsPlural[geoLevelsPlural.length - 1]
+          }`
+        : geoLevelsPlural.length == 2
+        ? `${largestGeoLevelPlural} and ${geoLevelsPlural[1]}`
+        : largestGeoLevelPlural;
 
     this.state = {
       run: !props.user.hasSeenTour,
@@ -103,7 +111,7 @@ class Tour extends Component<Props, State> {
               Your objective: build <strong>{numberOfDistricts} districts</strong> for{" "}
               <strong>{regionConfig}, </strong>
               each with a population of <strong>{population}.</strong> Use DistrictBuilder to group{" "}
-              {availableGeolevels} into districts.
+              {availableGeolevelsText} into districts.
             </p>
           ),
           disableBeacon: true,
@@ -189,15 +197,16 @@ class Tour extends Component<Props, State> {
                   src={require("../media/tour-clicking-counties-sidebar.gif")}
                   width="100%"
                   height="auto"
-                  alt="User clicks on two counties in the application and the sidebar updates."
+                  alt="User clicks on two geounits in the application and the sidebar updates."
                 />
               </Styled.div>
               <p>
                 We’re ready to start building! By default, District 1 is selected in the sidebar. As
-                you add counties, you can see the population of District 1 increase.
+                you add {largestGeoLevelPlural}, you can see the population of District 1 increase.
               </p>
               <Styled.div sx={{ bg: "success.1", color: "success.8", borderRadius: "2", p: 3 }}>
-                <strong>Try it now:</strong> click on a county on the map to add it to District 1.
+                <strong>Try it now:</strong> click on a {largestGeoLevelSingular} on the map to add
+                it to District 1.
               </Styled.div>
             </div>
           ),
@@ -215,9 +224,9 @@ class Tour extends Component<Props, State> {
           content: (
             <div>
               <p>
-                When you are happy with District 1, click “Accept” to save your changes. The
-                counties you selected will turn green, matching the color of District 1, meaning
-                they have been saved to District 1.
+                When you are happy with District 1, click “Accept” to save your changes. The{" "}
+                {largestGeoLevelPlural} you selected will turn green, matching the color of District
+                1, meaning they have been saved to District 1.
               </p>
             </div>
           ),
@@ -248,20 +257,29 @@ class Tour extends Component<Props, State> {
                   src={require("../media/tour-counties-blockgroups.gif")}
                   width="100%"
                   height="auto"
-                  alt="User selects counties vs. blockgroups."
+                  alt="User toggles geolevel selection"
                 />
               </Styled.div>
-              <p>
-                We recommend starting your map with counties because they are the largest census
-                boundary. Try to evenly distribute the population between all districts the best you
-                can.
-              </p>
-              <p>
-                Working with counties is like using a large paint roller – great for covering a lot
-                of ground quickly, but eventually you need a more detailed tool around the edges.
-                Switch to block groups to make finer level changes to your map and get even closer
-                to zero deviation.
-              </p>
+              {geoLevelsPlural.length === 1 ? (
+                <p>
+                  The only census boundary available for this map is {largestGeoLevelPlural}. Try to
+                  evenly distribute the population between all districts the best you can.
+                </p>
+              ) : (
+                <p>
+                  We recommend starting your map with {largestGeoLevelPlural} because they are the
+                  largest census boundary available for this map. Try to evenly distribute the
+                  population between all districts the best you can.
+                </p>
+              )}
+              {geoLevelsPlural.length === 1 ? null : (
+                <p>
+                  Working with {largestGeoLevelPlural} is like using a large paint roller – great
+                  for covering a lot of ground quickly, but eventually you need a more detailed tool
+                  around the edges. Switch to {geoLevelsPlural[1]} to make finer level changes to
+                  your map and get even closer to zero deviation.
+                </p>
+              )}
             </div>
           ),
           placement: "auto",

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -17,7 +17,7 @@ import {
   setFeaturesSelectedFromGeoUnits,
   getChildGeoUnits
 } from "./index";
-import { mergeGeoUnits } from "../../functions";
+import { isBaseGeoLevelAlwaysVisible, mergeGeoUnits } from "../../functions";
 
 import {
   DistrictsDefinition,
@@ -52,6 +52,8 @@ const RectangleSelectionTool: ISelectionTool = {
     map.getCanvas().style.cursor = "crosshair"; // eslint-disable-line
 
     const canvas = map.getCanvasContainer();
+
+    const isBaseLevelAlwaysVisible = isBaseGeoLevelAlwaysVisible(staticMetadata.geoLevelHierarchy);
 
     // Variable to hold the starting xy coordinates
     // when `mousedown` occured.
@@ -265,10 +267,16 @@ const RectangleSelectionTool: ISelectionTool = {
         // blockgroup is selected and then the county _containing_ that blockgroup is selected)
         Object.values(geoUnits).forEach(geoUnitsForLevel => {
           geoUnitsForLevel.forEach(geoUnitIndices => {
-            // Ignore bottom two geolevels (base geounits can't have sub-features and base geounits
-            // also can't be selected at the same time as features from one geolevel up)
+            // Ignore bottom geolevel, because it can't have sub-features. And if the base geolevel
+            // is not always visible, we can also ignore one additional geolevel, because these base
+            // geounits can't be selected at the same time as features from one geolevel up).
+            const numLevelsToIgnore = isBaseLevelAlwaysVisible ? 1 : 2;
+
             // eslint-disable-next-line
-            if (geoUnitIndices.length <= staticMetadata.geoLevelHierarchy.length - 2) {
+            if (
+              geoUnitIndices.length <=
+              staticMetadata.geoLevelHierarchy.length - numLevelsToIgnore
+            ) {
               const { childGeoUnits } = getChildGeoUnits(
                 geoUnitIndices,
                 staticMetadata,

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -18,6 +18,12 @@ export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
   return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
 }
 
+// Determines if we are in a scenario where all geolevels have the same minimum zoom,
+// and thus, the base geolevel doesn't require special handling
+export function isBaseGeoLevelAlwaysVisible(geoLevelHierarchy: GeoLevelHierarchy) {
+  return new Set(geoLevelHierarchy.map(level => level.minZoom)).size === 1;
+}
+
 export function allGeoUnitIndices(geoUnits: GeoUnits) {
   return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.values()));
 }

--- a/src/manage/README.md
+++ b/src/manage/README.md
@@ -18,7 +18,7 @@ $ npm install -g manage
 $ manage COMMAND
 running command...
 $ manage (-v|--version|version)
-manage/0.1.0 linux-x64 node-v12.18.4
+manage/0.1.0 linux-x64 node-v12.19.0
 $ manage --help [COMMAND]
 USAGE
   $ manage COMMAND
@@ -62,6 +62,8 @@ OPTIONS
 
   -d, --demographics=demographics      [default: population,white,black,asian,hispanic,other] Comma-separated census
                                        demographics to select and aggregate
+
+  -f, --filterPrefix=filterPrefix      Filter to only base geounits containing the specified prefix
 
   -l, --levels=levels                  [default: block,blockgroup,county] Comma-separated geolevel hierarchy: smallest
                                        to largest

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -89,6 +89,12 @@ it when necessary (file sizes ~1GB+).
       char: "u",
       description: "S3 directory for the previous run if we will be updating in-place",
       default: ""
+    }),
+
+    filterPrefix: flags.string({
+      char: "f",
+      description: "Filter to only base geounits containing the specified prefix",
+      default: ""
     })
   };
 
@@ -151,6 +157,14 @@ it when necessary (file sizes ~1GB+).
     }
 
     this.renameProps(baseGeoJson, geoLevels);
+
+    if (flags.filterPrefix) {
+      this.log(`Filtering to only prefixes of: ${flags.filterPrefix}`);
+      baseGeoJson.features = baseGeoJson.features.filter((f: any) =>
+        f.properties[geoLevelIds[0]].startsWith(flags.filterPrefix)
+      );
+      this.log(`Filtered GeoJSON contains ${baseGeoJson.features.length.toString()} features`);
+    }
 
     const topoJsonHierarchy = this.mkTopoJsonHierarchy(
       baseGeoJson,


### PR DESCRIPTION
## Overview

We would like to configure a region for Dane County, WI, and more generally would like to be able to configure single-county regions. This updates the processing script to be able to supply a prefix inclusion filter, to allow only blocks with matching FIPS code prefixes to be processed. Because the region is only a single county, we also don't need to allow selection of the "county" geolevel in the UI (the tour was also updated to reflect this change). Similarly, due to its smaller size, we can safely always display all blocks, so special handling of the base geolevel can be lifted.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![dane-county](https://user-images.githubusercontent.com/6386/96808322-964d8280-13e6-11eb-9c51-552b68380814.png)

### Notes

I didn't go overboard with logic in attempting to handle every scenario related to when a geolevel needs special handling. The normal case that we were already handling was for when the base geolevel is special (not always visible). I simply added another scenario for when all min zooms are the same, and thus the base geolevel isn't special (it is always visible). Those are the only known cases that we need to support at the moment, so I think it makes sense to maintain that simplicity until we come across a more involved scenario.

## Testing Instructions

- Process Dane County using the new filter flag, e.g.:
    - `mkdir src/manage/data/output-dane-county`
    - `./scripts/manage process-geojson data/input/WI.geojson -o data/output-dane-county -n 4,4 -x 12,12 -l block,blockgroup -f 55025`
- Publish the region (e.g. `./scripts/manage publish-region data/output-dane-county US WI "Dane County"`), create a project with it, and test it out
- Ensure that the text in the tour seems to make sense given the different set of geolevels
- Ensure you can select both blocks and blockgroups at all levels
- Also test another full-state project to make sure nothing has broken (also read through the tour here)
- In case it comes in handy, here's some SQL for resetting the tour and also disabling advanced editing mode
    - `update "user" set "hasSeenTour" = false;`
    - `update "project" set "advancedEditingEnabled" = false;`

Closes #472 
Closes #475 
