### PR TITLE
Ensure that disabled block button doesn't lose left border

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -21,18 +21,21 @@ const style: ThemeUIStyleObject = {
     "& button > svg": {
       marginRight: "0"
     },
-    "&:not(:last-of-type):not(:first-of-type) > span > button, & > button:not(:last-of-type):not(:first-of-type)": {
+    "&:not(:last-of-type):not(:first-of-type) > span > button": {
       borderRadius: 0,
-      borderRightWidth: 0
+      borderLeftWidth: 0
     },
     "&:first-of-type > span > button, & > button:first-of-type": {
       borderTopRightRadius: 0,
-      borderBottomRightRadius: 0,
-      borderRightWidth: 0
+      borderBottomRightRadius: 0
     },
     "&:last-of-type > span > button, & > button:last-of-type": {
       borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0
+      borderBottomLeftRadius: 0,
+      borderLeftWidth: 0
+    },
+    "&:not(:last-of-type):not(:first-of-type) > span > button[disabled], & > button:not(:last-of-type):not(:first-of-type)[disabled]": {
+      borderRightColor: "blue.7"
     }
   },
   header: {


### PR DESCRIPTION
## Overview
Fixes the disabled Block button looking strange by retaining a right border on the Block Groups button.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
<img width="820" alt="Screen Shot 2020-10-27 at 6 08 59 PM" src="https://user-images.githubusercontent.com/5672295/97314001-26fce600-185f-11eb-9f49-2da5c69e3e81.png">
<img width="923" alt="Screen Shot 2020-10-27 at 6 09 12 PM" src="https://user-images.githubusercontent.com/5672295/97314013-2a906d00-185f-11eb-8931-26f3ac28d37b.png">

## Testing Instructions
- `git pull`
- Go into a map. The Counties button should be selected. 
- Click on a county. The Blocks button should be disabled.
- Interact with the Block Groups button to see that the hover looks right.
- Now click "Cancel" or "Accept.
- Click the Blocks button and zoom in to select a block. The Block Groups and Counties buttons should be disabled.

Closes #447
