### PR TITLE
Fix label for Ward geounits

### DIFF
--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -127,16 +127,10 @@ export function assertNever(x: never): never {
 
 export const geoLevelLabel = (id: string): string => {
   switch (id) {
-    case "block":
-      return "Blocks";
-    case "tract":
-      return "Tracts";
-    case "blockgroup":
-      return "Blockgroups";
     case "county":
       return "Counties";
     default:
-      return id;
+      return id[0].toUpperCase() + id.slice(1) + "s";
   }
 };
 


### PR DESCRIPTION
## Overview

Fix label for new Dane County Ward geounits to say "Wards" instead of "ward" in the geounit selector.
Also makes the labelling function a little more generic to better support adding more types of geounits in the future.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_](https://user-images.githubusercontent.com/4432106/107392446-af7a5c00-6ac7-11eb-8860-40f911dbb81a.png)

## Testing Instructions

- Add a new row to your `region_config` table using this for the `s3_uri` column: `s3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-02-08T15:19:22.145Z/`
- On `develop` the geounit label will be `ward`, on this branch the label will be `Wards`

Connects to #564 
