### PR TITLE
Add last updated date to map list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow copying maps [#526](https://github.com/PublicMapping/districtbuilder/pull/526)
 - Reduce problem with hidden base geounits [#528](https://github.com/PublicMapping/districtbuilder/pull/528)
 - Find non-contiguous [#531](https://github.com/PublicMapping/districtbuilder/pull/531)
-- Add last updated date to map list [#539](https://github.com/PublicMapping/districtbuilder/pull/539)
+- Add last updated date to map list [#541](https://github.com/PublicMapping/districtbuilder/pull/541)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow copying maps [#526](https://github.com/PublicMapping/districtbuilder/pull/526)
 - Reduce problem with hidden base geounits [#528](https://github.com/PublicMapping/districtbuilder/pull/528)
 - Find non-contiguous [#531](https://github.com/PublicMapping/districtbuilder/pull/531)
+- Add last updated date to map list [#539](https://github.com/PublicMapping/districtbuilder/pull/539)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-loop": "5.0.1",
     "theme-ui": "0.4.0-rc.1",
+    "timeago-react": "3.0.1",
     "ts.data.json": "0.3.0",
     "typesafe-actions": "5.1.0",
     "typescript": "3.7.5",

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -144,7 +144,7 @@ export async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJS
 export async function fetchProjects(): Promise<readonly IProject[]> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .get("/api/projects")
+      .get("/api/projects?sort=updatedDt,DESC")
       .then(response => resolve(response.data))
       .catch(error => reject(error.message));
   });

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import Avatar from "react-avatar";
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Link, useHistory } from "react-router-dom";
+import TimeAgo from "timeago-react";
 import * as H from "history";
 import Icon from "../components/Icon";
 import SupportMenu from "../components/SupportMenu";
@@ -284,6 +285,15 @@ const HomeScreen = ({ projects, user }: StateProps) => {
                     ({project.regionConfig.name}, {project.numberOfDistricts} districts)
                   </p>
                 </Link>
+                <div
+                  sx={{
+                    fontWeight: "light",
+                    color: "gray.5",
+                    paddingLeft: "5px"
+                  }}
+                >
+                  Last updated <TimeAgo datetime={project.updatedDt} />
+                </div>
                 <Divider />
               </React.Fragment>
             ))

--- a/src/server/migrations/1607960574923-add_last_updated_to_projects.ts
+++ b/src/server/migrations/1607960574923-add_last_updated_to_projects.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class addLastUpdatedToProjects1607960574923 implements MigrationInterface {
+  name = "addLastUpdatedToProjects1607960574923";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `ALTER TABLE "project" ADD "updated_dt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "updated_dt"`);
+  }
+}

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -1,4 +1,12 @@
-import { Check, Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Check,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from "typeorm";
 
 import { DistrictsDefinition, IProject } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
@@ -32,6 +40,13 @@ export class Project implements IProject {
 
   @Column({ type: "timestamp with time zone", name: "created_dt", default: () => "NOW()" })
   createdDt: Date;
+
+  @UpdateDateColumn({
+    type: "timestamp with time zone",
+    name: "updated_dt",
+    default: () => "NOW()"
+  })
+  updatedDt: Date;
 
   @Column({ default: false })
   advancedEditingEnabled: boolean;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -101,6 +101,7 @@ export interface IProject {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
+  readonly updatedDt: Date;
   readonly districtsDefinition: DistrictsDefinition;
   readonly user: Pick<IUser, PublicUserProperties>;
   readonly advancedEditingEnabled: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11182,6 +11182,18 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+timeago-react@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/timeago-react/-/timeago-react-3.0.1.tgz#b67a7271f3241b8535c10d3bc2cf3ee18a0649e8"
+  integrity sha512-IWSLWO47saoPOplrrLF5JbOW474oXnx+GfTw4SIuskY9yaSbzNnf0Lah2G9AwLuuQ4dQHSu4EgEOSNTPBxdoQA==
+  dependencies:
+    timeago.js "^4.0.0"
+
+timeago.js@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
+  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"


### PR DESCRIPTION
## Overview

Adds last updated column to the `projects` table and displays this information on the user's home page map list by making use of `timeago`. Not listed in the A.C., but I also went ahead and sorted the maps by descending last updated timestamp in order to help users find their most recently edited maps.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![db-last-updated](https://user-images.githubusercontent.com/6386/102142594-b0c53a80-3e30-11eb-9e56-012d40530dbd.png)

### Notes

 * In planning, we agreed to not allow null last updated timestamps, and to just set all existing timestamps to `NOW`: that's what has been done here.
 * I came across `UpdateDateColumn`, which made my life a lot easier (was trying to do it manually first). This decorator will automatically set the value to the current timestamp on all updates. We should definitely use it for all future last updated columns.

## Testing Instructions

- `./scripts/update`, `./scripts/server`
- Visit the homepage, and all your maps should have a very recent last updated timestamp
- Edit various parts of different maps and ensure that the timestamps are being updated and displaying in the list accordingly

Closes #519 
