### PR TITLE
Fix health check when unable to load RegionConfig data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't show district lock status on read-only maps [#538](https://github.com/PublicMapping/districtbuilder/pull/538)
+- Fix topology health check to report inability to load region configs as an error [#546](https://github.com/PublicMapping/districtbuilder/pull/546)
 
 ## [1.2.0] - 2020-11-18
 

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -21,7 +21,7 @@ interface Layers {
 
 @Injectable()
 export class TopologyService {
-  private _layers: Layers = {};
+  private _layers?: Layers = undefined;
   private readonly logger = new Logger(TopologyService.name);
   private s3 = new S3();
 
@@ -39,11 +39,14 @@ export class TopologyService {
     });
   }
 
-  public layers(): Readonly<Layers> {
-    return Object.freeze(this._layers);
+  public layers(): Readonly<Layers> | undefined {
+    return this._layers && Object.freeze(this._layers);
   }
 
   public async get(s3URI: S3URI): Promise<GeoUnitTopology | void> {
+    if (!this._layers) {
+      return;
+    }
     if (!(s3URI in this._layers)) {
       // If we encounter a new layer (i.e. one added after the service has started),
       // then store the results in the `_layers` object.

--- a/src/server/src/healthcheck/topology-loaded.indicator.ts
+++ b/src/server/src/healthcheck/topology-loaded.indicator.ts
@@ -27,9 +27,14 @@ export default class TopologyLoadedIndicator extends HealthIndicator {
         });
       })
     )) as [string, boolean][];
-    const layerStatus = Object.fromEntries(layerEntries);
-    const isHealthy = Object.values(layerStatus).every(status => status);
-    const result = this.getStatus(key, isHealthy, layerStatus);
+
+    const isHealthy = layerEntries.every(([_, status]) => status);
+    const pendingLayers = layerEntries.filter(([_, status]) => !status).map(([layer, _]) => layer);
+    const result = this.getStatus(key, isHealthy, {
+      total: layerEntries.length,
+      complete: layerEntries.length - pendingLayers.length,
+      pendingLayers
+    });
 
     if (isHealthy) {
       return result;

--- a/src/server/src/healthcheck/topology-loaded.indicator.ts
+++ b/src/server/src/healthcheck/topology-loaded.indicator.ts
@@ -11,6 +11,11 @@ export default class TopologyLoadedIndicator extends HealthIndicator {
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
     const layers = this.topologyService.layers();
+    if (layers === undefined) {
+      const result = this.getStatus(key, false, {});
+      throw new HealthCheckError("Topology layers not intialized", result);
+    }
+
     const layerEntries = (await Promise.all(
       Object.entries(layers).map(([layerId, topology]) => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Overview

During a previous deployment, we encountered an issue where a change to the `RegionConfig` entity caused the service to be unable to load the topojson layers, but the healthcheck did not report a problem.

By adding a new field to the `RegionConfig` entity, I was able to recreate the original issue:

```diff
diff --git a/src/server/src/region-configs/entities/region-config.entity.ts b/src/server/src/region-configs/entities/region-config.entity.ts
index 8cba8b3..8636751 100644
--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -32,4 +32,7 @@ export class RegionConfig implements IRegionConfig {
 
   @Column({ type: "boolean", default: false })
   hidden: boolean;
+
+  @Column({ type: "boolean", default: false })
+  test: boolean;
 }
 ```
 
 From what I can tell, because the `_layers` field of TopologyService defaulted to `[]`, when it encountered an error in retrieving the regionConfigs the health check thought it was healthy bc it had no regions configured.
 
 Since the regions are loaded on startup, they didn't throw an error in the healthcheck itself, but are instead an unhandled error that only gets logged.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Notes

I also updated the topology health check indicator while I was at it, because it is a little unwieldy at this point to report every state we have configured. Instead I only list the states that are still pending, which should be enough to identify any problematic layers that are taking too long to load.


## Testing Instructions


Use the above diff to recreate the health check problem on develop. Verify on this branch that the health check correctly returns 503 if it fails to / has not yet loaded the region configs.

Closes #515 
