### PR TITLE
Add find non-contiguous option to find menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Shapefile export [#516](https://github.com/PublicMapping/districtbuilder/pull/516)
 - Allow copying maps [#526](https://github.com/PublicMapping/districtbuilder/pull/526)
 - Reduce problem with hidden base geounits [#528](https://github.com/PublicMapping/districtbuilder/pull/528)
+- Find non-contiguous [#531](https://github.com/PublicMapping/districtbuilder/pull/531)
 
 ### Changed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -7,6 +7,11 @@ export enum SelectionTool {
   Rectangle = "RECTANGLE"
 }
 
+export enum FindTool {
+  Unassigned = "UNASSIGNED",
+  NonContiguous = "NON_CONTIGUOUS"
+}
+
 export const setSelectedDistrictId = createAction("Set selected district id")<number>();
 
 export const addSelectedGeounits = createAction("Add selected geounits")<GeoUnits>();
@@ -47,6 +52,7 @@ export const undo = createAction("Undo project action")();
 export const redo = createAction("Redo project action")();
 
 export const toggleFind = createAction("Toggle find menu visibility")<boolean>();
+export const setFindType = createAction("Set find menu search type")<FindTool>();
 export const setFindIndex = createAction("Set find menu polygon index")<number | undefined>();
 
 export const saveDistrictsDefinition = createAction("Save districts definition")();

--- a/src/client/components/map/FindMenu.tsx
+++ b/src/client/components/map/FindMenu.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import MapboxGL from "mapbox-gl";
 import { connect } from "react-redux";
-import { Box, Button, Flex, jsx, ThemeUIStyleObject } from "theme-ui";
+import { Box, Button, Flex, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import bbox from "@turf/bbox";
 import { polygon } from "@turf/helpers";
 
@@ -9,17 +9,17 @@ import Icon from "../Icon";
 
 import { State } from "../../reducers";
 import { DistrictsGeoJSON } from "../../types";
-import { setFindIndex, toggleFind } from "../../actions/districtDrawing";
+import { FindTool, setFindIndex, setFindType, toggleFind } from "../../actions/districtDrawing";
 import store from "../../store";
 import { destructureResource } from "../../functions";
-import { useEffect } from "react";
+import { ChangeEvent, useEffect } from "react";
 
 const style: ThemeUIStyleObject = {
   menu: {
     position: "absolute",
     top: "-1px",
     left: 2,
-    width: "300px",
+    width: "350px",
     backgroundColor: "muted",
     border: "1px solid",
     borderTop: "none",
@@ -29,6 +29,9 @@ const style: ThemeUIStyleObject = {
     fontSize: 1,
     alignItems: "center",
     p: 2
+  },
+  select: {
+    minWidth: "132px"
   },
   numFound: {
     flex: "auto",
@@ -51,60 +54,73 @@ const style: ThemeUIStyleObject = {
 const FindMenu = ({
   findMenuOpen,
   findIndex,
+  findTool,
   geojson,
   map
 }: {
   readonly findMenuOpen: boolean;
   readonly findIndex?: number;
+  readonly findTool: FindTool;
   readonly geojson?: DistrictsGeoJSON;
   readonly map?: MapboxGL.Map;
 }) => {
-  const unassigned = geojson && geojson.features[0];
-  const allUnassigned =
+  const findCoords =
+    geojson &&
+    (findTool === FindTool.Unassigned
+      ? geojson.features[0].geometry.coordinates
+      : geojson.features
+          .slice(1)
+          .map(multipolygon => multipolygon.geometry.coordinates)
+          .filter(coords => coords.length >= 2)
+          .flat());
+  const areAllUnassigned =
     geojson &&
     geojson.features.slice(1).every(district => district.geometry.coordinates.length === 0);
-  const numUnassigned = allUnassigned ? 0 : unassigned?.geometry.coordinates.length;
+  const num = findTool === FindTool.Unassigned && areAllUnassigned ? 0 : findCoords?.length;
 
   useEffect(() => {
     // eslint-disable-next-line
-    if (
-      map &&
-      unassigned &&
-      findIndex !== undefined &&
-      unassigned.geometry.coordinates.length > findIndex
-    ) {
+    if (map && findCoords && findIndex !== undefined && findCoords.length > findIndex) {
       // eslint-disable-next-line
-      const bounds = bbox(polygon(unassigned.geometry.coordinates[findIndex])) as [
-        number,
-        number,
-        number,
-        number
-      ];
+      const bounds = bbox(polygon(findCoords[findIndex])) as [number, number, number, number];
       map.fitBounds(bounds, { padding: 50 });
     }
-  }, [map, unassigned, findIndex]);
+  }, [map, findCoords, findIndex]);
 
   return findMenuOpen ? (
     <Flex sx={style.menu}>
       <b>Find</b>
-      &nbsp; Unassigned
+      &nbsp;{" "}
+      <Select
+        sx={style.select}
+        value={findTool}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          store.dispatch(
+            setFindType(
+              e.target.value === FindTool.Unassigned ? FindTool.Unassigned : FindTool.NonContiguous
+            )
+          );
+          store.dispatch(setFindIndex(undefined));
+        }}
+      >
+        <option value={FindTool.Unassigned}>Unassigned</option>
+        <option value={FindTool.NonContiguous}>Non-contiguous</option>
+      </Select>
       <Box sx={style.numFound}>
-        {unassigned
-          ? findIndex !== undefined && numUnassigned
-            ? `${findIndex + 1} / ${numUnassigned}`
-            : `${numUnassigned} found`
+        {findCoords
+          ? findIndex !== undefined
+            ? `${findIndex + 1} / ${num}`
+            : `${num} found`
           : "—"}
       </Box>
       <Box sx={{ px: 1 }}>
         <Button
           sx={style.button}
-          disabled={numUnassigned === undefined || numUnassigned === 0}
+          disabled={num === undefined || num === 0}
           onClick={() =>
-            numUnassigned !== undefined &&
+            num !== undefined &&
             store.dispatch(
-              setFindIndex(
-                findIndex === undefined || findIndex === 0 ? numUnassigned - 1 : findIndex - 1
-              )
+              setFindIndex(findIndex === undefined || findIndex === 0 ? num - 1 : findIndex - 1)
             )
           }
         >
@@ -112,12 +128,10 @@ const FindMenu = ({
         </Button>
         <Button
           sx={style.button}
-          disabled={numUnassigned === undefined || numUnassigned === 0}
+          disabled={num === undefined || num === 0}
           onClick={() =>
-            numUnassigned !== undefined &&
-            store.dispatch(
-              setFindIndex(findIndex === undefined ? 0 : (findIndex + 1) % numUnassigned)
-            )
+            num !== undefined &&
+            store.dispatch(setFindIndex(findIndex === undefined ? 0 : (findIndex + 1) % num))
           }
         >
           <Icon name="chevron-right" />
@@ -136,6 +150,7 @@ function mapStateToProps(state: State) {
   return {
     findMenuOpen: state.project.findMenuOpen,
     findIndex: state.project.findIndex,
+    findTool: state.project.findTool,
     geojson: destructureResource(state.project.projectData, "geojson")
   };
 }

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -8,7 +8,8 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import {
   setGeoLevelVisibility,
   SelectionTool,
-  replaceSelectedGeounits
+  replaceSelectedGeounits,
+  FindTool
 } from "../../actions/districtDrawing";
 import { getDistrictColor } from "../../constants/colors";
 import {
@@ -54,6 +55,7 @@ interface Props {
   readonly lockedDistricts: LockedDistricts;
   readonly isReadOnly: boolean;
   readonly findMenuOpen: boolean;
+  readonly findTool: FindTool;
   readonly label?: string;
   readonly map?: MapboxGL.Map;
   // eslint-disable-next-line
@@ -72,6 +74,7 @@ const DistrictsMap = ({
   lockedDistricts,
   isReadOnly,
   findMenuOpen,
+  findTool,
   label,
   map,
   setMap
@@ -91,16 +94,6 @@ const DistrictsMap = ({
   // The ability to zoom this far in isn't needed in the typical use-case (+4 is fine for that),
   // but it's needed in order to allow the user to fix very tiny unassigned slivers that may arise.
   const overZoom = maxZoom + 8;
-
-  // Add a color property to the geojson, so it can be used for styling
-  geojson.features.forEach((feature, id) => {
-    // @ts-ignore
-    // eslint-disable-next-line
-    feature.properties.outlineColor = id === 0 ? "#F25DFE" : "transparent";
-    // @ts-ignore
-    // eslint-disable-next-line
-    feature.properties.color = getDistrictColor(id);
-  });
 
   useEffect(() => {
     // eslint-disable-next-line
@@ -164,11 +157,27 @@ const DistrictsMap = ({
     // eslint-disable-next-line
   }, [mapRef]);
 
-  // Update districts source when geojson is fetched
+  // Update districts source when geojson is fetched or find type is changed
   useEffect(() => {
+    // Add a color property to the geojson, so it can be used for styling
+    geojson.features.forEach((feature, id) => {
+      // @ts-ignore
+      // eslint-disable-next-line
+      feature.properties.outlineColor =
+        (findTool === FindTool.Unassigned && id === 0) ||
+        (findTool === FindTool.NonContiguous &&
+          id !== 0 &&
+          feature.geometry.coordinates.length >= 2)
+          ? "#F25DFE"
+          : "transparent";
+      // @ts-ignore
+      // eslint-disable-next-line
+      feature.properties.color = getDistrictColor(id);
+    });
+
     const districtsSource = map && map.getSource(DISTRICTS_SOURCE_ID);
     districtsSource && districtsSource.type === "geojson" && districtsSource.setData(geojson);
-  }, [map, geojson]);
+  }, [map, geojson, findTool]);
 
   const removeSelectedFeatures = (map: MapboxGL.Map, staticMetadata: IStaticMetadata) => {
     staticMetadata.geoLevelHierarchy
@@ -407,7 +416,8 @@ const DistrictsMap = ({
 
 function mapStateToProps(state: State) {
   return {
-    findMenuOpen: state.project.findMenuOpen
+    findMenuOpen: state.project.findMenuOpen,
+    findTool: state.project.findTool
   };
 }
 

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -24,8 +24,10 @@ import {
   replaceSelectedGeounits,
   toggleFind,
   setFindIndex,
+  setFindType,
   saveDistrictsDefinition,
-  setSavingState
+  setSavingState,
+  FindTool
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
@@ -98,6 +100,7 @@ export interface DistrictDrawingState {
   readonly showCopyMapModal: boolean;
   readonly findMenuOpen: boolean;
   readonly findIndex?: number;
+  readonly findTool: FindTool;
   readonly saving: SavingState;
   readonly undoHistory: UndoHistory;
 }
@@ -109,6 +112,7 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   showAdvancedEditingModal: false,
   showCopyMapModal: false,
   findMenuOpen: false,
+  findTool: FindTool.Unassigned,
   saving: "unsaved",
   undoHistory: {
     past: [],
@@ -251,6 +255,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
       return {
         ...state,
         findIndex: action.payload
+      };
+    case getType(setFindType):
+      return {
+        ...state,
+        findTool: action.payload
       };
     case getType(undo): {
       const lastPastState = state.undoHistory.past[state.undoHistory.past.length - 1];

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -279,7 +279,8 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
               ...state,
               projectData: {
                 resource: action.payload
-              }
+              },
+              findIndex: undefined
             },
             {
               districtsDefinition: action.payload.project.districtsDefinition


### PR DESCRIPTION
## Overview

Add find non-contiguous option to find menu

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_](https://user-images.githubusercontent.com/4432106/101402157-61679300-38a1-11eb-98c2-10c46dd8977f.png)

![localhost_3003_ (1)](https://user-images.githubusercontent.com/4432106/101402115-544aa400-38a1-11eb-82fc-1eb693863ece.png)


## Testing Instructions

- `scripts/server`

Closes #517 
