### PR TITLE
Organization project templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
+
 - Share menu now controls map visibility (private/public/shared w link) [#560](https://github.com/PublicMapping/districtbuilder/pull/560)
 - Organization detail screen [#562](https://github.com/PublicMapping/districtbuilder/pull/562)
+- Organization templates [#581](https://github.com/PublicMapping/districtbuilder/pull/581)
 - Duplicate a map from home screen [#572](https://github.com/PublicMapping/districtbuilder/pull/572)
 - Add script to load region configs [#575](https://github.com/PublicMapping/districtbuilder/pull/575)
 - Store chamber reference on project entity [#576](https://github.com/PublicMapping/districtbuilder/pull/576)
 - Allow users to join and leave an organization [#226](https://github.com/PublicMapping/districtbuilder/pull/578)
 
 ### Changed
+
 - Geounit label made more generic to support Dane County wards [#573](https://github.com/PublicMapping/districtbuilder/pull/573)
 - Update ESLint rules to prohibit console.log, allow conditional statements [#580](https://github.com/PublicMapping/districtbuilder/pull/580)
 
-
-
 ### Fixed
-
 
 ## [1.3.0] - 2021-01-26
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -118,7 +118,8 @@ export async function createProject({
   numberOfDistricts,
   chamber,
   regionConfig,
-  districtsDefinition
+  districtsDefinition,
+  projectTemplate
 }: CreateProjectData): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
@@ -127,7 +128,8 @@ export async function createProject({
         numberOfDistricts,
         regionConfig,
         districtsDefinition,
-        chamber
+        chamber,
+        projectTemplate
       })
       .then(response => resolve(response.data))
       .catch(error => reject(error.response?.data || error));

--- a/src/client/components/CopyMapModal.tsx
+++ b/src/client/components/CopyMapModal.tsx
@@ -80,7 +80,7 @@ const CopyMapModal = ({
                 createProject({
                   ...project,
                   name: `Copy of ${attributedName}`,
-                  chamber: project.chamber || null
+                  chamber: project.chamber || undefined
                 })
                   .then((project: IProject) => {
                     setCreateProjectResource({ resource: project });

--- a/src/client/components/ProjectName.tsx
+++ b/src/client/components/ProjectName.tsx
@@ -1,15 +1,27 @@
 /** @jsx jsx */
 import React, { useEffect, useRef, useState } from "react";
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import AriaModal from "react-aria-modal";
 import { connect } from "react-redux";
-import { Button, Flex, Input, jsx, Text } from "theme-ui";
-import { IProject } from "../../shared/entities";
+import { Link } from "react-router-dom";
+import { Box, Button, Flex, Heading, Input, jsx, Styled, Text } from "theme-ui";
+import { IProject, IProjectTemplate } from "../../shared/entities";
 import { setProjectNameEditing, updateProjectName } from "../actions/projectData";
 import { State } from "../reducers";
 import store from "../store";
 import { SavingState } from "../types";
 import Icon from "./Icon";
+import { style as menuButtonStyles } from "./MenuButton.styles";
 
 const style = {
+  modal: {
+    bg: "muted",
+    p: 5,
+    width: "small",
+    maxWidth: "90vw",
+    overflow: "hidden",
+    flexDirection: "column"
+  },
   button: {
     variant: "buttons.icon",
     color: "muted",
@@ -25,6 +37,11 @@ const style = {
   }
 } as const;
 
+enum MenuKeys {
+  Rename = "Rename",
+  AboutTemplate = "AboutTemplate"
+}
+
 const ProjectName = ({
   project,
   projectNameSaving,
@@ -37,6 +54,7 @@ const ProjectName = ({
   readonly isReadOnly: boolean;
 }) => {
   const [name, setName] = useState(project.name);
+  const [modalVisible, setModalVisibility] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -47,8 +65,83 @@ const ProjectName = ({
     projectNameSaving === "unsaved" && inputRef.current && inputRef.current.focus();
   }, [inputRef, projectNameSaving]);
 
+  const EditButton = project.projectTemplate ? (
+    <Wrapper
+      sx={{ position: "relative", pr: 1 }}
+      closeOnSelection={true}
+      onSelection={(menuKey: string) => {
+        if (menuKey === MenuKeys.Rename) {
+          store.dispatch(setProjectNameEditing(true));
+        } else if (menuKey === MenuKeys.AboutTemplate) {
+          setModalVisibility(true);
+        }
+      }}
+    >
+      <MenuButton
+        sx={{
+          ...menuButtonStyles.menuButton,
+          ...{ variant: "buttons.icon", color: "muted", ml: 2 }
+        }}
+        className="share-menu"
+      >
+        ···
+      </MenuButton>
+      <Menu
+        sx={{
+          ...menuButtonStyles.menu,
+          ...{ width: "250px", color: "text", right: undefined }
+        }}
+      >
+        <ul sx={menuButtonStyles.menuList}>
+          <li key={MenuKeys.Rename}>
+            <MenuItem value={MenuKeys.Rename}>
+              <Box sx={menuButtonStyles.menuListItem}>Rename map</Box>
+            </MenuItem>
+          </li>
+          <li key={MenuKeys.AboutTemplate}>
+            <MenuItem value={MenuKeys.AboutTemplate}>
+              <Box sx={menuButtonStyles.menuListItem}>
+                About “{project.projectTemplate?.name}” template
+              </Box>
+            </MenuItem>
+          </li>
+        </ul>
+      </Menu>
+    </Wrapper>
+  ) : (
+    <Button sx={style.button} onClick={() => store.dispatch(setProjectNameEditing(true))}>
+      <Icon name="pencil" />
+    </Button>
+  );
+
+  const TemplateModal = ({ template }: { readonly template: IProjectTemplate }) => (
+    <AriaModal
+      titleId="copy-map-modal-header"
+      onExit={() => setModalVisibility(false)}
+      focusDialog={true}
+      getApplicationNode={() => document.getElementById("root") as Element}
+      underlayStyle={{ paddingTop: "4.5rem" }}
+    >
+      <Flex sx={style.modal}>
+        <Styled.a as={Link} to={`/o/${template.organization.slug}`}>
+          {template.organization.name} ›
+        </Styled.a>
+        <Heading>{template.name}</Heading>
+        <Text>
+          {template.regionConfig.name} · {template.numberOfDistricts}
+        </Text>
+        <Text>{template.description}</Text>
+        <Heading as="h4">Details</Heading>
+        <Text>{template.details}</Text>
+      </Flex>
+    </AriaModal>
+  );
+
   return (
     <Flex sx={style.wrapper}>
+      {modalVisible && project.projectTemplate && (
+        <TemplateModal template={project.projectTemplate} />
+      )}
       {projectNameSaving !== "saved" ? (
         <Flex
           as="form"
@@ -84,11 +177,7 @@ const ProjectName = ({
           <Text as="h1" sx={{ variant: "header.title", m: 0 }}>
             {isReadOnly ? `${project.name} by ${project.user.name}` : project.name}
           </Text>
-          {!isReadOnly && (
-            <Button sx={style.button} onClick={() => store.dispatch(setProjectNameEditing(true))}>
-              <Icon name="pencil" />
-            </Button>
-          )}
+          {!isReadOnly && EditButton}
         </React.Fragment>
       )}
     </Flex>

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -47,7 +47,7 @@ interface ProjectForm {
 interface ValidForm {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
-  readonly chamber: IChamber | null;
+  readonly chamber?: IChamber;
   readonly numberOfDistricts: number;
   readonly isCustom: boolean;
   readonly valid: true;
@@ -207,7 +207,7 @@ const CreateProjectScreen = ({ regionConfigs }: StateProps) => {
                 setCreateProjectResource({ data, isPending: true });
                 createProject({
                   ...validatedForm,
-                  chamber: validatedForm.chamber,
+                  chamber: validatedForm.chamber || undefined,
                   numberOfDistricts: validatedForm.numberOfDistricts
                 })
                   .then((project: IProject) =>

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -1,9 +1,10 @@
 /** @jsx jsx */
 import { useEffect } from "react";
 import { connect } from "react-redux";
-import { useParams } from "react-router-dom";
-import { Box, Button, Flex, Heading, Image, Link, jsx } from "theme-ui";
+import { useHistory, useParams } from "react-router-dom";
+import { Box, Button, Flex, Heading, Image, Link, jsx, Text } from "theme-ui";
 
+import { showCopyMapModal } from "../actions/districtDrawing";
 import { organizationFetch } from "../actions/organization";
 import { joinOrganization, leaveOrganization } from "../actions/organizationJoin";
 import { userFetch } from "../actions/user";
@@ -14,10 +15,11 @@ import { ProjectState } from "../reducers/project";
 import { UserState } from "../reducers/user";
 import store from "../store";
 import SiteHeader from "../components/SiteHeader";
-import Icon from "../components/Icon";
-import { IOrganization, IUser } from "../../shared/entities";
-import { showCopyMapModal } from "../actions/districtDrawing";
 import JoinOrganizationModal from "../components/JoinOrganizationModal";
+import Icon from "../components/Icon";
+import { IProject, IOrganization, IUser } from "../../shared/entities";
+import { createProject } from "../api";
+
 interface StateProps {
   readonly organization: OrganizationState;
   readonly project: ProjectState;
@@ -52,11 +54,24 @@ const style = {
     p: 1,
     pt: 3,
     textAlign: "center"
+  },
+  templates: {
+    p: 5
+  },
+  templateContainer: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, 300px)",
+    gridGap: "30px",
+    justifyContent: "space-between"
+  },
+  template: {
+    flexDirection: "column"
   }
 } as const;
 
 const OrganizationScreen = ({ organization, project, user }: StateProps) => {
   const { organizationSlug } = useParams();
+  const history = useHistory();
   const isLoggedIn = getJWT() !== null;
   const userInOrg =
     "resource" in user &&
@@ -108,33 +123,45 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
       <SiteHeader user={user} />
       <Flex as="main" sx={style.main}>
         {"resource" in organization ? (
-          <Flex sx={style.header}>
-            {organization.resource.logoUrl && (
-              <Image src={organization.resource.logoUrl} sx={style.logo} />
-            )}
-            <Flex sx={{ flexDirection: "column" }}>
-              <Heading>{organization.resource.name}</Heading>
+          <Box>
+            <Flex sx={style.header}>
+              {organization.resource.logoUrl && (
+                <Image src={organization.resource.logoUrl} sx={style.logo} />
+              )}
               <Box>
-                {(organization.resource.municipality || organization.resource.region) && (
+                <Heading>{organization.resource.name}</Heading>
+                <Box>
+                  {(organization.resource.municipality || organization.resource.region) && (
+                    <Box as="span" sx={style.item}>
+                      <Icon name="map-marker" /> {organization.resource.municipality}
+                      {organization.resource.municipality && organization.resource.region && ", "}
+                      {organization.resource.region}
+                    </Box>
+                  )}
+                  {organization.resource.linkUrl && (
+                    <Box as="span" sx={style.item}>
+                      <Icon name="link" />{" "}
+                      <Link href={`https://${organization.resource.linkUrl}`}>
+                        {organization.resource.linkUrl}
+                      </Link>
+                    </Box>
+                  )}
                   <Box as="span" sx={style.item}>
-                    <Icon name="map-marker" /> {organization.resource.municipality}
-                    {organization.resource.municipality && organization.resource.region && ", "}
-                    {organization.resource.region}
+                    <Icon name="tools" /> {organization.resource.users.length} builders
                   </Box>
-                )}
-                {organization.resource.linkUrl && (
-                  <Box as="span" sx={style.item}>
-                    <Icon name="link" />{" "}
-                    <Link href={`https://${organization.resource.linkUrl}`}>
-                      {organization.resource.linkUrl}
-                    </Link>
-                  </Box>
-                )}
-                <Box as="span" sx={style.item}>
-                  <Icon name="tools" /> {organization.resource.users.length} builders
                 </Box>
+                {organization.resource.description && (
+                  <Box>{organization.resource.description}</Box>
+                )}
               </Box>
-              {organization.resource.description && <Box>{organization.resource.description}</Box>}
+              <Flex sx={{ flexDirection: "column", flex: "none" }}>
+                <Button disabled={true} sx={style.join}>
+                  Join organization
+                </Button>
+                <Box sx={style.joinText}>
+                  Join to start making district maps with this organization
+                </Box>
+              </Flex>
             </Flex>
             {userInOrg ? (
               <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={leaveOrg}>
@@ -155,7 +182,33 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                 </Box>
               </Flex>
             )}
-          </Flex>
+            {organization.resource.projectTemplates.length > 0 && (
+              <Box sx={style.templates}>
+                <Heading>Templates</Heading>
+                Start a new map using the official settings from {organization.resource.name}
+                <Box sx={style.templateContainer}>
+                  {organization.resource.projectTemplates.map(template => (
+                    <Flex key={template.id} sx={style.template}>
+                      <Heading>{template.name}</Heading>
+                      <Text>
+                        {template.regionConfig.name} · {template.numberOfDistricts}
+                      </Text>
+                      <Text>{template.description}</Text>
+                      <Button
+                        onClick={() => {
+                          void createProject(template).then((project: IProject) =>
+                            history.push(`/projects/${project.id}`)
+                          );
+                        }}
+                      >
+                        Use this template
+                      </Button>
+                    </Flex>
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </Box>
         ) : (
           <Box>Loading...</Box>
         )}

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -147,7 +147,7 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                     </Box>
                   )}
                   <Box as="span" sx={style.item}>
-                    <Icon name="tools" /> {organization.resource.users.length} builders
+                    <Icon name="tools" /> {organization.resource.users?.length || 0} builders
                   </Box>
                 </Box>
                 {organization.resource.description && (
@@ -196,9 +196,22 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                       <Text>{template.description}</Text>
                       <Button
                         onClick={() => {
-                          void createProject(template).then((project: IProject) =>
-                            history.push(`/projects/${project.id}`)
-                          );
+                          const {
+                            id,
+                            name,
+                            regionConfig,
+                            numberOfDistricts,
+                            districtsDefinition,
+                            chamber
+                          } = template;
+                          void createProject({
+                            name,
+                            regionConfig,
+                            numberOfDistricts,
+                            districtsDefinition,
+                            chamber,
+                            projectTemplate: { id }
+                          }).then((project: IProject) => history.push(`/projects/${project.id}`));
                         }}
                       >
                         Use this template

--- a/src/client/screens/StartProjectScreen.tsx
+++ b/src/client/screens/StartProjectScreen.tsx
@@ -15,7 +15,7 @@ const validate = (form: ProjectForm): ValidForm | InvalidForm => {
     ? {
         name,
         numberOfDistricts,
-        chamber: chamberId ? { id: chamberId } : null,
+        chamber: chamberId ? { id: chamberId } : undefined,
         regionConfig: { id: regionConfigId },
         valid: true
       }
@@ -31,7 +31,7 @@ interface ProjectForm {
 
 interface ValidForm {
   readonly name: string;
-  readonly chamber: { readonly id: ChamberId } | null;
+  readonly chamber?: { readonly id: ChamberId };
   readonly regionConfig: { readonly id: RegionConfigId };
   readonly numberOfDistricts: number;
   readonly valid: true;

--- a/src/manage/src/lib/dbUtils.ts
+++ b/src/manage/src/lib/dbUtils.ts
@@ -1,7 +1,9 @@
 import { ConnectionOptions } from "typeorm";
 import { Chamber } from "../../../server/src/chambers/entities/chamber.entity";
 import { Organization } from "../../../server/src/organizations/entities/organization.entity";
+import { ProjectTemplate } from "../../../server/src/project-templates/entities/project-template.entity";
 import { RegionConfig } from "../../../server/src/region-configs/entities/region-config.entity";
+import { User } from "../../../server/src/users/entities/user.entity";
 
 export const connectionOptions: ConnectionOptions = {
   type: "postgres",
@@ -10,7 +12,7 @@ export const connectionOptions: ConnectionOptions = {
   username: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
-  entities: [Chamber, Organization, RegionConfig],
+  entities: [Chamber, Organization, ProjectTemplate, RegionConfig, User],
   logging: true,
   synchronize: false
 };

--- a/src/server/migrations/1613651828605-ProjectTemplate.ts
+++ b/src/server/migrations/1613651828605-ProjectTemplate.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ProjectTemplate1613651828605 implements MigrationInterface {
+    name = 'ProjectTemplate1613651828605'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`CREATE TABLE "project_template" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "number_of_districts" integer NOT NULL, "districts_definition" jsonb, "description" character varying NOT NULL, "details" character varying NOT NULL, "organization_id" uuid NOT NULL, "region_config_id" uuid NOT NULL, "chamber_id" uuid, CONSTRAINT "PK_41cf7a5f5e816a0c36f494283b4" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD CONSTRAINT "FK_25db54e5c3cdafc129442082960" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD CONSTRAINT "FK_09c29a0babbc6f2602d4581ec17" FOREIGN KEY ("region_config_id") REFERENCES "region_config"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD CONSTRAINT "FK_cb419f246098b1f2594371c89d8" FOREIGN KEY ("chamber_id") REFERENCES "chamber"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project_template" DROP CONSTRAINT "FK_cb419f246098b1f2594371c89d8"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_template" DROP CONSTRAINT "FK_09c29a0babbc6f2602d4581ec17"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_template" DROP CONSTRAINT "FK_25db54e5c3cdafc129442082960"`, undefined);
+        await queryRunner.query(`DROP TABLE "project_template"`, undefined);
+    }
+
+}

--- a/src/server/migrations/1613662669746-project_template_reference.ts
+++ b/src/server/migrations/1613662669746-project_template_reference.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class projectTemplateReference1613662669746 implements MigrationInterface {
+    name = 'projectTemplateReference1613662669746'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "project_template_id" uuid`, undefined);
+        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_5bb9a0df7a43f52071785805ee9" FOREIGN KEY ("project_template_id") REFERENCES "project_template"("id") ON DELETE SET NULL ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_5bb9a0df7a43f52071785805ee9"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "project_template_id"`, undefined);
+    }
+
+}

--- a/src/server/src/app.module.ts
+++ b/src/server/src/app.module.ts
@@ -13,6 +13,7 @@ import { AuthModule } from "./auth/auth.module";
 import { HealthCheckModule } from "./healthcheck/healthcheck.module";
 import { OrganizationsModule } from "./organizations/organizations.module";
 import { ProjectsModule } from "./projects/projects.module";
+import { ProjectTemplatesModule } from "./project-templates/project-templates.module";
 import { RegionConfigsModule } from "./region-configs/region-configs.module";
 import { RollbarModule } from "./rollbar/rollbar.module";
 import { UsersModule } from "./users/users.module";
@@ -64,6 +65,7 @@ if (DEBUG) {
     HealthCheckModule,
     OrganizationsModule,
     ProjectsModule,
+    ProjectTemplatesModule,
     RegionConfigsModule,
     UsersModule
   ]

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -1,28 +1,17 @@
-import {
-  Controller,
-  UseGuards,
-  UseInterceptors,
-  Param,
-  Post,
-  Logger,
-  InternalServerErrorException,
-  NotFoundException,
-  Body
-} from "@nestjs/common";
-import { Crud, CrudAuth, CrudController } from "@nestjsx/crud";
+import { Controller, UseGuards, Param, Post, NotFoundException, Body } from "@nestjs/common";
+import { Crud, CrudController } from "@nestjsx/crud";
 import { IsNotEmpty } from "class-validator";
 
+import { OrganizationSlug, PublicUserProperties, UserId } from "../../../../shared/entities";
+import { JoinOrganizationErrors } from "../../../../shared/constants";
+
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { User } from "../../users/entities/user.entity";
+import { UsersService } from "../../users/services/users.service";
+
 import { Organization } from "../entities/organization.entity";
 import { OrganizationUserDto } from "../entities/organizationUser.dto";
-import { User } from "../../users/entities/user.entity";
-
-import { OrganizationSlug, UserId } from "../../../../shared/entities";
-
 import { OrganizationsService } from "../services/organizations.service";
-import { UsersService } from "../../users/services/users.service";
-import { PublicUserProperties } from "../../../../shared/entities";
-import { JoinOrganizationErrors } from "../../../../shared/constants";
 
 export class AddUserToOrg {
   @IsNotEmpty({ message: "Please enter a name for your project" })

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -29,6 +29,9 @@ export class AddUserToOrg {
     join: {
       projectTemplates: {
         eager: true
+      },
+      "projectTemplates.regionConfig": {
+        eager: true
       }
     }
   },

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -25,16 +25,6 @@ export class AddUserToOrg {
   routes: {
     only: ["getOneBase"]
   },
-  query: {
-    join: {
-      projectTemplates: {
-        eager: true
-      },
-      "projectTemplates.regionConfig": {
-        eager: true
-      }
-    }
-  },
   params: {
     slug: {
       field: "slug",
@@ -44,6 +34,12 @@ export class AddUserToOrg {
   },
   query: {
     join: {
+      projectTemplates: {
+        eager: true
+      },
+      "projectTemplates.regionConfig": {
+        eager: true
+      },
       users: {
         allow: ["id", "name"] as PublicUserProperties[],
         eager: true

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -25,6 +25,13 @@ export class AddUserToOrg {
   routes: {
     only: ["getOneBase"]
   },
+  query: {
+    join: {
+      projectTemplates: {
+        eager: true
+      }
+    }
+  },
   params: {
     slug: {
       field: "slug",
@@ -42,6 +49,7 @@ export class AddUserToOrg {
   }
 })
 @Controller("api/organization")
+// @ts-ignore
 export class OrganizationsController implements CrudController<Organization> {
   constructor(public service: OrganizationsService, private readonly usersService: UsersService) {}
 
@@ -74,11 +82,9 @@ export class OrganizationsController implements CrudController<Organization> {
 
     const user = await this.getUser(addUser.userId);
 
-    const userInOrg =
-      org.users &&
-      org.users.find(u => {
-        return u.id === user.id;
-      });
+    const userInOrg = org.users.find(u => {
+      return u.id === user.id;
+    });
 
     if (!userInOrg) {
       // eslint-disable-next-line

--- a/src/server/src/organizations/entities/organization.entity.ts
+++ b/src/server/src/organizations/entities/organization.entity.ts
@@ -1,7 +1,8 @@
-import { Column, Entity, PrimaryGeneratedColumn, ManyToMany, JoinTable } from "typeorm";
+import { Column, Entity, JoinTable, OneToMany, PrimaryGeneratedColumn, ManyToMany } from "typeorm";
 
 import { IOrganization } from "../../../../shared/entities";
 import { User } from "../../users/entities/user.entity";
+import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
 
 @Entity()
 export class Organization implements IOrganization {
@@ -38,4 +39,10 @@ export class Organization implements IOrganization {
   )
   @JoinTable()
   users: User[];
+
+  @OneToMany(
+    () => ProjectTemplate,
+    template => template.organization
+  )
+  projectTemplates: ProjectTemplate[];
 }

--- a/src/server/src/project-templates/entities/project-template-id.dto.ts
+++ b/src/server/src/project-templates/entities/project-template-id.dto.ts
@@ -1,0 +1,7 @@
+import { IsUUID } from "class-validator";
+import { IProjectTemplate, ProjectTemplateId } from "../../../../shared/entities";
+
+export class ProjectTemplateIdDto implements Pick<IProjectTemplate, "id"> {
+  @IsUUID()
+  readonly id: ProjectTemplateId;
+}

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -23,7 +23,7 @@ export class ProjectTemplate implements IProjectTemplate {
 
   @ManyToOne(() => Chamber, { nullable: true })
   @JoinColumn({ name: "chamber_id" })
-  chamber: Chamber;
+  chamber?: Chamber;
 
   @Column({ name: "number_of_districts", type: "integer" })
   numberOfDistricts: number;

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -14,7 +14,7 @@ export class ProjectTemplate implements IProjectTemplate {
   @JoinColumn({ name: "organization_id" })
   organization: Organization;
 
-  @Column()
+  @Column({ type: "character varying" })
   name: string;
 
   @ManyToOne(() => RegionConfig, { nullable: false })
@@ -25,7 +25,7 @@ export class ProjectTemplate implements IProjectTemplate {
   @JoinColumn({ name: "chamber_id" })
   chamber: Chamber;
 
-  @Column({ name: "number_of_districts" })
+  @Column({ name: "number_of_districts", type: "integer" })
   numberOfDistricts: number;
 
   @Column({
@@ -35,9 +35,9 @@ export class ProjectTemplate implements IProjectTemplate {
   })
   districtsDefinition: DistrictsDefinition;
 
-  @Column()
+  @Column({ type: "character varying" })
   description: string;
 
-  @Column()
+  @Column({ type: "character varying" })
   details: string;
 }

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -1,0 +1,43 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { DistrictsDefinition, IProjectTemplate } from "../../../../shared/entities";
+import { Chamber } from "../../chambers/entities/chamber.entity";
+import { Organization } from "../../organizations/entities/organization.entity";
+import { RegionConfig } from "../../region-configs/entities/region-config.entity";
+
+@Entity()
+export class ProjectTemplate implements IProjectTemplate {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @ManyToOne(() => Organization, { nullable: false, onDelete: "CASCADE" })
+  @JoinColumn({ name: "organization_id" })
+  organization: Organization;
+
+  @Column()
+  name: string;
+
+  @ManyToOne(() => RegionConfig, { nullable: false })
+  @JoinColumn({ name: "region_config_id" })
+  regionConfig: RegionConfig;
+
+  @ManyToOne(() => Chamber, { nullable: true })
+  @JoinColumn({ name: "chamber_id" })
+  chamber: Chamber;
+
+  @Column({ name: "number_of_districts" })
+  numberOfDistricts: number;
+
+  @Column({
+    type: "jsonb",
+    name: "districts_definition",
+    nullable: true
+  })
+  districtsDefinition: DistrictsDefinition;
+
+  @Column()
+  description: string;
+
+  @Column()
+  details: string;
+}

--- a/src/server/src/project-templates/project-templates.module.ts
+++ b/src/server/src/project-templates/project-templates.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { RegionConfigsModule } from "../region-configs/region-configs.module";
+import { ProjectTemplate } from "./entities/project-template.entity";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProjectTemplate]), RegionConfigsModule]
+})
+export class ProjectTemplatesModule {}

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -30,7 +30,12 @@ import * as _ from "lodash";
 import { GeometryCollection } from "topojson-specification";
 
 import { MakeDistrictsErrors } from "../../../../shared/constants";
-import { GeoUnitHierarchy, ProjectId, PublicUserProperties } from "../../../../shared/entities";
+import {
+  GeoUnitHierarchy,
+  IProjectTemplate,
+  ProjectId,
+  PublicUserProperties
+} from "../../../../shared/entities";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
 import { TopologyService } from "../../districts/services/topology.service";
@@ -57,6 +62,17 @@ import { Errors } from "../../../../shared/types";
   },
   query: {
     join: {
+      projectTemplate: {
+        exclude: ["districtsDefinition"],
+        eager: true
+      },
+      "projectTemplate.organization": {
+        eager: true
+      },
+      "projectTemplate.regionConfig": {
+        alias: "template_region_config",
+        eager: true
+      },
       regionConfig: {
         eager: true
       },

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -10,6 +10,7 @@ import {
 import { ChamberIdDto } from "src/chambers/entities/chamber-id.dto";
 
 import { CreateProjectData, DistrictsDefinition } from "../../../../shared/entities";
+import { ProjectTemplateIdDto } from "../../project-templates/entities/project-template-id.dto";
 import { RegionConfigIdDto } from "../../region-configs/entities/region-config-id.dto";
 
 export class CreateProjectDto implements CreateProjectData {
@@ -26,4 +27,6 @@ export class CreateProjectDto implements CreateProjectData {
   readonly districtsDefinition: DistrictsDefinition;
   @IsOptional()
   readonly chamber: ChamberIdDto;
+  @IsOptional()
+  readonly projectTemplate: ProjectTemplateIdDto;
 }

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -13,6 +13,7 @@ import { DistrictsDefinition, IProject } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
+import { ProjectTemplate } from "src/project-templates/entities/project-template.entity";
 
 @Entity()
 export class Project implements IProject {
@@ -28,7 +29,11 @@ export class Project implements IProject {
 
   @ManyToOne(() => Chamber, { nullable: true })
   @JoinColumn({ name: "chamber_id" })
-  chamber: Chamber;
+  chamber?: Chamber;
+
+  @ManyToOne(() => ProjectTemplate, { nullable: true, onDelete: "SET NULL" })
+  @JoinColumn({ name: "project_template_id" })
+  projectTemplate?: ProjectTemplate;
 
   @Column({ name: "number_of_districts" })
   numberOfDistricts: number;

--- a/src/server/src/users/entities/user.entity.ts
+++ b/src/server/src/users/entities/user.entity.ts
@@ -9,16 +9,16 @@ export class User implements IUser {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ unique: true })
+  @Column({ unique: true, type: "character varying" })
   email: string;
 
-  @Column()
+  @Column({ type: "character varying" })
   name: string;
 
-  @Column({ default: false })
+  @Column({ default: false, type: "boolean" })
   isEmailVerified: boolean;
 
-  @Column({ default: false })
+  @Column({ default: false, type: "boolean" })
   hasSeenTour: boolean;
 
   @ManyToMany(
@@ -29,7 +29,7 @@ export class User implements IUser {
 
   // TODO: Is it possible to make this private? I only want to allow
   // modification via setPassword
-  @Column()
+  @Column({ type: "character varying" })
   @Exclude()
   passwordHash: string;
 

--- a/src/server/src/users/services/users.service.ts
+++ b/src/server/src/users/services/users.service.ts
@@ -19,6 +19,7 @@ export class UsersService extends TypeOrmCrudService<User> {
   }
 
   save(user: User): Promise<User> {
+    // @ts-ignore
     return this.repo.save(user);
   }
 }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -124,7 +124,7 @@ interface ProjectTemplateFields {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
-  readonly chamber: IChamber;
+  readonly chamber?: IChamber;
   readonly districtsDefinition: DistrictsDefinition;
 }
 
@@ -134,6 +134,7 @@ export type IProject = ProjectTemplateFields & {
   readonly id: ProjectId;
   readonly updatedDt: Date;
   readonly user: Pick<IUser, PublicUserProperties>;
+  readonly projectTemplate?: IProjectTemplate;
   readonly advancedEditingEnabled: boolean;
   readonly lockedDistricts: readonly boolean[];
   readonly visibility: ProjectVisibility;
@@ -143,9 +144,10 @@ export type IProject = ProjectTemplateFields & {
 export interface CreateProjectData {
   readonly name: string;
   readonly numberOfDistricts: number;
-  readonly chamber: Pick<IChamber, "id"> | null;
   readonly regionConfig: Pick<IRegionConfig, "id">;
+  readonly chamber?: Pick<IChamber, "id">;
   readonly districtsDefinition?: DistrictsDefinition;
+  readonly projectTemplate?: Pick<IProjectTemplate, "id">;
 }
 
 export type UpdateProjectData = Pick<

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -26,6 +26,7 @@ export interface IOrganization {
   readonly municipality: string;
   readonly region: string;
   readonly users: readonly IUser[];
+  readonly projectTemplates: readonly IProjectTemplate[];
 }
 
 export interface AddUser {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -119,22 +119,25 @@ export interface IRegionConfig {
   readonly hidden: boolean;
 }
 
-export type ProjectId = string;
-
-export interface IProject {
-  readonly id: ProjectId;
+interface ProjectTemplateFields {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
-  readonly updatedDt: Date;
   readonly chamber: IChamber;
   readonly districtsDefinition: DistrictsDefinition;
+}
+
+export type ProjectId = string;
+
+export type IProject = ProjectTemplateFields & {
+  readonly id: ProjectId;
+  readonly updatedDt: Date;
   readonly user: Pick<IUser, PublicUserProperties>;
   readonly advancedEditingEnabled: boolean;
   readonly lockedDistricts: readonly boolean[];
   readonly visibility: ProjectVisibility;
   readonly archived: boolean;
-}
+};
 
 export interface CreateProjectData {
   readonly name: string;
@@ -153,6 +156,15 @@ export type UpdateProjectData = Pick<
   | "visibility"
   | "archived"
 >;
+
+export type ProjectTemplateId = string;
+
+export type IProjectTemplate = ProjectTemplateFields & {
+  readonly id: ProjectTemplateId;
+  readonly organization: IOrganization;
+  readonly description: string;
+  readonly details: string;
+};
 
 export type ChamberId = string;
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

New organization template section:
![localhost_3003_o_mikes-maps_ (4)](https://user-images.githubusercontent.com/4432106/108408003-84dc8180-71f2-11eb-9a07-8bd015d78a87.png)

Maps created from a template have a dropdown instead of a ✏:
![localhost_3003_o_mikes-maps_ (5)](https://user-images.githubusercontent.com/4432106/108408011-87d77200-71f2-11eb-986b-3ce4c02465b4.png)

About this template modal:
![localhost_3003_o_mikes-maps_ (6)](https://user-images.githubusercontent.com/4432106/108408019-89a13580-71f2-11eb-90ca-548cc8b6a5e5.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- `scripts/migration`
- Add project template(s) to your DB, either using SQL or w/ a YAML configuration and the `update-organization` command.
- Create a new map from an organization template on the Organization home screen (`/o/<organization.slug>`) - it should redirect you to the project screen 
- Maps created from templates should show a dropdown menu instead of a ✏ button next to the project name, allowing editing the project name (as normal) or opening a modal to show template details

Closes #227 
