### PR TITLE
Organization page stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Share menu now controls map visibility (private/public/shared w link) [#560](https://github.com/PublicMapping/districtbuilder/pull/560)
+- Organization detail screen [#562](https://github.com/PublicMapping/districtbuilder/pull/562)
 
 ### Changed
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -10,6 +10,7 @@ import CreateProjectScreen from "./screens/CreateProjectScreen";
 import ForgotPasswordScreen from "./screens/ForgotPasswordScreen";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
+import OrganizationScreen from "./screens/OrganizationScreen";
 import ProjectScreen from "./screens/ProjectScreen";
 import RegistrationScreen from "./screens/RegistrationScreen";
 import ResetPasswordScreen from "./screens/ResetPasswordScreen";
@@ -43,6 +44,7 @@ const App = () => (
         <PrivateRoute path="/" exact={true}>
           <HomeScreen />
         </PrivateRoute>
+        <Route path="/o/:organizationSlug" exact={true} component={OrganizationScreen} />
         <Route path="/projects/:projectId" exact={true} component={ProjectScreen} />
         <Route path="/login" exact={true} component={LoginScreen} />
         <Route path="/register" exact={true} component={RegistrationScreen} />

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -2,6 +2,7 @@ import { ActionType } from "typesafe-actions";
 
 import * as authActions from "./actions/auth";
 import * as districtDrawingActions from "./actions/districtDrawing";
+import * as organizationActions from "./actions/organization";
 import * as projectDataActions from "./actions/projectData";
 import * as projectsActions from "./actions/projects";
 import * as regionConfigActions from "./actions/regionConfig";
@@ -10,6 +11,7 @@ import * as userActions from "./actions/user";
 
 export type AuthAction = ActionType<typeof authActions>;
 export type DistrictDrawingAction = ActionType<typeof districtDrawingActions>;
+export type OrganizationAction = ActionType<typeof organizationActions>;
 export type ProjectDataAction = ActionType<typeof projectDataActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
 export type RegionConfigAction = ActionType<typeof regionConfigActions>;
@@ -19,6 +21,7 @@ export type UserAction = ActionType<typeof userActions>;
 export type Action =
   | AuthAction
   | DistrictDrawingAction
+  | OrganizationAction
   | ProjectDataAction
   | ProjectsAction
   | RegionConfigAction

--- a/src/client/actions/organization.ts
+++ b/src/client/actions/organization.ts
@@ -1,0 +1,6 @@
+import { createAction } from "typesafe-actions";
+import { IOrganization, OrganizationSlug } from "../../shared/entities";
+
+export const organizationFetch = createAction("Organization fetch")<OrganizationSlug>();
+export const organizationFetchSuccess = createAction("Organization fetch success")<IOrganization>();
+export const organizationFetchFailure = createAction("Organization fetch failure")<string>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -3,10 +3,12 @@ import { saveAs } from "file-saver";
 
 import {
   CreateProjectData,
+  IOrganization,
   IProject,
   IRegionConfig,
   IUser,
   JWT,
+  OrganizationSlug,
   ProjectId,
   UpdateProjectData,
   UpdateUserData
@@ -220,6 +222,15 @@ export async function exportProjectShp(project: IProject): Promise<void> {
           saveAs(new Blob([response.data], { type: "application/zip" }), `${project.name}.zip`)
         );
       })
+      .catch(error => reject(error.message));
+  });
+}
+
+export async function fetchOrganization(slug: OrganizationSlug): Promise<IOrganization> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .get(`/api/organization/${slug}`)
+      .then(response => resolve(response.data))
       .catch(error => reject(error.message));
   });
 }

