### PR TITLE
Allow for duplication of a map project from home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Share menu now controls map visibility (private/public/shared w link) [#560](https://github.com/PublicMapping/districtbuilder/pull/560)
 - Organization detail screen [#562](https://github.com/PublicMapping/districtbuilder/pull/562)
+- Duplicate a map from home screen [#572] (https://github.com/PublicMapping/districtbuilder/pull/572)
 
 ### Changed
 

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -50,6 +50,12 @@ export const updateDistrictLocksFailure = createAction("Update district locks fa
 
 export const updateProjectFailed = createAction("Update project failure")();
 
+export const duplicateProject = createAction("Duplicate project")<IProject>();
+export const duplicateProjectSuccess = createAction("Duplicate project success")<
+  DynamicProjectData
+>();
+export const duplicateProjectFailure = createAction("Duplicate project failure")<string>();
+
 export const exportCsv = createAction("Export project CSV")<IProject>();
 export const exportCsvFailure = createAction("Export project CSV failure")<string>();
 

--- a/src/client/components/ProjectListFlyout.tsx
+++ b/src/client/components/ProjectListFlyout.tsx
@@ -4,11 +4,12 @@ import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubu
 import { IProject } from "../../shared/entities";
 import { style, invertStyles } from "./MenuButton.styles";
 import store from "../store";
-import { exportCsv, exportGeoJson, exportShp } from "../actions/projectData";
+import { exportCsv, exportGeoJson, exportShp, duplicateProject } from "../actions/projectData";
 import { setDeleteProject } from "../actions/projects";
 
 enum UserMenuKeys {
   Delete = "delete",
+  CopyMap = "copy",
   ExportCsv = "csv",
   ExportShapefile = "shp",
   ExportGeoJson = "geojson"
@@ -34,6 +35,8 @@ const ProjectListFlyout = (props: FlyoutProps) => {
             ? exportCsv
             : userMenuKey === UserMenuKeys.ExportShapefile
             ? exportShp
+            : userMenuKey === UserMenuKeys.CopyMap
+            ? duplicateProject
             : exportGeoJson;
         store.dispatch(action(props.project));
       }}
@@ -60,6 +63,9 @@ const ProjectListFlyout = (props: FlyoutProps) => {
             </MenuItem>
             <MenuItem value={UserMenuKeys.ExportGeoJson}>
               <Box sx={style.menuListItem}>Export GeoJSON</Box>
+            </MenuItem>
+            <MenuItem value={UserMenuKeys.CopyMap}>
+              <Box sx={style.menuListItem}>Duplicate Map</Box>
             </MenuItem>
             <MenuItem value={UserMenuKeys.Delete}>
               <Box sx={style.menuListItem}>Delete Map</Box>

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -18,6 +18,9 @@ import {
   setProjectNameEditing,
   staticDataFetchFailure,
   staticDataFetchSuccess,
+  duplicateProject,
+  duplicateProjectSuccess,
+  duplicateProjectFailure,
   updateDistrictLocks,
   updateDistrictLocksFailure,
   updateDistrictLocksSuccess,
@@ -35,6 +38,7 @@ import { updateCurrentState } from "../reducers/undoRedo";
 import { IProject } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
+import { projectsFetch } from "../actions/projects";
 import { DistrictsGeoJSON, DynamicProjectData, SavingState, StaticProjectData } from "../types";
 import { Resource } from "../resource";
 
@@ -50,6 +54,7 @@ import {
   exportProjectShp,
   fetchProjectData,
   fetchProjectGeoJson,
+  createProject,
   patchProject
 } from "../api";
 import { fetchAllStaticData } from "../s3";
@@ -401,6 +406,22 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         },
         Cmd.run(showActionFailedToast)
       );
+    case getType(duplicateProject): {
+      return loop(
+        state,
+        Cmd.run(
+          () => createProject({ ...action.payload, name: `Copy of ${action.payload.name}` }),
+          {
+            successActionCreator: duplicateProjectSuccess,
+            failActionCreator: duplicateProjectFailure
+          }
+        )
+      );
+    }
+    case getType(duplicateProjectSuccess):
+      return loop(state, Cmd.action(projectsFetch()));
+    case getType(duplicateProjectFailure):
+      return loop(state, Cmd.run(showActionFailedToast));
     case getType(exportCsv):
       return loop(
         state,


### PR DESCRIPTION
- Add actions for duplicating a project
- Add reducers for duplicating a project
- Fix reducer to reload projects on successful duplication
- Add changelog entry

## Overview

Allows for a user to create a copy of one of their existing projects from the context menu on the project's list record in the homepage view. 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/107284510-eef36a80-6a2b-11eb-86b3-31ba27aceb25.png)

![image](https://user-images.githubusercontent.com/66973361/107284425-d08d6f00-6a2b-11eb-8b3d-35e486508e86.png)


## Testing Instructions

- `./scripts/update`
- `./scripts/server`
- Navigate to the homepage at http://localhost:3005
- Click on the context menu for an existing project, and select 'Duplicate Map'
- Expect: A new project is created, with the name "Copy of {PROJECT}"

Closes #563 
