### PR TITLE
Remove "Copy this map" button from owned maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove "Copy this map" button from owned maps [#545](https://github.com/PublicMapping/districtbuilder/pull/545)
+
 ### Fixed
 
 - Don't show district lock status on read-only maps [#538](https://github.com/PublicMapping/districtbuilder/pull/538)

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -102,7 +102,6 @@ const ProjectHeader = ({
               </Button>
             </React.Fragment>
           )}
-          <CopyMapButton invert={true} />
           <ShareMenu invert={true} />
           <SupportMenu invert={true} />
           {project ? <ExportMenu invert={true} project={project} /> : null}


### PR DESCRIPTION
## Overview

We want to remove the "Copy this map" button from owned maps in order to unclutter the UI. We'll eventually have this functionality available from the map list page as a "Duplicate" function.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![screenshot_12](https://user-images.githubusercontent.com/6386/102548788-2592b180-4089-11eb-8186-a4fedc8a3fe0.png)

## Testing Instructions

- Load a map that you own, and ensure you don't see a "Copy this map" button
- Open this same map in a private/unlogged-in window and verify that the button is displayed

Closes #530
