### PR TITLE
Restrict 'Join Organization' and 'Use this template' button to verified users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Geounit label made more generic to support Dane County wards [#573](https://github.com/PublicMapping/districtbuilder/pull/573)
 - Update ESLint rules to prohibit console.log, allow conditional statements [#580](https://github.com/PublicMapping/districtbuilder/pull/580)
+- Prevent unverified users from joining an organization or using a template [#591](https://github.com/PublicMapping/districtbuilder/pull/591)
 
 ### Fixed
 

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { useHistory, useParams } from "react-router-dom";
 import { Box, Button, Flex, Heading, Image, Link, jsx, Text } from "theme-ui";
 
-import { showCopyMapModal } from "../actions/districtDrawing";
 import { organizationFetch } from "../actions/organization";
 import { joinOrganization, leaveOrganization } from "../actions/organizationJoin";
 import { userFetch } from "../actions/user";
@@ -15,8 +14,10 @@ import { ProjectState } from "../reducers/project";
 import { UserState } from "../reducers/user";
 import store from "../store";
 import SiteHeader from "../components/SiteHeader";
-import JoinOrganizationModal from "../components/JoinOrganizationModal";
 import Icon from "../components/Icon";
+import { showCopyMapModal } from "../actions/districtDrawing";
+import JoinOrganizationModal from "../components/JoinOrganizationModal";
+import Tooltip from "../components/Tooltip";
 import { IProject, IOrganization, IUser } from "../../shared/entities";
 import { createProject } from "../api";
 
@@ -79,6 +80,8 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
     "resource" in organization &&
     organization.resource &&
     checkIfUserInOrg(organization.resource, user.resource);
+
+  const userIsVerified = "resource" in user && user.resource && user.resource.isEmailVerified;
 
   useEffect(() => {
     "resource" in user &&
@@ -150,9 +153,6 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                     <Icon name="tools" /> {organization.resource.users?.length || 0} builders
                   </Box>
                 </Box>
-                {organization.resource.description && (
-                  <Box>{organization.resource.description}</Box>
-                )}
               </Box>
               <Flex sx={{ flexDirection: "column", flex: "none" }}>
                 <Button disabled={true} sx={style.join}>
@@ -168,12 +168,30 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                 <Button sx={style.join}>Leave organization</Button>
               </Flex>
             ) : "resource" in user && user.resource ? (
-              <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={joinOrg}>
-                <Button sx={style.join}>Join organization</Button>
-                <Box sx={style.joinText}>
-                  Join to start making district maps with this organization
-                </Box>
-              </Flex>
+              userIsVerified ? (
+                <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={joinOrg}>
+                  <Button sx={style.join} disabled={!userIsVerified}>
+                    Join organization
+                  </Button>
+                  <Box sx={style.joinText}>
+                    Join to start making district maps with this organization
+                  </Box>
+                </Flex>
+              ) : (
+                <Tooltip
+                  key={1}
+                  content={<div>You must confirm your email before joining an organization</div>}
+                >
+                  <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={joinOrg}>
+                    <Button sx={style.join} disabled={!userIsVerified}>
+                      Join organization
+                    </Button>
+                    <Box sx={style.joinText}>
+                      Join to start making district maps with this organization
+                    </Box>
+                  </Flex>
+                </Tooltip>
+              )
             ) : (
               <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
                 <Button sx={style.join}>Join organization</Button>


### PR DESCRIPTION
## Overview

Disables the 'Join Organization' and 'Use this Template' buttons in the OrganizationScreen component for users who have not verified their email, and adds a tooltip indicating that they need to verify their email first.

### Checklist

- [ x ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

_With unconfirmed email_
![image](https://user-images.githubusercontent.com/66973361/108768306-80cb9f00-7525-11eb-87e2-ae7b90d5bba6.png)

![image](https://user-images.githubusercontent.com/66973361/108768323-8628e980-7525-11eb-9a96-a308c114fec0.png)

_With confirmed email_

![image](https://user-images.githubusercontent.com/66973361/108768384-96d95f80-7525-11eb-91ab-52b06ff95aa7.png)


### Notes

The JSX for this component here is getting pretty unwieldy. Might be worthwhile to refactor some of the boxes into separate components.

## Testing Instructions

- Create a new user with an unverified email address
- Navigate to an organization's page (e.g., http://localhost:3003/o/mikes-maps if you are using Mike's YAML file)
- _Expect_: the Join Organization button and Use this Template button are disabled
- Verify the email for the newly created user and go to the org page again
- Expect: The buttons are now enabled

Closes #585 
