### PR TITLE
Add option to scripts/server to run in debug mode

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,11 @@
+version: "2.4"
+services:
+  server:
+    ports:
+      - 3005:3005
+      - 9229:9229
+    command: start:debug
+
+  client:
+    ports:
+      - 3003:3003

--- a/scripts/server
+++ b/scripts/server
@@ -16,6 +16,8 @@ Bring up all of the services required for the project to function.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
+    elif [[ "${1}" == "--debug" ]]; then
+        docker-compose -f docker-compose.yml -f docker-compose.debug.yml up server client
     else
         docker-compose up server client
     fi

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -9,7 +9,7 @@
     "check-format": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
+    "start:debug": "nest start --debug 0.0.0.0:9229 --watch",
     "start:prod": "node dist/server/src/main",
     "lint": "eslint 'src/**/*.{ts,tsx,json}'",
     "fix": "eslint 'src/**/*.{ts,tsx,json}' --fix",


### PR DESCRIPTION
## Overview

Adds a `--debug` flag to `scripts/server` to run the backend in debug mode, with the standard `9229` Node.js debugging port exposed through Docker to the host.

## Notes

I used VS Code's built-in debugger with the following configuration, but I believe other tools compatible w/ the Node inspector like the Chrome dev tools should also work:
```
{
  // Use IntelliSense to learn about possible attributes.
  // Hover to view descriptions of existing attributes.
  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "attach",
      "name": "Attach to Node",
      "localRoot": "${workspaceFolder}/src",
      "remoteRoot": "/home/node/app",
      "port": 9229
    }
  ]
}
```

## Testing Instructions

- `scripts/server --debug`
- Attach a debugger to the backend
- Ensure you can set a breakpoint in backend code

