### PR TITLE
Fix project user filtering

### DIFF
--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -75,7 +75,7 @@ import { Errors } from "../../../../shared/types";
   filter: (req: any) => {
     // Filter to user's projects for all update requests and for full project
     // list. Unauthenticated access is allowed for individual projects
-    if (req.method !== "GET" || req.url === "/api/projects") {
+    if (req.method !== "GET" || req.route.path === "/api/projects") {
       const user = req.user as User;
       return {
         user_id: user ? user.id : undefined


### PR DESCRIPTION
## Overview

The project list endpoint was only filtering by user id when the URL exactly matched `/api/projects`. We recently began passing a sort parameter to this URL, and the match was no longer succeeding, causing user id filtering to not occur. This changes the match logic to use the route path rather than the URL for matching, since that doesn't include parameters.

### Checklist

- ~~[ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible~~

## Testing Instructions

- This is a trivial change that I'm going to merge as soon as CI passes
