### PR TITLE
Add script to load region configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Share menu now controls map visibility (private/public/shared w link) [#560](https://github.com/PublicMapping/districtbuilder/pull/560)
 - Organization detail screen [#562](https://github.com/PublicMapping/districtbuilder/pull/562)
+- Add script to load region configs [#575](https://github.com/PublicMapping/districtbuilder/pull/575)
 
 ### Changed
 - Geounit label made more generic to support Dane County wards [#573](https://github.com/PublicMapping/districtbuilder/pull/573)

--- a/scripts/load-region-configs
+++ b/scripts/load-region-configs
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Load region configs for development purposes.
+
+This avoids having to process GeoJSON locally and publish it to S3.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Bring up PostgreSQL and NestJS in a way that respects
+        # configured service health checks.
+        docker-compose \
+            -f docker-compose.yml \
+            up -d database server
+
+        docker-compose \
+            exec database psql -U districtbuilder districtbuilder -c "
+              INSERT INTO region_config
+              VALUES (
+                DEFAULT,
+                'Michigan',
+                'US',
+                'MI',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/MI/2020-09-08T20:15:12.635Z/',
+                DEFAULT,
+                DEFAULT
+              ), (
+                DEFAULT,
+                'Dane County',
+                'US',
+                'WI',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-02-08T15:19:22.145Z/',
+                DEFAULT,
+                DEFAULT
+              ), (
+                 DEFAULT,
+                'Pennsylvania',
+                'US',
+                'PA',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/PA/2021-02-08T18:07:18.957Z/',
+                DEFAULT,
+                DEFAULT
+             )
+              ON CONFLICT DO NOTHING;
+            "
+    fi
+fi


### PR DESCRIPTION
## Overview
Add script to load region configs

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes
This adds region configs for PA, MI, and an "atypical" one in Dane County. PA and MI are good for development since they're rather large states so we can hopefully see potential performance manifest themselves in dev first. 

## Testing Instructions
* Run `scripts/load-region-configs` and 3 rows should be added
* Run it again and no rows should be added but it should succeed
