### PR TITLE
Allow exporting map GeoJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce problem with hidden base geounits [#528](https://github.com/PublicMapping/districtbuilder/pull/528)
 - Find non-contiguous [#531](https://github.com/PublicMapping/districtbuilder/pull/531)
 - Add last updated date to map list [#541](https://github.com/PublicMapping/districtbuilder/pull/541)
+- Allow exporting map GeoJSON [#543](https://github.com/PublicMapping/districtbuilder/pull/543)
 
 ### Changed
 

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -45,5 +45,8 @@ export const updateProjectFailed = createAction("Update project failure")();
 export const exportCsv = createAction("Export project CSV")<IProject>();
 export const exportCsvFailure = createAction("Export project CSV failure")<string>();
 
+export const exportGeoJson = createAction("Export project GeoJSON")<IProject>();
+export const exportGeoJsonFailure = createAction("Export project GeoJSON failure")<string>();
+
 export const exportShp = createAction("Export project Shapefile")<IProject>();
 export const exportShpFailure = createAction("Export project Shapefile failure")<string>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -194,6 +194,22 @@ export async function exportProjectCsv(project: IProject): Promise<void> {
   });
 }
 
+export async function exportProjectGeoJson(project: IProject): Promise<void> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .get(`/api/projects/${project.id}/export/geojson`)
+      .then(response => {
+        return resolve(
+          saveAs(
+            new Blob([JSON.stringify(response.data)], { type: "application/json" }),
+            `${project.name}.geojson`
+          )
+        );
+      })
+      .catch(error => reject(error.message));
+  });
+}
+
 export async function exportProjectShp(project: IProject): Promise<void> {
   return new Promise((resolve, reject) => {
     apiAxios

--- a/src/client/components/ExportMenu.tsx
+++ b/src/client/components/ExportMenu.tsx
@@ -5,11 +5,12 @@ import Icon from "../components/Icon";
 import { IProject } from "../../shared/entities";
 import { style, invertStyles } from "./MenuButton.styles";
 import store from "../store";
-import { exportCsv, exportShp } from "../actions/projectData";
+import { exportCsv, exportGeoJson, exportShp } from "../actions/projectData";
 
 enum UserMenuKeys {
   ExportCsv = "csv",
-  ExportShapefile = "shp"
+  ExportShapefile = "shp",
+  ExportGeoJson = "geojson"
 }
 
 interface ExportProps {
@@ -22,7 +23,12 @@ const ExportMenu = (props: ExportProps) => {
     <Wrapper
       sx={{ position: "relative", pr: 1 }}
       onSelection={(userMenuKey: string) => {
-        const action = userMenuKey === UserMenuKeys.ExportCsv ? exportCsv : exportShp;
+        const action =
+          userMenuKey === UserMenuKeys.ExportCsv
+            ? exportCsv
+            : userMenuKey === UserMenuKeys.ExportShapefile
+            ? exportShp
+            : exportGeoJson;
         store.dispatch(action(props.project));
       }}
     >
@@ -46,6 +52,9 @@ const ExportMenu = (props: ExportProps) => {
             </MenuItem>
             <MenuItem value={UserMenuKeys.ExportCsv}>
               <Box sx={style.menuListItem}>Export CSV</Box>
+            </MenuItem>
+            <MenuItem value={UserMenuKeys.ExportGeoJson}>
+              <Box sx={style.menuListItem}>Export GeoJSON</Box>
             </MenuItem>
           </li>
         </ul>

--- a/src/client/components/ProjectListFlyout.tsx
+++ b/src/client/components/ProjectListFlyout.tsx
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+import { jsx, Box } from "theme-ui";
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import { IProject } from "../../shared/entities";
+import { style, invertStyles } from "./MenuButton.styles";
+import store from "../store";
+import { exportCsv, exportGeoJson, exportShp } from "../actions/projectData";
+
+enum UserMenuKeys {
+  ExportCsv = "csv",
+  ExportShapefile = "shp",
+  ExportGeoJson = "geojson"
+}
+
+interface FlyoutProps {
+  readonly invert?: boolean;
+  readonly project: IProject;
+}
+
+// Flyout ("..." button) for each project on the project list page.
+// Currently the actions are all related to exporting, and this component
+// is therefore very similar to the ExportMenu component, but there will
+// eventually be other types of actions (e.g. archiving, duplicating),
+// that will cause divergence, so it has intentionally not been unified.
+const ProjectListFlyout = (props: FlyoutProps) => {
+  return (
+    <Wrapper
+      onSelection={(userMenuKey: string) => {
+        const action =
+          userMenuKey === UserMenuKeys.ExportCsv
+            ? exportCsv
+            : userMenuKey === UserMenuKeys.ExportShapefile
+            ? exportShp
+            : exportGeoJson;
+        store.dispatch(action(props.project));
+      }}
+    >
+      <MenuButton
+        sx={{
+          ...{ variant: "buttons.ghost", fontWeight: "light" },
+          ...style.menuButton,
+          ...invertStyles(props),
+          ...props
+        }}
+        className="project-list-flyout-menu"
+      >
+        ...
+      </MenuButton>
+      <Menu sx={{ ...style.menu, ...{ position: "relative" } }}>
+        <ul sx={style.menuList}>
+          <li key={UserMenuKeys.ExportCsv}>
+            <MenuItem value={UserMenuKeys.ExportShapefile}>
+              <Box sx={style.menuListItem}>Export Shapefile</Box>
+            </MenuItem>
+            <MenuItem value={UserMenuKeys.ExportCsv}>
+              <Box sx={style.menuListItem}>Export CSV</Box>
+            </MenuItem>
+            <MenuItem value={UserMenuKeys.ExportGeoJson}>
+              <Box sx={style.menuListItem}>Export GeoJSON</Box>
+            </MenuItem>
+          </li>
+        </ul>
+      </Menu>
+    </Wrapper>
+  );
+};
+
+export default ProjectListFlyout;

--- a/src/client/components/ProjectListFlyout.tsx
+++ b/src/client/components/ProjectListFlyout.tsx
@@ -46,7 +46,7 @@ const ProjectListFlyout = (props: FlyoutProps) => {
       >
         ...
       </MenuButton>
-      <Menu sx={{ ...style.menu, ...{ position: "relative" } }}>
+      <Menu sx={{ ...style.menu }}>
         <ul sx={style.menuList}>
           <li key={UserMenuKeys.ExportCsv}>
             <MenuItem value={UserMenuKeys.ExportShapefile}>

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -5,6 +5,8 @@ import { Action } from "../actions";
 import {
   exportCsv,
   exportCsvFailure,
+  exportGeoJson,
+  exportGeoJsonFailure,
   exportShp,
   exportShpFailure,
   projectDataFetch,
@@ -42,6 +44,7 @@ import {
 } from "../functions";
 import {
   exportProjectCsv,
+  exportProjectGeoJson,
   exportProjectShp,
   fetchProjectData,
   fetchProjectGeoJson,
@@ -353,6 +356,16 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         })
       );
     case getType(exportCsvFailure):
+      return loop(state, Cmd.run(showActionFailedToast));
+    case getType(exportGeoJson):
+      return loop(
+        state,
+        Cmd.run(exportProjectGeoJson, {
+          failActionCreator: exportGeoJsonFailure,
+          args: [action.payload] as Parameters<typeof exportProjectGeoJson>
+        })
+      );
+    case getType(exportGeoJsonFailure):
       return loop(state, Cmd.run(showActionFailedToast));
     case getType(exportShp):
       return loop(

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -134,6 +134,7 @@ const style: ThemeUIStyleObject = {
     display: "flex",
     alignItems: "baseline",
     borderRadius: "med",
+    marginRight: "auto",
     px: 1,
     "&:hover:not([disabled])": {
       bg: "rgba(256,256,256,0.2)",
@@ -275,28 +276,37 @@ const HomeScreen = ({ projects, user }: StateProps) => {
           projects.resource.length ? (
             projects.resource.map(project => (
               <React.Fragment key={project.id}>
-                <Link to={`/projects/${project.id}`} sx={style.projectRow}>
-                  <Heading
-                    as="h2"
-                    sx={{ fontFamily: "heading", variant: "text.h5", fontWeight: "light", mr: 3 }}
+                <Box>
+                  <Flex sx={{ position: "relative" }}>
+                    <Link to={`/projects/${project.id}`} sx={style.projectRow}>
+                      <Heading
+                        as="h2"
+                        sx={{
+                          fontFamily: "heading",
+                          variant: "text.h5",
+                          fontWeight: "light",
+                          mr: 3
+                        }}
+                      >
+                        {project.name}
+                      </Heading>
+                      <p sx={{ fontSize: 2, color: "gray.7" }}>
+                        ({project.regionConfig.name}, {project.numberOfDistricts} districts)
+                      </p>
+                    </Link>
+                    <ProjectListFlyout project={project} />
+                  </Flex>
+                  <div
+                    sx={{
+                      fontWeight: "light",
+                      color: "gray.5",
+                      paddingLeft: "5px"
+                    }}
                   >
-                    {project.name}
-                  </Heading>
-                  <p sx={{ fontSize: 2, color: "gray.7" }}>
-                    ({project.regionConfig.name}, {project.numberOfDistricts} districts)
-                  </p>
-                </Link>
-                <ProjectListFlyout project={project} />
-                <div
-                  sx={{
-                    fontWeight: "light",
-                    color: "gray.5",
-                    paddingLeft: "5px"
-                  }}
-                >
-                  Last updated <TimeAgo datetime={project.updatedDt} />
-                </div>
-                <Divider />
+                    Last updated <TimeAgo datetime={project.updatedDt} />
+                  </div>
+                  <Divider />
+                </Box>
               </React.Fragment>
             ))
           ) : (

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import { Link, useHistory } from "react-router-dom";
 import TimeAgo from "timeago-react";
 import * as H from "history";
+import ProjectListFlyout from "../components/ProjectListFlyout";
 import Icon from "../components/Icon";
 import SupportMenu from "../components/SupportMenu";
 import {
@@ -285,6 +286,7 @@ const HomeScreen = ({ projects, user }: StateProps) => {
                     ({project.regionConfig.name}, {project.numberOfDistricts} districts)
                   </p>
                 </Link>
+                <ProjectListFlyout project={project} />
                 <div
                   sx={{
                     fontWeight: "light",


### PR DESCRIPTION
## Overview

This adds a GeoJSON export option to the export menu on the map page, and also brings over the now three export options to the map list page, so it can be done directly from there.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![geojson-export-1](https://user-images.githubusercontent.com/6386/102267233-9d28db00-3ee7-11eb-962e-86ed57b210f1.png)
![geojson-export-2](https://user-images.githubusercontent.com/6386/102267235-9dc17180-3ee7-11eb-887c-06df3ca7667b.png)
![geojson-export-3](https://user-images.githubusercontent.com/6386/102267236-9dc17180-3ee7-11eb-8282-a7ad5117c818.png)
![geojson-export-4](https://user-images.githubusercontent.com/6386/102267238-9dc17180-3ee7-11eb-8fb1-12bac71d95f3.png)

### Notes

 * The GeoJSON isn't available on the project page. Even though it is available on the map page, I chose to keep it simple by using the same code path in both places, and thus requesting GeoJSON on the map page, even though we technically do already have it available. I think reducing the complexity is worth the second or so wait when a user exports GeoJSON.
 * I spent some time attempting to properly style the flyout on the project list page, but couldn't quite get it right, and ultimately decided to revert my styling attempt, and kick it over to the design team for efficiency sake.

## Testing Instructions

- `./scripts/server`
- Test exporting GeoJSON from the map page
- Test exporting GeoJSON (as well as CSV, SHP) from the map page

Closes #238 
