### PR TITLE
Don't show district lock status on read-only maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Don't show district lock status on read-only maps [#538](https://github.com/PublicMapping/districtbuilder/pull/538)
+
 ## [1.2.0] - 2020-11-18
 
 ### Added

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -352,7 +352,7 @@ const SidebarRow = memo(
         </Styled.td>
         <Styled.td sx={{ ...style.td, ...style.number }}>{compactnessDisplay}</Styled.td>
         <Styled.td>
-          {isDistrictLocked ? (
+          {isReadOnly ? null : isDistrictLocked ? (
             <Tooltip
               content={
                 <span>
@@ -364,7 +364,7 @@ const SidebarRow = memo(
                 <Icon name="lock-locked" color="#131f28" size={0.75} />
               </Button>
             </Tooltip>
-          ) : !isReadOnly ? (
+          ) : (
             <Tooltip content="Lock this district">
               <Button
                 variant="icon"
@@ -375,7 +375,7 @@ const SidebarRow = memo(
                 <Icon name="lock-unlocked" size={0.75} />
               </Button>
             </Tooltip>
-          ) : null}
+          )}
         </Styled.td>
       </Styled.tr>
     );

--- a/src/server/src/auth/guards/jwt-auth.guard.ts
+++ b/src/server/src/auth/guards/jwt-auth.guard.ts
@@ -3,3 +3,12 @@ import { AuthGuard } from "@nestjs/passport";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {}
+
+// This guard is for use in a view that's accessible to both logged in
+// and not logged in users, but we optionally want to have access to
+// user information in order to drive what's being returned.
+export class OptionalJwtAuthGuard extends JwtAuthGuard {
+  handleRequest<T>(_err: any, user: T): T {
+    return user;
+  }
+}

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -58,4 +58,9 @@ export class Project implements IProject {
     default: "'{}'"
   })
   lockedDistricts: readonly boolean[];
+
+  // Strips out data that we don't want to have available in the read-only view in the UI
+  getReadOnlyView(): Project {
+    return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };
+  }
 }


### PR DESCRIPTION
## Overview

District lock status was showing up in the sidebar and the map in read-only mode, where it wasn't desired.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Read only:
![lock-not-logged-in](https://user-images.githubusercontent.com/6386/101946847-861f7b80-3bbd-11eb-8a36-0ccaa0e500cd.png)

Owner view:
![lock-logged-in](https://user-images.githubusercontent.com/6386/101946848-86b81200-3bbd-11eb-80f4-c28360302d75.png)

### Notes

The sidebar was straightforward, but getting the map layer to not show the locked status was a little trickier than expected. The least invasive and future-proof approach seemed to be stripping the data at the source: the Project `getOne` function in the controller. However in order to get this to work, I needed to add a new Auth guard that would allow user information to be available in that function if present. This is because using the standard Auth guard will deny unauthenticated requests, and using no auth guard will not pass along any user information to the function. Once that was worked out, the new logic is simply removing the locking information from the project when it's not being requested by the project owner. As our auth story grows, if it turns out we need to do more things of this nature, I can see it being worth getting fancier with types here: for instance having a separate type for a ReadOnlyProject that doesn't even include certain fields, such as locked districts. This type of change seems overkill at this point though, so I just kept it simple.

## Testing Instructions

- `./scripts/server`
- View a project that you own and ensure you can lock/unlock districts and they show as such on the map
- View the same project in a private tab (not logged in) and ensure lock information doesn't show up on the sidebar/map
- Log in as a second user, view the same map, and ensure you also see the same read-only locking behavior with this user

Closes #529 
