### PR TITLE
Show error page for 404 errors on project and organization screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duplicate a map from home screen [#572](https://github.com/PublicMapping/districtbuilder/pull/572)
 - Add script to load region configs [#575](https://github.com/PublicMapping/districtbuilder/pull/575)
 - Store chamber reference on project entity [#576](https://github.com/PublicMapping/districtbuilder/pull/576)
+- Display error page for 404 errors [#582](https://github.com/PublicMapping/districtbuilder/pull/582)
 - Allow users to join and leave an organization [#226](https://github.com/PublicMapping/districtbuilder/pull/578)
 
 ### Changed

--- a/src/client/actions/organization.ts
+++ b/src/client/actions/organization.ts
@@ -1,6 +1,9 @@
 import { createAction } from "typesafe-actions";
 import { IOrganization, OrganizationSlug } from "../../shared/entities";
+import { ResourceFailure } from "../resource";
 
 export const organizationFetch = createAction("Organization fetch")<OrganizationSlug>();
 export const organizationFetchSuccess = createAction("Organization fetch success")<IOrganization>();
-export const organizationFetchFailure = createAction("Organization fetch failure")<string>();
+export const organizationFetchFailure = createAction("Organization fetch failure")<
+  ResourceFailure
+>();

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -2,16 +2,19 @@ import { createAction } from "typesafe-actions";
 import { ProjectVisibility } from "../../shared/constants";
 import { DistrictsDefinition, IProject, LockedDistricts, ProjectId } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
+import { ResourceFailure } from "../resource";
 
 export const projectFetch = createAction("Project fetch")<ProjectId>();
 export const projectFetchSuccess = createAction("Project fetch success")<DynamicProjectData>();
-export const projectFetchFailure = createAction("Project fetch failure")<string>();
+export const projectFetchFailure = createAction("Project fetch failure")<ResourceFailure>();
 
 export const projectDataFetch = createAction("Project data fetch")<ProjectId>();
 export const projectDataFetchSuccess = createAction("Project data fetch success")<
   DynamicProjectData
 >();
-export const projectDataFetchFailure = createAction("Project data fetch failure")<string>();
+export const projectDataFetchFailure = createAction("Project data fetch failure")<
+  ResourceFailure
+>();
 
 export const staticDataFetchSuccess = createAction("Static data fetch success")<
   StaticProjectData

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -141,7 +141,9 @@ async function fetchProject(id: ProjectId): Promise<IProject> {
     apiAxios
       .get(`/api/projects/${id}`)
       .then(response => resolve(response.data))
-      .catch(error => reject(error.message));
+      .catch(error =>
+        reject({ errorMessage: error.response.message, statusCode: error.response.status })
+      );
   });
 }
 
@@ -150,7 +152,7 @@ export async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJS
     apiAxios
       .get(`/api/projects/${id}/export/geojson`)
       .then(response => resolve(response.data))
-      .catch(error => reject(error.message));
+      .catch(error => reject(error.response.data));
   });
 }
 
@@ -159,7 +161,7 @@ export async function fetchProjects(): Promise<readonly IProject[]> {
     apiAxios
       .get("/api/projects?sort=updatedDt,DESC")
       .then(response => resolve(response.data))
-      .catch(error => reject(error.message));
+      .catch(error => reject(error.response.data));
   });
 }
 
@@ -241,7 +243,9 @@ export async function fetchOrganization(slug: OrganizationSlug): Promise<IOrgani
     apiAxios
       .get(`/api/organization/${slug}`)
       .then(response => resolve(response.data))
-      .catch(error => reject(error.message));
+      .catch(error => {
+        reject(error.response.data);
+      });
   });
 }
 

--- a/src/client/reducers/organization.ts
+++ b/src/client/reducers/organization.ts
@@ -42,7 +42,7 @@ const organizationReducer: LoopReducer<OrganizationState, Action> = (
     case getType(organizationFetchFailure):
       return loop(
         {
-          errorMessage: action.payload
+          ...action.payload
         },
         Cmd.run(showResourceFailedToast)
       );

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -139,9 +139,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       return loop(
         {
           ...state,
-          projectData: {
-            errorMessage: action.payload
-          }
+          projectData: action.payload
         },
         Cmd.run(showActionFailedToast)
       );
@@ -188,9 +186,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       return loop(
         {
           ...state,
-          projectData: {
-            errorMessage: action.payload
-          }
+          projectData: action.payload
         },
         Cmd.run(showResourceFailedToast)
       );

--- a/src/client/resource.ts
+++ b/src/client/resource.ts
@@ -11,6 +11,7 @@ export interface ResourceSuccess<T> {
 }
 export interface ResourceFailure {
   readonly errorMessage: string;
+  readonly statusCode?: number;
 }
 export interface ResourceRefreshing<T> {
   readonly isPending: true;

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -20,6 +20,7 @@ import JoinOrganizationModal from "../components/JoinOrganizationModal";
 import Tooltip from "../components/Tooltip";
 import { IProject, IOrganization, IUser } from "../../shared/entities";
 import { createProject } from "../api";
+import PageNotFoundScreen from "./PageNotFoundScreen";
 
 interface StateProps {
   readonly organization: OrganizationState;
@@ -240,6 +241,8 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
               </Box>
             )}
           </Box>
+        ) : "statusCode" in organization && organization.statusCode === 404 ? (
+          <PageNotFoundScreen model={"organization"} />
         ) : (
           <Box>Loading...</Box>
         )}

