### PR TITLE
Update PostgreSQL for RDS engine default to 12.x

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -73,12 +73,12 @@ variable "rds_allocated_storage" {
 }
 
 variable "rds_engine_version" {
-  default = "11"
+  default = "12.4"
   type    = string
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres11"
+  default = "postgres12"
   type    = string
 }
 


### PR DESCRIPTION
Ensure that these defaults reflect the current state of the DistrictBuilder AWS environments.

Connects #341

---

**Testing**

Review the changes and ensure that they align with the [RDS configuration](https://console.aws.amazon.com/rds/home?region=us-east-1#database:id=districtbuilder-production;is-cluster=false;tab=configuration).



