### PR TITLE
Rewrite null values in SHP export to prevent them from being dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Shapefile export [#516](https://github.com/PublicMapping/districtbuilder/pull/516)
+- Added Shapefile export [#516](https://github.com/PublicMapping/districtbuilder/pull/516) & [#556](https://github.com/PublicMapping/districtbuilder/pull/556)
 - Allow copying maps [#526](https://github.com/PublicMapping/districtbuilder/pull/526)
 - Reduce problem with hidden base geounits [#528](https://github.com/PublicMapping/districtbuilder/pull/528)
 - Find non-contiguous [#531](https://github.com/PublicMapping/districtbuilder/pull/531)

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -3,8 +3,8 @@ import React, { memo, useEffect, useState, Fragment } from "react";
 import { Box, Button, Flex, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
-  CompactnessScore,
   DemographicCounts,
+  DistrictProperties,
   GeoUnitHierarchy,
   GeoUnits,
   IProject,
@@ -208,8 +208,8 @@ const ProjectSidebar = ({
 
 const BLANK_VALUE = "–";
 
-function getCompactnessDisplay(compactness: CompactnessScore) {
-  return compactness === null ? (
+function getCompactnessDisplay(properties: DistrictProperties) {
+  return properties.contiguity === "" ? (
     <Tooltip
       placement="top-start"
       content={
@@ -220,19 +220,7 @@ function getCompactnessDisplay(compactness: CompactnessScore) {
     >
       <span sx={{ color: "gray.2" }}>{BLANK_VALUE}</span>
     </Tooltip>
-  ) : typeof compactness === "number" ? (
-    <Tooltip
-      placement="top-start"
-      content={
-        <span>
-          <strong>{Math.floor(compactness * 100)}% compactness.</strong> Calculated using the
-          Polsby-Popper measurement
-        </span>
-      }
-    >
-      <span>{`${Math.floor(compactness * 100)}%`}</span>
-    </Tooltip>
-  ) : compactness === "non-contiguous" ? (
+  ) : properties.contiguity === "non-contiguous" ? (
     <Tooltip
       placement="top-start"
       content={
@@ -246,8 +234,20 @@ function getCompactnessDisplay(compactness: CompactnessScore) {
         <Icon name="alert-triangle" color="#f06543" size={0.95} />
       </span>
     </Tooltip>
+  ) : properties.contiguity === "contiguous" ? (
+    <Tooltip
+      placement="top-start"
+      content={
+        <span>
+          <strong>{Math.floor(properties.compactness * 100)}% compactness.</strong> Calculated using
+          the Polsby-Popper measurement
+        </span>
+      }
+    >
+      <span>{`${Math.floor(properties.compactness * 100)}%`}</span>
+    </Tooltip>
   ) : (
-    assertNever(compactness)
+    assertNever(properties.contiguity)
   );
 }
 
@@ -291,7 +291,7 @@ const SidebarRow = memo(
       districtId === 0 ? (
         <span sx={style.blankValue}>{BLANK_VALUE}</span>
       ) : (
-        getCompactnessDisplay(district.properties.compactness)
+        getCompactnessDisplay(district.properties)
       );
     const toggleHover = () => setHover(!isHovered);
     const toggleLocked = (e: React.MouseEvent) => {

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -26,6 +26,7 @@ import stringify from "csv-stringify/lib/sync";
 import { Response } from "express";
 import { FeatureCollection } from "geojson";
 import { convert } from "geojson2shp";
+import * as _ from "lodash";
 import { GeometryCollection } from "topojson-specification";
 
 import { MakeDistrictsErrors } from "../../../../shared/constants";

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -34,7 +34,12 @@ export interface IDistrictsDefinition {
   readonly districts: DistrictsDefinition;
 }
 
-export type DistrictProperties = { readonly [name: string]: number };
+export type DistrictProperties = {
+  readonly contiguity: "contiguous" | "non-contiguous" | "";
+  readonly compactness: number;
+} & {
+  readonly [name: string]: number;
+};
 
 export interface IStaticFile {
   readonly id: string;
@@ -154,7 +159,7 @@ export interface MutableGeoUnits {
   [geoLevelId: string]: Map<FeatureId, GeoUnitIndices>;
 }
 
-export type CompactnessScore = number | null | "non-contiguous";
+export type Contiguity = "" | "contiguous" | "non-contiguous";
 
 export type DistrictId = number;
 


### PR DESCRIPTION
~Fixes issue of the compactness field being dropped, which seems to have happened whenever the first district had a null value.~

~This manifested in compactness scores being dropped, but I think would be an issue for any nullable field.~

Edit:
The initial approach didn't work out well, and was reworked in https://github.com/PublicMapping/districtbuilder/pull/556/commits/1e3e09130376c6d889535870000e50b4ee21569f to make the `compactness` field numeric-only and add a new `contiguity` field in the export.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Load up a map with no unassigned blocks
- On `develop` the Shapefile export should not have a `compactness` column - on this branch it should

Closes #554 
