### PR TITLE
Allow saving with undo/redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify max-old-space-size on server [#470](https://github.com/PublicMapping/districtbuilder/pull/470)
 - Fix formatting of population counts [#474](https://github.com/PublicMapping/districtbuilder/pull/474)
 - Make it possible to swap out the RDS DB parameter group [#478](https://github.com/PublicMapping/districtbuilder/pull/478)
+- Allow saving with undo/redo [#498](https://github.com/PublicMapping/districtbuilder/pull/498)
 
 ### Fixed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,4 +1,3 @@
-import MapboxGL from "mapbox-gl";
 import { createAction } from "typesafe-actions";
 import { DistrictId, GeoUnits } from "../../shared/entities";
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -45,3 +45,5 @@ export const redo = createAction("Redo project action")();
 
 export const toggleFind = createAction("Toggle find menu visibility")<boolean>();
 export const setFindIndex = createAction("Set find menu polygon index")<number | undefined>();
+
+export const saveDistrictsDefinition = createAction("Save districts definition")();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -41,8 +41,8 @@ export const showAdvancedEditingModal = createAction("Show advanced editing warn
   boolean
 >();
 
-export const undo = createAction("Undo project action")<MapboxGL.Map>();
-export const redo = createAction("Redo project action")<MapboxGL.Map>();
+export const undo = createAction("Undo project action")();
+export const redo = createAction("Redo project action")();
 
 export const toggleFind = createAction("Toggle find menu visibility")<boolean>();
 export const setFindIndex = createAction("Set find menu polygon index")<number | undefined>();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,5 +1,6 @@
 import { createAction } from "typesafe-actions";
 import { DistrictId, GeoUnits } from "../../shared/entities";
+import { SavingState } from "../types";
 
 export enum SelectionTool {
   Default = "DEFAULT",
@@ -47,3 +48,5 @@ export const toggleFind = createAction("Toggle find menu visibility")<boolean>()
 export const setFindIndex = createAction("Set find menu polygon index")<number | undefined>();
 
 export const saveDistrictsDefinition = createAction("Save districts definition")();
+
+export const setSavingState = createAction("Set saving state")<SavingState>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -1,5 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { IProject, ProjectId } from "../../shared/entities";
+import { DistrictsDefinition, IProject, ProjectId } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 
 export const projectFetch = createAction("Project fetch")<ProjectId>();
@@ -24,7 +24,9 @@ export const updateProjectNameSuccess = createAction("Update project name succes
   DynamicProjectData
 >();
 
-export const updateDistrictsDefinition = createAction("Update districts definition")();
+export const updateDistrictsDefinition = createAction(
+  "Update districts definition"
+)<DistrictsDefinition | null>();
 export const updateDistrictsDefinitionSuccess = createAction("Update districts definition success")<
   IProject
 >();

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -87,14 +87,14 @@ const ProjectHeader = ({
               <Button
                 sx={style.undoRedo}
                 disabled={undoHistory.past.length === 0}
-                onClick={() => store.dispatch(undo(map))}
+                onClick={() => store.dispatch(undo())}
               >
                 <Icon name="undo" />
               </Button>
               <Button
                 sx={{ ...style.undoRedo, mr: 4 }}
                 disabled={undoHistory.future.length === 0}
-                onClick={() => store.dispatch(redo(map))}
+                onClick={() => store.dispatch(redo())}
               >
                 <Icon name="redo" />
               </Button>

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -15,7 +15,7 @@ import ShareMenu from "../components/ShareMenu";
 import SupportMenu from "../components/SupportMenu";
 import store from "../store";
 import { State } from "../reducers";
-import { UndoHistory } from "../reducers/districtDrawing";
+import { UndoHistory } from "../reducers/undoRedo";
 
 import { style as menuButtonStyle } from "./MenuButton.styles";
 

--- a/src/client/components/ProjectSidebarHeader.tsx
+++ b/src/client/components/ProjectSidebarHeader.tsx
@@ -8,8 +8,7 @@ import { areAnyGeoUnitsSelected, destructureResource } from "../functions";
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
 
-import { updateDistrictsDefinition } from "../actions/projectData";
-import { clearSelectedGeounits } from "../actions/districtDrawing";
+import { saveDistrictsDefinition, clearSelectedGeounits } from "../actions/districtDrawing";
 import { State } from "../reducers";
 import store from "../store";
 
@@ -81,7 +80,7 @@ const ProjectSidebarHeader = ({
             <Button
               variant="circular"
               onClick={() => {
-                store.dispatch(updateDistrictsDefinition());
+                store.dispatch(saveDistrictsDefinition());
               }}
             >
               <Icon name="check" />

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -30,7 +30,8 @@ import {
   levelToLineLayerId,
   onlyUnlockedGeoUnits,
   getChildGeoUnits,
-  DISTRICTS_OUTLINE_LAYER_ID
+  DISTRICTS_OUTLINE_LAYER_ID,
+  setFeaturesSelectedFromGeoUnits
 } from "./index";
 import DefaultSelectionTool from "./DefaultSelectionTool";
 import FindMenu from "./FindMenu";
@@ -244,6 +245,25 @@ const DistrictsMap = ({
       );
     }
   }, [map, staticMetadata, geoLevelIndex]);
+
+  // Keep track of when selected geounits change
+  const prevSelectedGeoUnitsRef = useRef<typeof selectedGeounits | undefined>();
+  useEffect(() => {
+    prevSelectedGeoUnitsRef.current = selectedGeounits; // eslint-disable-line
+  });
+  const prevSelectedGeoUnits = prevSelectedGeoUnitsRef.current;
+
+  // Update map when selected geounits change.
+  // Typically the geounits change as a result of using the selection tools directly -- map is
+  // changed and then that needs to be reflected in state -- but this accounts for undo/redo actions
+  // affecting state which then needs to be reflected in the map.
+  useEffect(() => {
+    // eslint-disable-next-line
+    if (map) {
+      prevSelectedGeoUnits && setFeaturesSelectedFromGeoUnits(map, prevSelectedGeoUnits, false);
+      selectedGeounits && setFeaturesSelectedFromGeoUnits(map, selectedGeounits, true);
+    }
+  }, [map, selectedGeounits, prevSelectedGeoUnits]);
 
   // Keep track of when selected geolevel changes
   const prevGeoLevelIndexRef = useRef<typeof geoLevelIndex | undefined>();

--- a/src/client/components/map/MapMessage.tsx
+++ b/src/client/components/map/MapMessage.tsx
@@ -5,6 +5,7 @@ import MapboxGL from "mapbox-gl";
 import Icon from "../Icon";
 
 import { State } from "../../reducers";
+import { getPresentDrawingState } from "../../reducers/districtDrawing";
 import { geoLevelLabel } from "../../functions";
 import { IStaticMetadata } from "../../../shared/entities";
 import { destructureResource } from "../../functions";
@@ -76,8 +77,8 @@ const MapMessage = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: state.project.undoHistory.present.geoLevelIndex,
-    geoLevelVisibility: state.project.undoHistory.present.geoLevelVisibility,
+    geoLevelIndex: getPresentDrawingState(state.project.undoHistory).geoLevelIndex,
+    geoLevelVisibility: getPresentDrawingState(state.project.undoHistory).geoLevelVisibility,
     staticMetadata: destructureResource(state.project.staticData, "staticMetadata")
   };
 }

--- a/src/client/components/map/MapMessage.tsx
+++ b/src/client/components/map/MapMessage.tsx
@@ -5,7 +5,6 @@ import MapboxGL from "mapbox-gl";
 import Icon from "../Icon";
 
 import { State } from "../../reducers";
-import { getPresentDrawingState } from "../../reducers/districtDrawing";
 import { geoLevelLabel } from "../../functions";
 import { IStaticMetadata } from "../../../shared/entities";
 import { destructureResource } from "../../functions";
@@ -77,8 +76,8 @@ const MapMessage = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: getPresentDrawingState(state.project.undoHistory).geoLevelIndex,
-    geoLevelVisibility: getPresentDrawingState(state.project.undoHistory).geoLevelVisibility,
+    geoLevelIndex: state.project.undoHistory.present.state.geoLevelIndex,
+    geoLevelVisibility: state.project.undoHistory.present.state.geoLevelVisibility,
     staticMetadata: destructureResource(state.project.staticData, "staticMetadata")
   };
 }

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -10,6 +10,7 @@ import { areAnyGeoUnitsSelected, destructureResource, geoLevelLabel } from "../.
 import { getTotalSelectedDemographics } from "../../worker-functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
+import { getPresentDrawingState } from "../../reducers/districtDrawing";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 
@@ -235,7 +236,7 @@ const MapTooltip = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: state.project.undoHistory.present.geoLevelIndex,
+    geoLevelIndex: getPresentDrawingState(state.project.undoHistory).geoLevelIndex,
     highlightedGeounits: state.project.highlightedGeounits,
     project: destructureResource(state.project.projectData, "project"),
     staticMetadata: destructureResource(state.project.staticData, "staticMetadata")

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -10,7 +10,6 @@ import { areAnyGeoUnitsSelected, destructureResource, geoLevelLabel } from "../.
 import { getTotalSelectedDemographics } from "../../worker-functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
-import { getPresentDrawingState } from "../../reducers/districtDrawing";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 
@@ -236,7 +235,7 @@ const MapTooltip = ({
 
 function mapStateToProps(state: State) {
   return {
-    geoLevelIndex: getPresentDrawingState(state.project.undoHistory).geoLevelIndex,
+    geoLevelIndex: state.project.undoHistory.present.state.geoLevelIndex,
     highlightedGeounits: state.project.highlightedGeounits,
     project: destructureResource(state.project.projectData, "project"),
     staticMetadata: destructureResource(state.project.staticData, "staticMetadata")

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -82,7 +82,9 @@ function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
   }, {});
 }
 
-export function pushState(state: ProjectState, undoState: UndoableStateAndEffect): ProjectState {
+// TODO: Set up guard rails around pushState and replaceState to allow for just updating a single
+// property or adding an effect
+function pushState(state: ProjectState, undoState: UndoableStateAndEffect): ProjectState {
   return {
     ...state,
     undoHistory: {
@@ -352,6 +354,8 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
     }
     case getType(saveDistrictsDefinition):
       return loop(
+        // Save an effect with the current districts definition (before saving) so that we can
+        // undo/redo saving of the districts definition
         pushState(state, {
           ...present,
           effect: Cmd.action(updateDistrictsDefinition(present.state.districtsDefinition))

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -30,6 +30,8 @@ import { GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entiti
 import { ProjectState, initialProjectState } from "./project";
 import { setFeaturesSelectedFromGeoUnits } from "../components/map";
 
+const UNDO_HISTORY_MAX_LENGTH = 100;
+
 function setGeoUnitsForLevel(
   currentGeoUnits: GeoUnitsForLevel,
   geoUnitsToAdd: GeoUnitsForLevel,
@@ -79,7 +81,12 @@ function pushState(state: ProjectState, undoState: UndoableState): ProjectState 
     // Need to clear new project GeoJSON whenever clearing redo states
     currentProjectData: undefined,
     undoHistory: {
-      past: [...state.undoHistory.past, state.undoHistory.present],
+      past: [
+        // We want to limit the undo history to the n most recent items, which is why a negative
+        // index is used
+        ...state.undoHistory.past.slice(UNDO_HISTORY_MAX_LENGTH * -1),
+        state.undoHistory.present
+      ],
       present: undoState,
       future: []
     }

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -298,7 +298,7 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
                 future: [present, ...state.undoHistory.future]
               }
             },
-            "effect" in lastPastState ? lastPastState.effect : Cmd.none
+            "effect" in state.undoHistory.present ? state.undoHistory.present.effect : Cmd.none
           );
     }
     case getType(redo): {
@@ -319,7 +319,7 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
                 future: state.undoHistory.future.slice(1)
               }
             },
-            "effect" in nextFutureState ? nextFutureState.effect : Cmd.none
+            "effect" in state.undoHistory.present ? state.undoHistory.present.effect : Cmd.none
           );
     }
     default:

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -82,7 +82,7 @@ function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
   }, {});
 }
 
-function pushState(state: ProjectState, undoState: UndoableStateAndEffect): ProjectState {
+export function pushState(state: ProjectState, undoState: UndoableStateAndEffect): ProjectState {
   return {
     ...state,
     undoHistory: {
@@ -98,7 +98,7 @@ function pushState(state: ProjectState, undoState: UndoableStateAndEffect): Proj
   };
 }
 
-function replaceState(state: ProjectState, undoState: UndoableStateAndEffect) {
+export function replaceState(state: ProjectState, undoState: UndoableStateAndEffect) {
   return {
     ...state,
     undoHistory: {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -311,17 +311,12 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
         findIndex: action.payload
       };
     case getType(undo): {
-      const projectData =
-        state.undoHistory.past.length === 1 && state.previousProjectData
-          ? { projectData: state.previousProjectData }
-          : {};
       const lastPastState = state.undoHistory.past[state.undoHistory.past.length - 1];
       return state.undoHistory.past.length === 0
         ? state
         : loop(
             {
               ...state,
-              ...projectData,
               undoHistory: {
                 past: state.undoHistory.past.slice(0, -1),
                 present: lastPastState,
@@ -332,17 +327,12 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
           );
     }
     case getType(redo): {
-      const projectData =
-        state.undoHistory.past.length === 0 && state.currentProjectData
-          ? { projectData: state.currentProjectData }
-          : {};
       const nextFutureState = state.undoHistory.future[0];
       return state.undoHistory.future.length === 0
         ? state
         : loop(
             {
               ...state,
-              ...projectData,
               undoHistory: {
                 past: [...state.undoHistory.past, present],
                 present: nextFutureState,

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -338,8 +338,8 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
     }
     case getType(saveDistrictsDefinition):
       return loop(
-        // Save an effect with the current districts definition (before saving) so that we can
-        // undo/redo saving of the districts definition
+        // Save an effect function which takes the appropriate districts definition so that we can
+        // undo/redo saving of the districts definition with the correct state snapshot.
         pushStateUpdate(state, {
           effect: (state: UndoableState) =>
             Cmd.action(updateDistrictsDefinition(state.districtsDefinition))

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -151,12 +151,16 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   }
 };
 
+export function getPresentDrawingState(undoHistory: UndoHistory): UndoableState {
+  return "state" in undoHistory.present ? undoHistory.present.state : undoHistory.present;
+}
+
 const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
   state: ProjectState = initialProjectState,
   action: Action
 ): ProjectState | Loop<ProjectState, Action> => {
   const { present } = state.undoHistory;
-  const presentState = "state" in present ? present.state : present;
+  const presentState = getPresentDrawingState(state.undoHistory);
   switch (action.type) {
     case getType(resetProjectState):
       return {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -90,9 +90,8 @@ function pushStateUpdate(
     ...state,
     undoHistory: {
       past: [
-        // We want to limit the undo history to the n most recent items, which is why a negative
-        // index is used
-        ...state.undoHistory.past.slice(UNDO_HISTORY_MAX_LENGTH * -1),
+        // Limit the undo history to the n most recent items
+        ...state.undoHistory.past.slice((UNDO_HISTORY_MAX_LENGTH - 1) * -1),
         state.undoHistory.present
       ],
       present:

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -140,11 +140,10 @@ interface UndoableState {
 // Accompanying effect builder for state update when undone/redone (eg. saving districts definition)
 type Effect = (state: UndoableState) => CmdType<Action>;
 
-type UndoableStateAndEffect = {
+interface UndoableStateAndEffect {
   readonly state: UndoableState;
-} & {
   readonly effect?: Effect;
-};
+}
 
 export interface UndoHistory {
   readonly past: readonly UndoableStateAndEffect[];

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -216,7 +216,8 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
       });
     case getType(clearSelectedGeounits): {
       const clearedViaCancel = action.payload;
-      return pushState(
+      const func = clearedViaCancel ? pushState : replaceState;
+      return func(
         {
           ...state,
           saving: clearedViaCancel ? "unsaved" : "saved"

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -97,7 +97,18 @@ function replaceState(state: ProjectState, undoState: UndoableStateAndAction) {
     ...state,
     undoHistory: {
       ...state.undoHistory,
-      present: undoState
+      present:
+        "effect" in undoState || "effect" in state.undoHistory.present
+          ? {
+              effect:
+                "effect" in undoState
+                  ? undoState.effect
+                  : "effect" in state.undoHistory.present
+                  ? state.undoHistory.present.effect
+                  : ("impossible" as never),
+              state: "state" in undoState ? undoState.state : undoState
+            }
+          : undoState
     }
   };
 }

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -22,8 +22,10 @@ import {
   undo,
   replaceSelectedGeounits,
   toggleFind,
-  setFindIndex
+  setFindIndex,
+  saveDistrictsDefinition
 } from "../actions/districtDrawing";
+import { updateDistrictsDefinition } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entities";
@@ -322,6 +324,14 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
             "effect" in state.undoHistory.present ? state.undoHistory.present.effect : Cmd.none
           );
     }
+    case getType(saveDistrictsDefinition):
+      return loop(
+        pushState(state, {
+          state: getPresentDrawingState(state.undoHistory),
+          effect: Cmd.action(updateDistrictsDefinition())
+        }),
+        Cmd.action(updateDistrictsDefinition())
+      );
     default:
       return state as never;
   }

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -190,7 +190,6 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
   action: Action
 ): ProjectState | Loop<ProjectState, Action> => {
   const { present } = state.undoHistory;
-  console.log(action, state);
   switch (action.type) {
     case getType(resetProjectState):
       return {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -82,15 +82,16 @@ function clearGeoUnits(geoUnits: GeoUnits): GeoUnits {
   }, {});
 }
 
+function truncatePastUndoHistory(past: readonly UndoableStateAndEffect[]) {
+  // Limit the undo history to the n most recent items
+  return past.slice((UNDO_HISTORY_MAX_LENGTH - 1) * -1);
+}
+
 function pushStateUpdate(state: ProjectState, undoState: Partial<UndoableState>): ProjectState {
   return {
     ...state,
     undoHistory: {
-      past: [
-        // Limit the undo history to the n most recent items
-        ...state.undoHistory.past.slice((UNDO_HISTORY_MAX_LENGTH - 1) * -1),
-        state.undoHistory.present
-      ],
+      past: [...truncatePastUndoHistory(state.undoHistory.past), state.undoHistory.present],
       present: {
         state: {
           ...state.undoHistory.present.state,
@@ -106,11 +107,7 @@ function pushEffect(state: ProjectState, effect: Effect): ProjectState {
   return {
     ...state,
     undoHistory: {
-      past: [
-        // Limit the undo history to the n most recent items
-        ...state.undoHistory.past.slice((UNDO_HISTORY_MAX_LENGTH - 1) * -1),
-        state.undoHistory.present
-      ],
+      past: [...truncatePastUndoHistory(state.undoHistory.past), state.undoHistory.present],
       present: {
         ...state.undoHistory.present,
         effect

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -47,8 +47,6 @@ function fetchGeoJsonForProject(project: IProject) {
 
 export type ProjectDataState = {
   readonly projectData: Resource<DynamicProjectData>;
-  readonly previousProjectData?: Resource<DynamicProjectData>;
-  readonly currentProjectData?: Resource<DynamicProjectData>;
   readonly staticData: Resource<StaticProjectData>;
   readonly projectNameSaving: SavingState;
 };
@@ -265,8 +263,6 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         ? replaceState(
             {
               ...state,
-              previousProjectData: state.projectData,
-              currentProjectData: { resource: action.payload },
               projectData: {
                 resource: action.payload
               }

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -20,7 +20,7 @@ import {
   updateProjectNameSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits, setSavingState } from "../actions/districtDrawing";
-import { getPresentDrawingState, replaceState } from "../reducers/districtDrawing";
+import { updateCurrentState } from "../reducers/districtDrawing";
 import { IProject } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
@@ -124,7 +124,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       );
     case getType(projectDataFetchSuccess):
       return loop(
-        replaceState(
+        updateCurrentState(
           {
             ...state,
             projectData: {
@@ -136,11 +136,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
             }
           },
           {
-            ...state.undoHistory.present,
-            state: {
-              ...state.undoHistory.present.state,
-              districtsDefinition: action.payload.project.districtsDefinition
-            }
+            districtsDefinition: action.payload.project.districtsDefinition
           }
         ),
         Cmd.run(fetchAllStaticData, {
@@ -234,9 +230,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                         assignGeounitsToDistrict(
                           state.projectData.resource.project.districtsDefinition,
                           state.staticData.resource.geoUnitHierarchy,
-                          allGeoUnitIndices(
-                            getPresentDrawingState(state.undoHistory).selectedGeounits
-                          ),
+                          allGeoUnitIndices(state.undoHistory.present.state.selectedGeounits),
                           state.selectedDistrictId
                         )
                     }
@@ -260,7 +254,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       );
     case getType(updateDistrictsDefinitionRefetchGeoJsonSuccess): {
       return "resource" in state.projectData
-        ? replaceState(
+        ? updateCurrentState(
             {
               ...state,
               projectData: {
@@ -268,11 +262,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
               }
             },
             {
-              ...state.undoHistory.present,
-              state: {
-                ...state.undoHistory.present.state,
-                districtsDefinition: action.payload.project.districtsDefinition
-              }
+              districtsDefinition: action.payload.project.districtsDefinition
             }
           )
         : state;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -138,6 +138,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
             }
           },
           {
+            ...state.undoHistory.present,
             state: {
               ...state.undoHistory.present.state,
               districtsDefinition: action.payload.project.districtsDefinition
@@ -227,10 +228,13 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                   args: [
                     state.projectData.resource.project.id,
                     {
+                      // Districts definition may be optionally specified in the action to make this
+                      // action apply to a snapshot of state to allow for undoing/redoings changes
+                      // to districts
                       districtsDefinition:
                         action.payload ||
                         assignGeounitsToDistrict(
-                          state.undoHistory.present.state.districtsDefinition,
+                          state.projectData.resource.project.districtsDefinition,
                           state.staticData.resource.geoUnitHierarchy,
                           allGeoUnitIndices(
                             getPresentDrawingState(state.undoHistory).selectedGeounits
@@ -268,6 +272,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
               }
             },
             {
+              ...state.undoHistory.present,
               state: {
                 ...state.undoHistory.present.state,
                 districtsDefinition: action.payload.project.districtsDefinition

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -20,7 +20,7 @@ import {
   updateProjectNameSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits, setSavingState } from "../actions/districtDrawing";
-import { updateCurrentState } from "../reducers/districtDrawing";
+import { updateCurrentState } from "../reducers/undoRedo";
 import { IProject } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -235,26 +235,12 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         )
       );
     case getType(updateDistrictsDefinitionRefetchGeoJsonSuccess): {
-      const lastPastState = state.undoHistory.past[state.undoHistory.past.length - 1];
       return loop(
         "resource" in state.projectData
           ? {
               ...state,
               previousProjectData: state.projectData,
-              currentProjectData: { resource: action.payload },
-              undoHistory: {
-                ...state.undoHistory,
-                past: state.undoHistory.past.length
-                  ? [
-                      ...state.undoHistory.past.slice(0, -1),
-                      {
-                        state: "state" in lastPastState ? lastPastState.state : lastPastState,
-                        effect: Cmd.action(updateDistrictsDefinition())
-                      }
-                    ]
-                  : [],
-                future: []
-              }
+              currentProjectData: { resource: action.payload }
             }
           : state,
         Cmd.action(projectFetchSuccess(action.payload))

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -222,9 +222,10 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                   args: [
                     state.projectData.resource.project.id,
                     {
-                      // Districts definition may be optionally specified in the action to make this
-                      // action apply to a snapshot of state to allow for undoing/redoings changes
-                      // to districts
+                      // Districts definition may be optionally specified in the action payload and
+                      // is used if available. This is needed to go back/forward in time for a given
+                      // state snapshot -- as opposed to just using the current districts definition
+                      // -- for undo/redo to work correctly.
                       districtsDefinition:
                         action.payload ||
                         assignGeounitsToDistrict(
@@ -236,6 +237,11 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                     }
                   ] as Parameters<typeof patchProject>
                 }),
+                // When updating districts definition after a save, we want to clear the selected
+                // geounits since we're "done". However, when redoing/undoing changes with a
+                // specific districts definition, we want to keep those geounits selected to allow
+                // the user to potentially edit their selection or continuing undoing/redoing their
+                // changes.
                 action.payload
                   ? Cmd.action(setSavingState("saved"))
                   : Cmd.action(clearSelectedGeounits(false))

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -20,7 +20,7 @@ import {
   updateProjectNameSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits, setSavingState } from "../actions/districtDrawing";
-import { getPresentDrawingState } from "../reducers/districtDrawing";
+import { getPresentDrawingState, replaceState } from "../reducers/districtDrawing";
 import { IProject } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
@@ -126,26 +126,24 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       );
     case getType(projectDataFetchSuccess):
       return loop(
-        {
-          ...state,
-          projectData: {
-            resource: action.payload
-          },
-          undoHistory: {
-            ...state.undoHistory,
-            present: {
-              ...state.undoHistory.present,
-              state: {
-                ...state.undoHistory.present.state,
-                districtsDefinition: action.payload.project.districtsDefinition
-              }
+        replaceState(
+          {
+            ...state,
+            projectData: {
+              resource: action.payload
+            },
+            staticData: {
+              ...state.staticData,
+              isPending: true
             }
           },
-          staticData: {
-            ...state.staticData,
-            isPending: true
+          {
+            state: {
+              ...state.undoHistory.present.state,
+              districtsDefinition: action.payload.project.districtsDefinition
+            }
           }
-        },
+        ),
         Cmd.run(fetchAllStaticData, {
           successActionCreator: staticDataFetchSuccess,
           failActionCreator: staticDataFetchFailure,
@@ -260,24 +258,22 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       );
     case getType(updateDistrictsDefinitionRefetchGeoJsonSuccess): {
       return "resource" in state.projectData
-        ? {
-            ...state,
-            previousProjectData: state.projectData,
-            currentProjectData: { resource: action.payload },
-            projectData: {
-              resource: action.payload
+        ? replaceState(
+            {
+              ...state,
+              previousProjectData: state.projectData,
+              currentProjectData: { resource: action.payload },
+              projectData: {
+                resource: action.payload
+              }
             },
-            undoHistory: {
-              ...state.undoHistory,
-              present: {
-                ...state.undoHistory.present,
-                state: {
-                  ...state.undoHistory.present.state,
-                  districtsDefinition: action.payload.project.districtsDefinition
-                }
+            {
+              state: {
+                ...state.undoHistory.present.state,
+                districtsDefinition: action.payload.project.districtsDefinition
               }
             }
-          }
+          )
         : state;
     }
     case getType(updateProjectFailed):

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -20,6 +20,7 @@ import {
   updateProjectNameSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits } from "../actions/districtDrawing";
+import { getPresentDrawingState } from "../reducers/districtDrawing";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
 import { DistrictsGeoJSON, DynamicProjectData, SavingState, StaticProjectData } from "../types";
@@ -209,11 +210,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                   districtsDefinition: assignGeounitsToDistrict(
                     state.projectData.resource.project.districtsDefinition,
                     state.staticData.resource.geoUnitHierarchy,
-                    allGeoUnitIndices(
-                      "state" in state.undoHistory.present
-                        ? state.undoHistory.present.state.selectedGeounits
-                        : state.undoHistory.present.selectedGeounits
-                    ),
+                    allGeoUnitIndices(getPresentDrawingState(state.undoHistory).selectedGeounits),
                     state.selectedDistrictId
                   )
                 }

--- a/src/client/reducers/undoRedo.ts
+++ b/src/client/reducers/undoRedo.ts
@@ -1,0 +1,83 @@
+import { CmdType } from "redux-loop";
+
+import { Action } from "../actions";
+import { DistrictsDefinition, GeoUnits, LockedDistricts } from "../../shared/entities";
+import { ProjectState } from "./project";
+
+const UNDO_HISTORY_MAX_LENGTH = 100;
+
+export interface UndoableState {
+  readonly selectedGeounits: GeoUnits;
+  readonly geoLevelIndex: number; // Index is based off of reversed geoLevelHierarchy in static metadata
+  readonly geoLevelVisibility: ReadonlyArray<boolean>; // Visibility values at indices corresponding to `geoLevelIndex`
+  readonly lockedDistricts: LockedDistricts;
+  readonly districtsDefinition: DistrictsDefinition;
+}
+
+// Accompanying effect builder for state update when undone/redone (eg. saving districts definition)
+export type Effect = (state: UndoableState) => CmdType<Action>;
+
+export interface UndoableStateAndEffect {
+  readonly state: UndoableState;
+  readonly effect?: Effect;
+}
+
+export interface UndoHistory {
+  readonly past: readonly UndoableStateAndEffect[];
+  readonly present: UndoableStateAndEffect;
+  readonly future: readonly UndoableStateAndEffect[];
+}
+
+function truncatePastUndoHistory(past: readonly UndoableStateAndEffect[]) {
+  // Limit the undo history to the n most recent items
+  return past.slice((UNDO_HISTORY_MAX_LENGTH - 1) * -1);
+}
+
+export function pushStateUpdate(
+  state: ProjectState,
+  undoState: Partial<UndoableState>
+): ProjectState {
+  return {
+    ...state,
+    undoHistory: {
+      past: [...truncatePastUndoHistory(state.undoHistory.past), state.undoHistory.present],
+      present: {
+        state: {
+          ...state.undoHistory.present.state,
+          ...undoState
+        }
+      },
+      future: []
+    }
+  };
+}
+
+export function pushEffect(state: ProjectState, effect: Effect): ProjectState {
+  return {
+    ...state,
+    undoHistory: {
+      past: [...truncatePastUndoHistory(state.undoHistory.past), state.undoHistory.present],
+      present: {
+        ...state.undoHistory.present,
+        effect
+      },
+      future: []
+    }
+  };
+}
+
+export function updateCurrentState(state: ProjectState, undoState: Partial<UndoableState>) {
+  return {
+    ...state,
+    undoHistory: {
+      ...state.undoHistory,
+      present: {
+        ...state.undoHistory.present,
+        state: {
+          ...state.undoHistory.present.state,
+          ...undoState
+        }
+      }
+    }
+  };
+}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -15,7 +15,7 @@ import {
   UintArrays
 } from "../../shared/entities";
 import { projectDataFetch } from "../actions/projectData";
-import { DistrictDrawingState } from "../reducers/districtDrawing";
+import { DistrictDrawingState, getPresentDrawingState } from "../reducers/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { userFetch } from "../actions/user";
 import "../App.css";
@@ -72,12 +72,13 @@ const ProjectScreen = ({
   const [map, setMap] = useState<MapboxGL.Map | undefined>(undefined);
   const isLoggedIn = getJWT() !== null;
   const isFirstLoadPending = isLoading && (project === undefined || staticMetadata === undefined);
+  const presentDrawingState = getPresentDrawingState(districtDrawing.undoHistory);
 
   // Warn the user when attempting to leave the page with selected geounits
   useBeforeunload(event => {
     // Disabling 'functional/no-conditional-statement' without naming it.
     // eslint-disable-next-line
-    if (areAnyGeoUnitsSelected(districtDrawing.undoHistory.present.selectedGeounits)) {
+    if (areAnyGeoUnitsSelected(presentDrawingState.selectedGeounits)) {
       // Old style, used by e.g. Chrome
       // Disabling 'functional/immutable-data' without naming it.
       // eslint-disable-next-line
@@ -120,10 +121,10 @@ const ProjectScreen = ({
           isLoading={isLoading}
           staticMetadata={staticMetadata}
           selectedDistrictId={districtDrawing.selectedDistrictId}
-          selectedGeounits={districtDrawing.undoHistory.present.selectedGeounits}
+          selectedGeounits={presentDrawingState.selectedGeounits}
           highlightedGeounits={districtDrawing.highlightedGeounits}
           geoUnitHierarchy={geoUnitHierarchy}
-          lockedDistricts={districtDrawing.undoHistory.present.lockedDistricts}
+          lockedDistricts={presentDrawingState.lockedDistricts}
           saving={districtDrawing.saving}
           isReadOnly={isReadOnly}
         />
@@ -133,8 +134,8 @@ const ProjectScreen = ({
             setMapLabel={setMapLabel}
             metadata={staticMetadata}
             selectionTool={districtDrawing.selectionTool}
-            geoLevelIndex={districtDrawing.undoHistory.present.geoLevelIndex}
-            selectedGeounits={districtDrawing.undoHistory.present.selectedGeounits}
+            geoLevelIndex={presentDrawingState.geoLevelIndex}
+            selectedGeounits={presentDrawingState.selectedGeounits}
             advancedEditingEnabled={project?.advancedEditingEnabled}
             isReadOnly={isReadOnly}
           />
@@ -153,11 +154,11 @@ const ProjectScreen = ({
                 geojson={geojson}
                 staticMetadata={staticMetadata}
                 staticGeoLevels={staticGeoLevels}
-                selectedGeounits={districtDrawing.undoHistory.present.selectedGeounits}
+                selectedGeounits={presentDrawingState.selectedGeounits}
                 selectedDistrictId={districtDrawing.selectedDistrictId}
                 selectionTool={districtDrawing.selectionTool}
-                geoLevelIndex={districtDrawing.undoHistory.present.geoLevelIndex}
-                lockedDistricts={districtDrawing.undoHistory.present.lockedDistricts}
+                geoLevelIndex={presentDrawingState.geoLevelIndex}
+                lockedDistricts={presentDrawingState.lockedDistricts}
                 isReadOnly={isReadOnly}
                 label={label}
                 map={map}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -15,7 +15,7 @@ import {
   UintArrays
 } from "../../shared/entities";
 import { projectDataFetch } from "../actions/projectData";
-import { DistrictDrawingState, getPresentDrawingState } from "../reducers/districtDrawing";
+import { DistrictDrawingState } from "../reducers/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { userFetch } from "../actions/user";
 import "../App.css";
@@ -72,7 +72,7 @@ const ProjectScreen = ({
   const [map, setMap] = useState<MapboxGL.Map | undefined>(undefined);
   const isLoggedIn = getJWT() !== null;
   const isFirstLoadPending = isLoading && (project === undefined || staticMetadata === undefined);
-  const presentDrawingState = getPresentDrawingState(districtDrawing.undoHistory);
+  const presentDrawingState = districtDrawing.undoHistory.present.state;
 
   // Warn the user when attempting to leave the page with selected geounits
   useBeforeunload(event => {


### PR DESCRIPTION
## Overview
This change makes undo/redo work with effects so that we can go backwards and forwards to previously saved map states. 

### Checklist
- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![db_undo_redo_saving](https://user-images.githubusercontent.com/2926237/98174189-7a57df80-1ec2-11eb-9f74-7a75e452a17b.gif)

### Notes
This was really quite hard to get working... I've added longer comments around the trickier parts of this to try to make things more clear.

The big change in terms of what state we represent is to have both a `state` and optionally `effect` represented to undo/redo saves. We also now need to keep track of `districtsDefinition` in our `UndoableState` to allow for undoing/redoing of saves. Most of the rest of the code is state/effect management in the reducers as you might suspect.

There were several non-obvious things that tripped me up along the way to getting this working, such as how we were always clearing the selected geounits after a save (this worked fine until we wanted to not do that for undo/redo and thus had to be wired up differently for the undo/redo save case). There were several such small-ish changes needed to the reducers to make things shake out correctly, such as having a separate action just for updating `saving` state. Most of these changes are in or around `updateDistrictsDefinition`, so taking a look at that plus the comments I've added there should hopefully make things clear.

I'm a little concerned about the complexity of managing undo/redo state here but I'm not sure how it can really be avoided. Having the notion of a `Cmd` in redux-loop I found helpful as a description of an effect that can be kept lying around in the queue until we really need to apply it. One of the things I did to try to make this less brittle is to modify `pushState` and `replaceState` to work with essentially patches (single discrete changes) and not wholesale replacements (PATCH vs PUT in REST-speak). It seems that in all cases we just want to change one thing at a time so this should be relatively ergonomic (before this change, I was having trouble updating the whole piece of state where I had only meant to update a part of it) 

There is a refactor in this (see 4e307e3) which is to move the map management around undo/redo-ing geounit selection into the map itself. IMHO it's preferable for the reducer to just be responsible for state updates (and effects that relate to state) and then the map should sort itself out so as to look right in response to those state changes.

In closing, I'm glad that this seems to work but would welcome further abstraction/guard rails to make things more ergonomic/less brittle. I'm also open to having horribly over-complicated this so if there are any suggestions to simplify things I'm open to them.

## Testing Instructions
* Select a bunch of geounits
* Save them to a district
* Undo one step and they should be unsaved (the selected geounits should be back assigned to whatever district they were before) and the geounits should still be selected
* Redo and the geounits should be re-saved to the district you originally assigned them to
* Undo all the way back and your changes should be completely undone
* Redo all the way back and your changes should be completely redone
* Undo partially, select some other geounit, and then save again and it should work as expected

Closes #405
