### PR TITLE
Add chamber field to project entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Share menu now controls map visibility (private/public/shared w link) [#560](https://github.com/PublicMapping/districtbuilder/pull/560)
 - Organization detail screen [#562](https://github.com/PublicMapping/districtbuilder/pull/562)
-- Duplicate a map from home screen [#572] (https://github.com/PublicMapping/districtbuilder/pull/572)
+- Duplicate a map from home screen [#572](https://github.com/PublicMapping/districtbuilder/pull/572)
 - Add script to load region configs [#575](https://github.com/PublicMapping/districtbuilder/pull/575)
+- Store chamber reference on projece entity [#576](https://github.com/PublicMapping/districtbuilder/pull/576)
 
 ### Changed
 - Geounit label made more generic to support Dane County wards [#573](https://github.com/PublicMapping/districtbuilder/pull/573)

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -115,12 +115,19 @@ export async function resetPassword(token: string, password: string): Promise<vo
 export async function createProject({
   name,
   numberOfDistricts,
+  chamber,
   regionConfig,
   districtsDefinition
 }: CreateProjectData): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .post("/api/projects", { name, numberOfDistricts, regionConfig, districtsDefinition })
+      .post("/api/projects", {
+        name,
+        numberOfDistricts,
+        regionConfig,
+        districtsDefinition,
+        chamber
+      })
       .then(response => resolve(response.data))
       .catch(error => reject(error.response?.data || error));
   });

--- a/src/client/components/CopyMapModal.tsx
+++ b/src/client/components/CopyMapModal.tsx
@@ -77,7 +77,11 @@ const CopyMapModal = ({
               sx={{ flexDirection: "column" }}
               onSubmit={(e: React.FormEvent) => {
                 e.preventDefault();
-                createProject({ ...project, name: `Copy of ${attributedName}` })
+                createProject({
+                  ...project,
+                  name: `Copy of ${attributedName}`,
+                  chamber: project.chamber || null
+                })
                   .then((project: IProject) => {
                     setCreateProjectResource({ resource: project });
 

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
-import { IProject, IRegionConfig } from "../../shared/entities";
+import { IProject, IRegionConfig, IChamber } from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
 import { createProject } from "../api";
 import { InputField, SelectField } from "../components/Field";
@@ -38,6 +38,7 @@ const validate = (form: ProjectForm) =>
 
 interface ProjectForm {
   readonly name: string;
+  readonly chamber: IChamber | null;
   readonly regionConfig: IRegionConfig | null;
   readonly numberOfDistricts: number | null;
   readonly isCustom: boolean;
@@ -46,6 +47,7 @@ interface ProjectForm {
 interface ValidForm {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
+  readonly chamber: IChamber | null;
   readonly numberOfDistricts: number;
   readonly isCustom: boolean;
   readonly valid: true;
@@ -65,6 +67,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
     data: {
       name: "",
       regionConfig: null,
+      chamber: null,
       numberOfDistricts: null,
       isCustom: false
     }
@@ -82,9 +85,10 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
         ...(chamber
           ? {
               numberOfDistricts: chamber.numberOfDistricts,
+              chamber: chamber || null,
               isCustom: false
             }
-          : { numberOfDistricts: null, isCustom: true })
+          : { numberOfDistricts: null, isCustom: true, chamber: null })
       }
     });
   };
@@ -203,6 +207,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                 setCreateProjectResource({ data, isPending: true });
                 createProject({
                   ...validatedForm,
+                  chamber: validatedForm.chamber,
                   numberOfDistricts: validatedForm.numberOfDistricts
                 })
                   .then((project: IProject) =>

--- a/src/client/screens/StartProjectScreen.tsx
+++ b/src/client/screens/StartProjectScreen.tsx
@@ -3,18 +3,19 @@ import { useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router-dom";
 import { Flex, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
 
-import { IProject, RegionConfigId } from "../../shared/entities";
+import { IProject, RegionConfigId, ChamberId } from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
 import { createProject } from "../api";
 import { WriteResource } from "../resource";
 import store from "../store";
 
 const validate = (form: ProjectForm): ValidForm | InvalidForm => {
-  const { numberOfDistricts, regionConfigId, name } = form;
+  const { numberOfDistricts, regionConfigId, chamberId, name } = form;
   return name && name.trim() !== "" && !Number.isNaN(numberOfDistricts) && regionConfigId !== null
     ? {
         name,
         numberOfDistricts,
+        chamber: chamberId ? { id: chamberId } : null,
         regionConfig: { id: regionConfigId },
         valid: true
       }
@@ -23,12 +24,14 @@ const validate = (form: ProjectForm): ValidForm | InvalidForm => {
 
 interface ProjectForm {
   readonly name: string | null;
+  readonly chamberId: ChamberId | null;
   readonly regionConfigId: RegionConfigId | null;
   readonly numberOfDistricts: number;
 }
 
 interface ValidForm {
   readonly name: string;
+  readonly chamber: { readonly id: ChamberId } | null;
   readonly regionConfig: { readonly id: RegionConfigId };
   readonly numberOfDistricts: number;
   readonly valid: true;
@@ -58,6 +61,7 @@ export default () => {
   useEffect(() => {
     const form = validate({
       name: params.get("name"),
+      chamberId: params.get("chamberId") || null,
       regionConfigId: params.get("regionConfigId"),
       numberOfDistricts: Number.parseInt(params.get("numberOfDistricts") || "")
     });

--- a/src/server/migrations/1612973895673-project_chamber.ts
+++ b/src/server/migrations/1612973895673-project_chamber.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class projectChamber1612973895673 implements MigrationInterface {
+    name = 'projectChamber1612973895673'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "chamber_id" uuid`, undefined);
+        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_75d1f8b659b714de8aa529a5fc6" FOREIGN KEY ("chamber_id") REFERENCES "chamber"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_75d1f8b659b714de8aa529a5fc6"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "chamber_id"`, undefined);
+    }
+
+}

--- a/src/server/src/chambers/chambers.module.ts
+++ b/src/server/src/chambers/chambers.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Chamber } from "./entities/chamber.entity";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Chamber])],
+  controllers: [],
+  providers: [],
+  exports: []
+})
+export class ChambersModule {}

--- a/src/server/src/chambers/entities/chamber-id.dto.ts
+++ b/src/server/src/chambers/entities/chamber-id.dto.ts
@@ -1,0 +1,7 @@
+import { IsUUID } from "class-validator";
+import { IChamber, ChamberId } from "../../../../shared/entities";
+
+export class ChamberIdDto implements Pick<IChamber, "id"> {
+  @IsUUID()
+  readonly id: ChamberId;
+}

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -7,6 +7,7 @@ import {
   IsOptional,
   IsPositive
 } from "class-validator";
+import { ChamberIdDto } from "src/chambers/entities/chamber-id.dto";
 
 import { CreateProjectData, DistrictsDefinition } from "../../../../shared/entities";
 import { RegionConfigIdDto } from "../../region-configs/entities/region-config-id.dto";
@@ -23,4 +24,6 @@ export class CreateProjectDto implements CreateProjectData {
   @ArrayNotEmpty()
   @IsOptional()
   readonly districtsDefinition: DistrictsDefinition;
+  @IsOptional()
+  readonly chamber: ChamberIdDto;
 }

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -11,6 +11,7 @@ import {
 import { ProjectVisibility } from "../../../../shared/constants";
 import { DistrictsDefinition, IProject } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
+import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
 
 @Entity()
@@ -24,6 +25,10 @@ export class Project implements IProject {
   @ManyToOne(() => RegionConfig, { nullable: false })
   @JoinColumn({ name: "region_config_id" })
   regionConfig: RegionConfig;
+
+  @ManyToOne(() => Chamber, { nullable: true })
+  @JoinColumn({ name: "chamber_id" })
+  chamber: Chamber;
 
   @Column({ name: "number_of_districts" })
   numberOfDistricts: number;

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -6,9 +6,15 @@ import { RegionConfigsModule } from "../region-configs/region-configs.module";
 import { ProjectsController } from "./controllers/projects.controller";
 import { Project } from "./entities/project.entity";
 import { ProjectsService } from "./services/projects.service";
+import { ChambersModule } from "../chambers/chambers.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project]), DistrictsModule, RegionConfigsModule],
+  imports: [
+    TypeOrmModule.forFeature([Project]),
+    DistrictsModule,
+    RegionConfigsModule,
+    ChambersModule
+  ],
   controllers: [ProjectsController],
   providers: [ProjectsService],
   exports: [ProjectsService]

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -122,6 +122,7 @@ export interface IProject {
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
   readonly updatedDt: Date;
+  readonly chamber: IChamber;
   readonly districtsDefinition: DistrictsDefinition;
   readonly user: Pick<IUser, PublicUserProperties>;
   readonly advancedEditingEnabled: boolean;
@@ -133,6 +134,7 @@ export interface IProject {
 export interface CreateProjectData {
   readonly name: string;
   readonly numberOfDistricts: number;
+  readonly chamber: Pick<IChamber, "id"> | null;
   readonly regionConfig: Pick<IRegionConfig, "id">;
   readonly districtsDefinition?: DistrictsDefinition;
 }


### PR DESCRIPTION
## Overview

Adds a foreign key onto the Project entity to associate it with an optional Chamber that is selected by the user when a project is created.

### Checklist

- [ x ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Ensure that you have your local dev environment set up with a region and a chamber associated with that region
- Create a new project with a region that has an associated chamber
- `./scripts/dbshell`
- `SELECT * FROM project`
- _Expect:_ the last project in the list has a chamber_id value associated with it equal to the ID of the chamber you selected on the frontend

Closes #559 
