### PR TITLE
Persist locking districts

### DIFF
--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -1,5 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { DistrictsDefinition, IProject, ProjectId } from "../../shared/entities";
+import { DistrictsDefinition, IProject, LockedDistricts, ProjectId } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 
 export const projectFetch = createAction("Project fetch")<ProjectId>();
@@ -33,6 +33,12 @@ export const updateDistrictsDefinitionSuccess = createAction("Update districts d
 export const updateDistrictsDefinitionRefetchGeoJsonSuccess = createAction(
   "Update districts definition refetch geojson success"
 )<DynamicProjectData>();
+
+export const updateDistrictLocks = createAction("Update district locks")<LockedDistricts>();
+export const updateDistrictLocksSuccess = createAction("Update district locks success")<
+  DynamicProjectData
+>();
+export const updateDistrictLocksFailure = createAction("Update district locks failure")<string>();
 
 export const updateProjectFailed = createAction("Update project failure")();
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -486,7 +486,7 @@ const SidebarRows = ({
             demographics={demographics}
             deviation={deviation}
             key={districtId}
-            isDistrictLocked={lockedDistricts.has(districtId)}
+            isDistrictLocked={lockedDistricts[districtId]}
             districtId={districtId}
             isReadOnly={isReadOnly}
           />

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -225,7 +225,7 @@ const DistrictsMap = ({
     map &&
       [...new Array(project.numberOfDistricts + 1).keys()].forEach(districtId =>
         map.setFeatureState(featureStateDistricts(districtId), {
-          locked: lockedDistricts.has(districtId)
+          locked: lockedDistricts[districtId]
         })
       );
   }, [map, project, lockedDistricts]);

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -275,12 +275,12 @@ function isGeoUnitLocked(
       )
     : typeof districtsDefinition === "number"
     ? // Check if this specific district is locked
-      lockedDistricts.has(districtsDefinition)
+      lockedDistricts[districtsDefinition]
     : // Check if any district at this geolevel is locked
       districtsDefinition.some(districtId =>
         typeof districtId === "number"
           ? // Whole district is assigned so it can be looked up directly
-            lockedDistricts.has(districtId)
+            lockedDistricts[districtId]
           : // District definition has more nesting so it must be followed further
             isGeoUnitLocked(districtId, lockedDistricts, geoUnitIndices)
       );

--- a/src/server/migrations/1606339829204-update_locked_districts.ts
+++ b/src/server/migrations/1606339829204-update_locked_districts.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class updateLockedDistricts1606339829204 implements MigrationInterface {
+  name = "updateLockedDistricts1606339829204";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `UPDATE project SET locked_districts = array_fill(FALSE, ARRAY[number_of_districts])`,
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`UPDATE project SET locked_districts = '{}'`, undefined);
+  }
+}

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -154,7 +154,7 @@ export class ProjectsController implements CrudController<Project> {
       return this.service.createOne(req, {
         ...dto,
         districtsDefinition: new Array(geoCollection.hierarchy.length).fill(0),
-        lockedDistricts: new Array(geoCollection.hierarchy.length).fill(false),
+        lockedDistricts: new Array(dto.numberOfDistricts).fill(false),
         user: req.parsed.authPersist.userId
       });
     } catch (error) {

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -154,6 +154,7 @@ export class ProjectsController implements CrudController<Project> {
       return this.service.createOne(req, {
         ...dto,
         districtsDefinition: new Array(geoCollection.hierarchy.length).fill(0),
+        lockedDistricts: new Array(geoCollection.hierarchy.length).fill(false),
         user: req.parsed.authPersist.userId
       });
     } catch (error) {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -155,7 +155,7 @@ export type CompactnessScore = number | null | "non-contiguous";
 
 export type DistrictId = number;
 
-export type LockedDistricts = ReadonlySet<DistrictId>;
+export type LockedDistricts = readonly boolean[];
 
 export interface DemographicCounts {
   // key is demographic group (eg. population, white, black, etc)


### PR DESCRIPTION
## Overview

This persists locking districts to the backend, including as part of undo/redo

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Saving:
![22de1df9-bf61-4176-bd02-aad38136b7cf](https://user-images.githubusercontent.com/4432106/100460902-fa263380-3095-11eb-879e-24fc597f3763.gif)

Undo/redo
![52cf93eb-6498-40ea-b6e1-4173546d83a8](https://user-images.githubusercontent.com/4432106/100460663-91d75200-3095-11eb-969b-59081ef0d313.gif)


## Testing Instructions

- `scripts/server`

Closes #405 
