### PR TITLE
Add CSV export headers

### DIFF
--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -252,9 +252,8 @@ export class ProjectsController implements CrudController<Project> {
     accumulateCsvRows(project.districtsDefinition, geoCollection.getGeoUnitHierarchy());
 
     return stringify(mutableCsvRows, {
-      // Unsure if this CSV file should have headers. Switch the following to true if it should.
-      header: false,
-      columns: ["geoId", "districtId"]
+      header: true,
+      columns: [`${baseGeoLevel.toUpperCase()}ID`, "DISTRICT"]
     });
   }
 }


### PR DESCRIPTION
## Overview

We want headers on the CSV export. An [example at the Census Bureau](https://www.census.gov/geographies/mapping-files/2018/dec/rdo/2018-state-legislative-bef.html) uses `BLOCKID` and `DISTRICT`, so that's what we're going with here.

### Checklist

- ~~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~~

### Demo

![csv-headers](https://user-images.githubusercontent.com/6386/99398176-1108a100-28b2-11eb-832d-a3c209b39948.png)

### Notes

I made the "BLOCKID" column dynamic, in case blocks aren't the base geounit. For example, if precincts are the base geounit, it will be set to "PRECINCTID".

## Testing Instructions

- Load up a map
- Click the export to CSV button
- Ensure the CSV has headers of: "BLOCKID,DISTRICT"

Closes #502