--- a/src/client/components/SiteHeader.tsx
+++ b/src/client/components/SiteHeader.tsx
@@ -1,0 +1,173 @@
+/** @jsx jsx */
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import Avatar from "react-avatar";
+import React from "react";
+import { Link, useHistory } from "react-router-dom";
+import * as H from "history";
+import Icon from "../components/Icon";
+import SupportMenu from "../components/SupportMenu";
+import { Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+import { ReactComponent as Logo } from "../media/logos/logo.svg";
+
+import { resetState } from "../actions/root";
+import { clearJWT, getJWT } from "../jwt";
+import { UserState } from "../reducers/user";
+import store from "../store";
+
+interface Props {
+  readonly user: UserState;
+}
+
+enum UserMenuKeys {
+  Logout = "logout"
+}
+
+const logout = () => {
+  clearJWT();
+  store.dispatch(resetState());
+};
+
+const style: ThemeUIStyleObject = {
+  header: {
+    alignItems: "center",
+    justifyContent: "space-between",
+    py: 3,
+    px: 3,
+    bg: "gray.0",
+    borderBottom: "1px solid",
+    borderColor: "gray.1",
+    boxShadow: "small"
+  },
+  logoLink: {
+    borderRadius: "small",
+    "&:focus": {
+      outline: "none",
+      boxShadow: "focus"
+    }
+  },
+  avatar: {
+    fontFamily: "heading",
+    cursor: "pointer",
+    ".sb-avatar__text": {
+      "&:hover": {
+        backgroundColor: "#395c78 !important"
+      },
+      "&:active": {
+        backgroundColor: "#2c485e !important"
+      }
+    }
+  },
+  menuButton: {
+    display: "flex",
+    alignItems: "center",
+    bg: "transparent",
+    p: 1,
+    borderRadius: "small",
+    "&:focus": {
+      outline: "none",
+      boxShadow: "focus"
+    }
+  },
+  menu: {
+    width: "150px",
+    position: "absolute",
+    mt: 2,
+    right: 2,
+    bg: "muted",
+    py: 1,
+    px: 1,
+    border: "1px solid",
+    borderColor: "gray.2",
+    boxShadow: "small",
+    borderRadius: "small"
+  },
+  menuList: {
+    p: "0",
+    m: "0",
+    listStyleType: "none"
+  },
+  menuListItem: {
+    borderRadius: "small",
+    py: 1,
+    px: 2,
+    "&:hover:not([disabled])": {
+      bg: "gray.0",
+      cursor: "pointer"
+    },
+    "&[disabled]": {
+      color: "gray.3",
+      cursor: "not-allowed"
+    },
+    "&:focus": {
+      bg: "gray.0",
+      outline: "none",
+      boxShadow: "focus"
+    },
+    "&:active": {
+      bg: "gray.1"
+    }
+  }
+};
+
+const SiteHeader = ({ user }: Props) => {
+  const history = useHistory();
+  const isLoggedIn = getJWT() !== null;
+
+  return (
+    <Flex as="header" sx={style.header}>
+      <Heading as="h1" sx={{ mb: "0px", mr: "auto", p: 2 }}>
+        <Link to="/" sx={style.logoLink}>
+          <Logo sx={{ width: "15rem" }} />
+        </Link>
+      </Heading>
+      {!isLoggedIn ? (
+        <React.Fragment>
+          <Link to="/login" sx={{ p: 2 }}>
+            Login
+          </Link>{" "}
+          <Link to="/register" sx={{ p: 2 }}>
+            Register
+          </Link>
+        </React.Fragment>
+      ) : "resource" in user ? (
+        <React.Fragment>
+          <SupportMenu />
+          <Wrapper onSelection={handleSelection(history)} sx={{ ml: 3 }}>
+            <MenuButton sx={style.menuButton}>
+              <Avatar
+                name={user.resource.name}
+                round={true}
+                size={"2.5rem"}
+                color={"#2c485e"}
+                maxInitials={3}
+                sx={style.avatar}
+              />
+              <div sx={{ ml: 2 }}>
+                <Icon name="chevron-down" />
+              </div>
+            </MenuButton>
+            <Menu sx={style.menu}>
+              <ul sx={style.menuList}>
+                <li key={UserMenuKeys.Logout}>
+                  <MenuItem value={UserMenuKeys.Logout} sx={style.menuListItem}>
+                    Logout
+                  </MenuItem>
+                </li>
+              </ul>
+            </Menu>
+          </Wrapper>
+        </React.Fragment>
+      ) : null}
+    </Flex>
+  );
+};
+
+const handleSelection = (history: H.History) => (key: string | number) => {
+  // eslint-disable-next-line
+  if (key === UserMenuKeys.Logout) {
+    logout();
+    history.push("/login");
+  }
+};
+
+export default SiteHeader;

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -17,26 +17,26 @@ import projectReducer, { ProjectState, initialProjectState } from "./reducers/pr
 
 export interface State {
   readonly auth: AuthState;
-  readonly user: UserState;
-  readonly regionConfig: RegionConfigState;
-  readonly projects: ProjectsState;
   readonly project: ProjectState;
+  readonly projects: ProjectsState;
+  readonly regionConfig: RegionConfigState;
+  readonly user: UserState;
 }
 
 export const initialState: State = {
   auth: initialAuthState,
-  user: initialUserState,
-  regionConfig: initialRegionConfigState,
+  project: initialProjectState,
   projects: initialProjectsState,
-  project: initialProjectState
+  regionConfig: initialRegionConfigState,
+  user: initialUserState
 };
 
 const allReducers = combineReducers({
   auth: authReducer,
-  user: userReducer,
-  regionConfig: regionConfigReducer,
+  project: projectReducer,
   projects: projectsReducer,
-  project: projectReducer
+  regionConfig: regionConfigReducer,
+  user: userReducer
 });
 
 export default (state = initialState, action: Action) => {

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -4,6 +4,10 @@ import { getType } from "typesafe-actions";
 import { Action } from "./actions";
 import { resetState } from "./actions/root";
 import authReducer, { AuthState, initialState as initialAuthState } from "./reducers/auth";
+import organizationReducer, {
+  OrganizationState,
+  initialState as initialOrganizationState
+} from "./reducers/organization";
 import projectsReducer, {
   initialState as initialProjectsState,
   ProjectsState
@@ -19,12 +23,14 @@ export interface State {
   readonly auth: AuthState;
   readonly project: ProjectState;
   readonly projects: ProjectsState;
+  readonly organization: OrganizationState;
   readonly regionConfig: RegionConfigState;
   readonly user: UserState;
 }
 
 export const initialState: State = {
   auth: initialAuthState,
+  organization: initialOrganizationState,
   project: initialProjectState,
   projects: initialProjectsState,
   regionConfig: initialRegionConfigState,
@@ -33,6 +39,7 @@ export const initialState: State = {
 
 const allReducers = combineReducers({
   auth: authReducer,
+  organization: organizationReducer,
   project: projectReducer,
   projects: projectsReducer,
   regionConfig: regionConfigReducer,

--- a/src/client/reducers/organization.ts
+++ b/src/client/reducers/organization.ts
@@ -1,0 +1,54 @@
+import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
+
+import { Action } from "../actions";
+import {
+  organizationFetch,
+  organizationFetchFailure,
+  organizationFetchSuccess
+} from "../actions/organization";
+
+import { IOrganization } from "../../shared/entities";
+import { fetchOrganization } from "../api";
+import { showResourceFailedToast } from "../functions";
+import { Resource } from "../resource";
+
+export type OrganizationState = Resource<IOrganization>;
+
+export const initialState = {
+  isPending: false
+};
+
+const organizationReducer: LoopReducer<OrganizationState, Action> = (
+  state: OrganizationState = initialState,
+  action: Action
+): OrganizationState | Loop<OrganizationState, Action> => {
+  switch (action.type) {
+    case getType(organizationFetch):
+      return loop(
+        {
+          isPending: true
+        },
+        Cmd.run(fetchOrganization, {
+          successActionCreator: organizationFetchSuccess,
+          failActionCreator: organizationFetchFailure,
+          args: [action.payload] as Parameters<typeof fetchOrganization>
+        })
+      );
+    case getType(organizationFetchSuccess):
+      return {
+        resource: action.payload
+      };
+    case getType(organizationFetchFailure):
+      return loop(
+        {
+          errorMessage: action.payload
+        },
+        Cmd.run(showResourceFailedToast)
+      );
+    default:
+      return state;
+  }
+};
+
+export default organizationReducer;

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -1,14 +1,10 @@
 /** @jsx jsx */
-import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
-import Avatar from "react-avatar";
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import TimeAgo from "timeago-react";
-import * as H from "history";
 import ProjectListFlyout from "../components/ProjectListFlyout";
 import Icon from "../components/Icon";
-import SupportMenu from "../components/SupportMenu";
 import {
   Alert,
   Box,
@@ -21,115 +17,26 @@ import {
   Styled,
   ThemeUIStyleObject
 } from "theme-ui";
-import { ReactComponent as Logo } from "../media/logos/logo.svg";
 import { ReactComponent as NoMapsIllustration } from "../media/no-maps-illustration.svg";
 
-import { resetState } from "../actions/root";
 import { projectsFetch } from "../actions/projects";
 import { userFetch } from "../actions/user";
 import { resendConfirmationEmail } from "../api";
-import { clearJWT, getJWT } from "../jwt";
+import { getJWT } from "../jwt";
 import { State } from "../reducers";
 import { UserState } from "../reducers/user";
 import { Resource, WriteResource } from "../resource";
 import store from "../store";
 import { IProject } from "../../shared/entities";
 import DeleteProjectModal from "../components/DeleteProjectModal";
+import SiteHeader from "../components/SiteHeader";
 
 interface StateProps {
   readonly projects: Resource<readonly IProject[]>;
   readonly user: UserState;
 }
 
-enum UserMenuKeys {
-  Logout = "logout"
-}
-
-const logout = () => {
-  clearJWT();
-  store.dispatch(resetState());
-};
-
 const style: ThemeUIStyleObject = {
-  header: {
-    alignItems: "center",
-    justifyContent: "space-between",
-    py: 3,
-    px: 3,
-    bg: "gray.0",
-    borderBottom: "1px solid",
-    borderColor: "gray.1",
-    boxShadow: "small"
-  },
-  logoLink: {
-    borderRadius: "small",
-    "&:focus": {
-      outline: "none",
-      boxShadow: "focus"
-    }
-  },
-  avatar: {
-    fontFamily: "heading",
-    cursor: "pointer",
-    ".sb-avatar__text": {
-      "&:hover": {
-        backgroundColor: "#395c78 !important"
-      },
-      "&:active": {
-        backgroundColor: "#2c485e !important"
-      }
-    }
-  },
-  menuButton: {
-    display: "flex",
-    alignItems: "center",
-    bg: "transparent",
-    p: 1,
-    borderRadius: "small",
-    "&:focus": {
-      outline: "none",
-      boxShadow: "focus"
-    }
-  },
-  menu: {
-    width: "150px",
-    position: "absolute",
-    mt: 2,
-    right: 2,
-    bg: "muted",
-    py: 1,
-    px: 1,
-    border: "1px solid",
-    borderColor: "gray.2",
-    boxShadow: "small",
-    borderRadius: "small"
-  },
-  menuList: {
-    p: "0",
-    m: "0",
-    listStyleType: "none"
-  },
-  menuListItem: {
-    borderRadius: "small",
-    py: 1,
-    px: 2,
-    "&:hover:not([disabled])": {
-      bg: "gray.0",
-      cursor: "pointer"
-    },
-    "&[disabled]": {
-      color: "gray.3",
-      cursor: "not-allowed"
-    },
-    "&:focus": {
-      bg: "gray.0",
-      outline: "none",
-      boxShadow: "focus"
-    },
-    "&:active": {
-      bg: "gray.1"
-    }
-  },
   projectRow: {
     textDecoration: "none",
     display: "flex",
@@ -155,7 +62,6 @@ const style: ThemeUIStyleObject = {
 };
 
 const HomeScreen = ({ projects, user }: StateProps) => {
-  const history = useHistory();
   const [resendEmail, setResendEmail] = useState<WriteResource<void, void>>({ data: void 0 });
   const isLoggedIn = getJWT() !== null;
   const projectList =
@@ -212,51 +118,7 @@ const HomeScreen = ({ projects, user }: StateProps) => {
           </Box>
         </Alert>
       )}
-      <Flex as="header" sx={style.header}>
-        <Heading as="h1" sx={{ mb: "0px", mr: "auto", p: 2 }}>
-          <Link to="/" sx={style.logoLink}>
-            <Logo sx={{ width: "15rem" }} />
-          </Link>
-        </Heading>
-        {!isLoggedIn ? (
-          <React.Fragment>
-            <Link to="/login" sx={{ p: 2 }}>
-              Login
-            </Link>{" "}
-            <Link to="/register" sx={{ p: 2 }}>
-              Register
-            </Link>
-          </React.Fragment>
-        ) : "resource" in user ? (
-          <React.Fragment>
-            <SupportMenu />
-            <Wrapper onSelection={handleSelection(history)} sx={{ ml: 3 }}>
-              <MenuButton sx={style.menuButton}>
-                <Avatar
-                  name={user.resource.name}
-                  round={true}
-                  size={"2.5rem"}
-                  color={"#2c485e"}
-                  maxInitials={3}
-                  sx={style.avatar}
-                />
-                <div sx={{ ml: 2 }}>
-                  <Icon name="chevron-down" />
-                </div>
-              </MenuButton>
-              <Menu sx={style.menu}>
-                <ul sx={style.menuList}>
-                  <li key={UserMenuKeys.Logout}>
-                    <MenuItem value={UserMenuKeys.Logout} sx={style.menuListItem}>
-                      Logout
-                    </MenuItem>
-                  </li>
-                </ul>
-              </Menu>
-            </Wrapper>
-          </React.Fragment>
-        ) : null}
-      </Flex>
+      <SiteHeader user={user} />
       <Flex
         as="main"
         sx={{ width: "100%", maxWidth: "large", my: 6, mx: "auto", flexDirection: "column", px: 4 }}
@@ -355,14 +217,6 @@ const HomeScreen = ({ projects, user }: StateProps) => {
       </Flex>
     </Flex>
   );
-};
-
-const handleSelection = (history: H.History) => (key: string | number) => {
-  // eslint-disable-next-line
-  if (key === UserMenuKeys.Logout) {
-    logout();
-    history.push("/login");
-  }
 };
 
 function mapStateToProps(state: State): StateProps {

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -1,0 +1,57 @@
+/** @jsx jsx */
+import { useEffect } from "react";
+import { connect } from "react-redux";
+import { useParams } from "react-router-dom";
+import { Box, Flex, jsx } from "theme-ui";
+
+import { organizationFetch } from "../actions/organization";
+import { userFetch } from "../actions/user";
+import { getJWT } from "../jwt";
+import { State } from "../reducers";
+import { OrganizationState } from "../reducers/organization";
+import { UserState } from "../reducers/user";
+import store from "../store";
+import SiteHeader from "../components/SiteHeader";
+
+interface StateProps {
+  readonly organization: OrganizationState;
+  readonly user: UserState;
+}
+
+const OrganizationScreen = ({ organization, user }: StateProps) => {
+  const { organizationSlug } = useParams();
+  const isLoggedIn = getJWT() !== null;
+
+  useEffect(() => {
+    isLoggedIn && store.dispatch(userFetch());
+  }, [isLoggedIn]);
+
+  useEffect(() => {
+    store.dispatch(organizationFetch(organizationSlug));
+  }, [organizationSlug]);
+
+  return (
+    <Flex sx={{ flexDirection: "column" }}>
+      <SiteHeader user={user} />
+      <Flex
+        as="main"
+        sx={{ width: "100%", maxWidth: "large", my: 6, mx: "auto", flexDirection: "column", px: 4 }}
+      >
+        {"resource" in organization ? (
+          <Box>Organization: {organization.resource.name}</Box>
+        ) : (
+          <Box>Loading...</Box>
+        )}
+      </Flex>
+    </Flex>
+  );
+};
+
+function mapStateToProps(state: State): StateProps {
+  return {
+    organization: state.organization,
+    user: state.user
+  };
+}
+
+export default connect(mapStateToProps)(OrganizationScreen);

--- a/src/server/migrations/1611668130609-initial_organization_entity.ts
+++ b/src/server/migrations/1611668130609-initial_organization_entity.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class initialOrganizationEntity1611668130609 implements MigrationInterface {
+  name = "initialOrganizationEntity1611668130609";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `CREATE TABLE "organization" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "slug" character varying NOT NULL, "name" character varying NOT NULL, CONSTRAINT "UQ_a08804baa7c5d5427067c49a31f" UNIQUE ("slug"), CONSTRAINT "PK_472c1f99a32def1b0abb219cd67" PRIMARY KEY ("id"))`,
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`DROP TABLE "organization"`, undefined);
+  }
+}

--- a/src/server/src/app.module.ts
+++ b/src/server/src/app.module.ts
@@ -11,6 +11,7 @@ import * as StreamTransport from "nodemailer/lib/stream-transport";
 import { DEBUG } from "./common/constants";
 import { AuthModule } from "./auth/auth.module";
 import { HealthCheckModule } from "./healthcheck/healthcheck.module";
+import { OrganizationsModule } from "./organizations/organizations.module";
 import { ProjectsModule } from "./projects/projects.module";
 import { RegionConfigsModule } from "./region-configs/region-configs.module";
 import { RollbarModule } from "./rollbar/rollbar.module";
@@ -61,9 +62,10 @@ if (DEBUG) {
     RollbarModule,
     AuthModule,
     HealthCheckModule,
-    UsersModule,
+    OrganizationsModule,
+    ProjectsModule,
     RegionConfigsModule,
-    ProjectsModule
+    UsersModule
   ]
 })
 export class AppModule {}

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, UseGuards } from "@nestjs/common";
+import { Crud, CrudAuth, CrudController } from "@nestjsx/crud";
+
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { Organization } from "../entities/organization.entity";
+import { OrganizationsService } from "../services/organizations.service";
+
+@Crud({
+  model: {
+    type: Organization
+  },
+  routes: {
+    only: ["getOneBase"]
+  },
+  params: {
+    slug: {
+      field: "slug",
+      type: "string",
+      primary: true
+    }
+  }
+})
+@Controller("api/organization")
+export class OrganizationsController implements CrudController<Organization> {
+  constructor(public service: OrganizationsService) {}
+}

--- a/src/server/src/organizations/entities/organization.entity.ts
+++ b/src/server/src/organizations/entities/organization.entity.ts
@@ -2,8 +2,10 @@ import bcrypt from "bcrypt";
 import { Exclude } from "class-transformer";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
+import { IOrganization } from "../../../../shared/entities";
+
 @Entity()
-export class Organization {
+export class Organization implements IOrganization {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 

--- a/src/server/src/organizations/entities/organization.entity.ts
+++ b/src/server/src/organizations/entities/organization.entity.ts
@@ -1,0 +1,15 @@
+import bcrypt from "bcrypt";
+import { Exclude } from "class-transformer";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class Organization {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ unique: true })
+  slug: string;
+
+  @Column()
+  name: string;
+}

--- a/src/server/src/organizations/organizations.module.ts
+++ b/src/server/src/organizations/organizations.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { OrganizationsController } from "./controllers/organizations.controller";
+import { Organization } from "./entities/organization.entity";
+import { OrganizationsService } from "./services/organizations.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Organization])],
+  controllers: [OrganizationsController],
+  providers: [OrganizationsService],
+  exports: [OrganizationsService]
+})
+export class OrganizationsModule {}

--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
+import { Repository } from "typeorm";
+
+import { Organization } from "../entities/organization.entity";
+
+@Injectable()
+export class OrganizationsService extends TypeOrmCrudService<Organization> {
+  constructor(@InjectRepository(Organization) repo: Repository<Organization>) {
+    super(repo);
+  }
+
+  save(org: Organization): Promise<Organization> {
+    return this.repo.save(org);
+  }
+}

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -14,6 +14,14 @@ export interface IUser {
 
 export type UpdateUserData = Pick<IUser, "name" | "hasSeenTour">;
 
+export type OrganizationSlug = string;
+
+export interface IOrganization {
+  readonly id: string;
+  readonly slug: OrganizationSlug;
+  readonly name: string;
+}
+
 export type GeoUnitCollection = number | readonly GeoUnitCollection[];
 
 // eslint-disable-next-line


### PR DESCRIPTION
## Overview

This adds a skeleton frontend & backend for displaying an Organization page

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/105874732-eed68200-5fca-11eb-85d2-41920ba7208e.png)


### Notes

@jfrankl I saw in the Abstract wireframes that this had a similar header to the main Home screen, so I made the Home screen header into a reusable `SiteHeader` component (this also brought along the Support option, which _wasn't_ in the wireframes). I can revert this easily enough if you think the headers on those pages are going to end up looking different.

## Testing Instructions

- `scripts/migration`
- Add a new Organization using `scripts/dbshell` (e.g. `INSERT INTO organization (name, slug) VALUES ( 'Mikes Map Competition', 'mikes-maps' );`)
- You should be able to access the Organization page for your organizations slug, whether or not you are logged in.

Closes #224 