--- a/src/client/screens/PageNotFoundScreen.tsx
+++ b/src/client/screens/PageNotFoundScreen.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { Box, Card, Heading, jsx } from "theme-ui";
+
+import CenteredContent from "../components/CenteredContent";
+
+interface StateProps {
+  readonly model: string;
+}
+
+const PageNotFoundScreen = ({ model }: StateProps) => {
+  return (
+    <CenteredContent sx={{ mb: 5 }}>
+      <Card sx={{ variant: "card.floating" }}>
+        <Heading as="h2" sx={{ fontSize: 4, mb: 20, textAlign: "left" }}>
+          Page not found!
+        </Heading>
+        <Box sx={{ fontSize: 1, mt: 3, textAlign: "left" }}>
+          The {model} you are looking for could not be found :(
+        </Box>
+      </Card>
+    </CenteredContent>
+  );
+};
+
+export default PageNotFoundScreen;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -32,12 +32,15 @@ import { State } from "../reducers";
 import { Resource } from "../resource";
 import store from "../store";
 import { useBeforeunload } from "react-beforeunload";
+import PageNotFoundScreen from "./PageNotFoundScreen";
+import SiteHeader from "../components/SiteHeader";
 
 interface StateProps {
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
   readonly staticMetadata?: IStaticMetadata;
   readonly staticGeoLevels: UintArrays;
+  readonly projectNotFound?: boolean;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly districtDrawing: DistrictDrawingState;
   readonly isLoading: boolean;
@@ -62,6 +65,7 @@ const ProjectScreen = ({
   geojson,
   staticMetadata,
   staticGeoLevels,
+  projectNotFound,
   geoUnitHierarchy,
   districtDrawing,
   isLoading,
@@ -112,6 +116,11 @@ const ProjectScreen = ({
     </CenteredContent>
   ) : "errorMessage" in user ? (
     <Redirect to={"/login"} />
+  ) : projectNotFound ? (
+    <Flex sx={{ height: "100%", flexDirection: "column" }}>
+      <SiteHeader user={user} />
+      <PageNotFoundScreen model={"project"} />
+    </Flex>
   ) : (
     <Flex sx={{ height: "100%", flexDirection: "column" }}>
       <ProjectHeader map={map} project={project} isReadOnly={isReadOnly} />
@@ -193,6 +202,10 @@ function mapStateToProps(state: State): StateProps {
     isLoading:
       ("isPending" in state.project.projectData && state.project.projectData.isPending) ||
       ("isPending" in state.project.staticData && state.project.staticData.isPending),
+    projectNotFound: !!(
+      ("statusCode" in state.project.projectData && state.project.projectData.statusCode === 400) ||
+      ("statusCode" in state.project.staticData && state.project.staticData.statusCode === 400)
+    ),
     isReadOnly:
       !("resource" in state.user) ||
       (project !== undefined && state.user.resource.id !== project.user.id),


### PR DESCRIPTION
## Overview

Displays an error screen on the Project or Organization pages if a user attempts to navigate to an entity (project / organization) that does not exist. 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/108427042-929e0100-720a-11eb-9b26-ce14d5811743.png)
![image](https://user-images.githubusercontent.com/66973361/108427091-a47fa400-720a-11eb-9b8e-c4018117ddcb.png)


### Notes

I'm not entirely sure about how to handle the current toast notification that appears when a fetch error occurs. It seems like if nothing else, the copy should be updated here - since refreshing will not change the fact that the organization or project does not exist. But, I imagine that we want this to be displayed in the event that there is an unexpected failure when fetching a project that _does_ exist...

Also, we may need a little finessing on the style here @jfrankl 

## Testing Instructions

- `./scripts/update`
- Attempt to navigate to a URL for a project that does not exist, e.g. [http://localhost:3003/projects/777](http://localhost:3003/projects/777)
- Attempt to navigate to a URL for an organization that does not exist, e.g. [http://localhost:3003/o/FAKE](http://localhost:3003/o/FAKE)

Closes #561 
