### PR TITLE
Fix region config validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix region config validation error [#500](https://github.com/PublicMapping/districtbuilder/pull/500)
+
 ## [1.1.0] - 2020-10-08
 
 ### Added

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -9,5 +9,6 @@ export class CreateProjectDto implements CreateProjectData {
   @IsInt({ message: "Number of districts must be an integer" })
   @IsPositive({ message: "Number of districts must be a positive number" })
   readonly numberOfDistricts: number;
+  @IsNotEmpty({ message: "Need to supply a region configuration" })
   readonly regionConfig: RegionConfigIdDto;
 }


### PR DESCRIPTION
## Overview

There was an error when creating a new map: `property regionConfig should not exist`. This was happening, because `forbidNonWhitelisted` validation was turned on in this commit: https://github.com/PublicMapping/districtbuilder/commit/f9238245471b413b81b724dc38cd35590056226b, but the `regionConfig` property didn't have a validation decorator, so wasn't whitelisted. The fix implemented here adds a simple validation decorator to `regionConfig`, just verifying that it's present.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Attempt to create a new map. This wasn't working beforehand, but should succeed now.

Closes #494
