### PR TITLE
Don't reset find index after accepting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't show district lock status on read-only maps [#538](https://github.com/PublicMapping/districtbuilder/pull/538)
 - Fix topology health check to report inability to load region configs as an error [#546](https://github.com/PublicMapping/districtbuilder/pull/546)
+- Keep position in find menu after accepting changes [#557](https://github.com/PublicMapping/districtbuilder/pull/557)
 
 ## [1.2.0] - 2020-11-18
 

--- a/src/client/components/map/FindMenu.tsx
+++ b/src/client/components/map/FindMenu.tsx
@@ -10,6 +10,7 @@ import Icon from "../Icon";
 import { State } from "../../reducers";
 import { DistrictsGeoJSON } from "../../types";
 import { FindTool, setFindIndex, setFindType, toggleFind } from "../../actions/districtDrawing";
+import { getFindCoords } from "../../reducers/projectData";
 import store from "../../store";
 import { destructureResource } from "../../functions";
 import { ChangeEvent, useEffect } from "react";
@@ -64,19 +65,8 @@ const FindMenu = ({
   readonly geojson?: DistrictsGeoJSON;
   readonly map?: MapboxGL.Map;
 }) => {
-  const findCoords =
-    geojson &&
-    (findTool === FindTool.Unassigned
-      ? geojson.features[0].geometry.coordinates
-      : geojson.features
-          .slice(1)
-          .map(multipolygon => multipolygon.geometry.coordinates)
-          .filter(coords => coords.length >= 2)
-          .flat());
-  const areAllUnassigned =
-    geojson &&
-    geojson.features.slice(1).every(district => district.geometry.coordinates.length === 0);
-  const num = findTool === FindTool.Unassigned && areAllUnassigned ? 0 : findCoords?.length;
+  const findCoords = getFindCoords(findTool, geojson);
+  const num = findCoords?.length || 0;
 
   useEffect(() => {
     // eslint-disable-next-line


### PR DESCRIPTION
## Overview

Keeps position in the Find menu in place after accepting changes when possible.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

This is a little harder than it might initially seem (my first attempt at this was to simply leave the `findIndex` state as-is after changes are save, but that runs into issues where the index might no longer be valid).

## Testing Instructions

- `scripts/server`
- Create a few unassigned spots and non-contiguous districts. Ensure the find position is preserved for both find options, when possible

Closes #555 