### PR TITLE
Require users to confirm understanding before joining an organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add script to load region configs [#575](https://github.com/PublicMapping/districtbuilder/pull/575)
 - Store chamber reference on project entity [#576](https://github.com/PublicMapping/districtbuilder/pull/576)
 - Allow users to join and leave an organization [#226](https://github.com/PublicMapping/districtbuilder/pull/578)
+- Require users to confirm before joining an organization [#593](https://github.com/PublicMapping/districtbuilder/pull/593)
 
 ### Changed
 

--- a/src/client/components/ConfirmJoinOrganization.tsx
+++ b/src/client/components/ConfirmJoinOrganization.tsx
@@ -1,0 +1,98 @@
+/** @jsx jsx */
+import React from "react";
+import { connect } from "react-redux";
+import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+
+import { IOrganization, IUser } from "../../shared/entities";
+import { State } from "../reducers";
+import store from "../store";
+import { Resource } from "../resource";
+import { joinOrganization } from "../actions/organizationJoin";
+import { showCopyMapModal } from "../actions/districtDrawing";
+
+const style: ThemeUIStyleObject = {
+  footer: {
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 5
+  },
+  header: {
+    mb: 5
+  },
+  heading: {
+    fontFamily: "heading",
+    fontWeight: "light",
+    fontSize: 4
+  },
+  modal: {
+    bg: "muted",
+    p: 5,
+    width: "small",
+    maxWidth: "90vw",
+    overflow: "hidden"
+  }
+};
+
+const ConfirmJoinOrganization = ({
+  organization,
+  user
+}: {
+  readonly organization: IOrganization;
+  readonly user: Resource<IUser>;
+}) => {
+  const hideModal = () => store.dispatch(showCopyMapModal(false));
+
+  function joinOrg() {
+    "resource" in user &&
+      user.resource &&
+      store.dispatch(
+        joinOrganization({ organization: organization.slug, user: user.resource.id })
+      ) &&
+      store.dispatch(showCopyMapModal(false));
+  }
+
+  return (
+    <React.Fragment>
+      <Box sx={style.header}>
+        <Heading as="h1" sx={style.heading} id="copy-map-modal-header">
+          Join {organization.name}
+        </Heading>
+      </Box>
+      <Flex sx={{ flexDirection: "column" }}>
+        <Box>
+          Joining an organization allows you to create maps using their templates, participate in
+          contents and...
+        </Box>
+        <Box>
+          This organization will be able to see some information about you when you build out a map
+          using one of their templates
+          <ul>
+            <li>View your name and email address</li>
+            <li>View any maps you create using their templates</li>
+          </ul>
+        </Box>
+        <Flex sx={style.footer}>
+          <Button id="primary-action" sx={{ marginBottom: 3 }} onClick={joinOrg}>
+            Join now
+          </Button>
+          <Button
+            id="cancel-copy-map-modal"
+            onClick={hideModal}
+            sx={{ variant: "buttons.linkStyle", margin: "0 auto" }}
+          >
+            Go back
+          </Button>
+        </Flex>
+      </Flex>
+    </React.Fragment>
+  );
+};
+
+function mapStateToProps(state: State) {
+  return {
+    showModal: state.project.showCopyMapModal,
+    user: state.user
+  };
+}
+
+export default connect(mapStateToProps)(ConfirmJoinOrganization);

--- a/src/client/components/ConfirmJoinOrganization.tsx
+++ b/src/client/components/ConfirmJoinOrganization.tsx
@@ -3,12 +3,14 @@ import React from "react";
 import { connect } from "react-redux";
 import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
 
-import { IOrganization, IUser } from "../../shared/entities";
+import { CreateProjectData, IOrganization, IUser, IProject } from "../../shared/entities";
+import { useHistory } from "react-router-dom";
 import { State } from "../reducers";
 import store from "../store";
 import { Resource } from "../resource";
 import { joinOrganization } from "../actions/organizationJoin";
 import { showCopyMapModal } from "../actions/districtDrawing";
+import { createProject } from "../api";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -35,12 +37,15 @@ const style: ThemeUIStyleObject = {
 
 const ConfirmJoinOrganization = ({
   organization,
-  user
+  user,
+  projectTemplate
 }: {
   readonly organization: IOrganization;
   readonly user: Resource<IUser>;
+  readonly projectTemplate?: CreateProjectData;
 }) => {
   const hideModal = () => store.dispatch(showCopyMapModal(false));
+  const history = useHistory();
 
   function joinOrg() {
     "resource" in user &&
@@ -49,6 +54,15 @@ const ConfirmJoinOrganization = ({
         joinOrganization({ organization: organization.slug, user: user.resource.id })
       ) &&
       store.dispatch(showCopyMapModal(false));
+
+    projectTemplate && createProjectFromTemplate();
+  }
+
+  function createProjectFromTemplate() {
+    projectTemplate &&
+      void createProject(projectTemplate).then((project: IProject) =>
+        history.push(`/projects/${project.id}`)
+      );
   }
 
   return (

--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -11,6 +11,7 @@ import store from "../store";
 import { AuthModalContent } from "./AuthComponents";
 import ConfirmJoinOrganization from "./ConfirmJoinOrganization";
 import { Resource } from "../resource";
+import { CreateProjectData } from "../../shared/entities";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -38,11 +39,13 @@ const style: ThemeUIStyleObject = {
 const JoinOrganizationModal = ({
   organization,
   user,
-  showModal
+  showModal,
+  projectTemplate
 }: {
   readonly organization: IOrganization;
   readonly showModal: boolean;
   readonly user: Resource<IUser>;
+  readonly projectTemplate?: CreateProjectData;
 }) => {
   const hideModal = () => store.dispatch(showCopyMapModal(false));
 
@@ -56,7 +59,7 @@ const JoinOrganizationModal = ({
     >
       <Box sx={style.modal}>
         {"resource" in user ? (
-          <ConfirmJoinOrganization organization={organization} />
+          <ConfirmJoinOrganization organization={organization} projectTemplate={projectTemplate} />
         ) : (
           <AuthModalContent organization={organization} />
         )}

--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -1,13 +1,16 @@
 /** @jsx jsx */
 import AriaModal from "react-aria-modal";
 import { connect } from "react-redux";
+
 import { Box, jsx, ThemeUIStyleObject } from "theme-ui";
 
-import { IOrganization } from "../../shared/entities";
+import { IOrganization, IUser } from "../../shared/entities";
 import { showCopyMapModal } from "../actions/districtDrawing";
 import { State } from "../reducers";
 import store from "../store";
 import { AuthModalContent } from "./AuthComponents";
+import ConfirmJoinOrganization from "./ConfirmJoinOrganization";
+import { Resource } from "../resource";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -34,10 +37,12 @@ const style: ThemeUIStyleObject = {
 
 const JoinOrganizationModal = ({
   organization,
+  user,
   showModal
 }: {
   readonly organization: IOrganization;
   readonly showModal: boolean;
+  readonly user: Resource<IUser>;
 }) => {
   const hideModal = () => store.dispatch(showCopyMapModal(false));
 
@@ -49,7 +54,13 @@ const JoinOrganizationModal = ({
       getApplicationNode={() => document.getElementById("root") as Element}
       underlayStyle={{ paddingTop: "4.5rem" }}
     >
-      <Box sx={style.modal}>{<AuthModalContent organization={organization} />}</Box>
+      <Box sx={style.modal}>
+        {"resource" in user ? (
+          <ConfirmJoinOrganization organization={organization} />
+        ) : (
+          <AuthModalContent organization={organization} />
+        )}
+      </Box>
     </AriaModal>
   ) : null;
 };

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -5,7 +5,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { Box, Button, Flex, Heading, Image, Link, jsx, Text } from "theme-ui";
 
 import { organizationFetch } from "../actions/organization";
-import { joinOrganization, leaveOrganization } from "../actions/organizationJoin";
+import { leaveOrganization } from "../actions/organizationJoin";
 import { userFetch } from "../actions/user";
 import { getJWT } from "../jwt";
 import { State } from "../reducers";
@@ -18,7 +18,7 @@ import Icon from "../components/Icon";
 import { showCopyMapModal } from "../actions/districtDrawing";
 import JoinOrganizationModal from "../components/JoinOrganizationModal";
 import Tooltip from "../components/Tooltip";
-import { IProject, IOrganization, IUser } from "../../shared/entities";
+import { IProject, IOrganization, IUser, IProjectTemplate } from "../../shared/entities";
 import { createProject } from "../api";
 
 interface StateProps {
@@ -80,11 +80,13 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
     "resource" in organization &&
     organization.resource &&
     checkIfUserInOrg(organization.resource, user.resource);
+  const userLoggedIn = "resource" in user && user.resource;
 
   const userIsVerified = "resource" in user && user.resource && user.resource.isEmailVerified;
 
   useEffect(() => {
-    "resource" in user &&
+    !userLoggedIn &&
+      "resource" in user &&
       user.resource &&
       project.showCopyMapModal &&
       store.dispatch(showCopyMapModal(false));
@@ -97,12 +99,6 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
   useEffect(() => {
     store.dispatch(organizationFetch(organizationSlug));
   }, [organizationSlug]);
-
-  function joinOrg() {
-    "resource" in user &&
-      user.resource &&
-      store.dispatch(joinOrganization({ organization: organizationSlug, user: user.resource.id }));
-  }
 
   function signupAndJoinOrg() {
     store.dispatch(showCopyMapModal(true));
@@ -119,6 +115,20 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
       return u.id === user.id;
     });
     return userExists.length > 0;
+  }
+
+  function createProjectFromTemplate(template: IProjectTemplate) {
+    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
+    userInOrg
+      ? void createProject({
+          name,
+          regionConfig,
+          numberOfDistricts,
+          districtsDefinition,
+          chamber,
+          projectTemplate: { id }
+        }).then((project: IProject) => history.push(`/projects/${project.id}`))
+      : store.dispatch(showCopyMapModal(true));
   }
 
   return (
@@ -153,6 +163,9 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                     <Icon name="tools" /> {organization.resource.users?.length || 0} builders
                   </Box>
                 </Box>
+                {organization.resource.description && (
+                  <Box>{organization.resource.description}</Box>
+                )}
               </Box>
               <Flex sx={{ flexDirection: "column", flex: "none" }}>
                 <Button disabled={true} sx={style.join}>
@@ -169,7 +182,7 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
               </Flex>
             ) : "resource" in user && user.resource ? (
               userIsVerified ? (
-                <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={joinOrg}>
+                <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
                   <Button sx={style.join} disabled={!userIsVerified}>
                     Join organization
                   </Button>
@@ -182,7 +195,7 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                   key={1}
                   content={<div>You must confirm your email before joining an organization</div>}
                 >
-                  <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={joinOrg}>
+                  <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
                     <Button sx={style.join} disabled={!userIsVerified}>
                       Join organization
                     </Button>
@@ -212,26 +225,7 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                         {template.regionConfig.name} · {template.numberOfDistricts}
                       </Text>
                       <Text>{template.description}</Text>
-                      <Button
-                        onClick={() => {
-                          const {
-                            id,
-                            name,
-                            regionConfig,
-                            numberOfDistricts,
-                            districtsDefinition,
-                            chamber
-                          } = template;
-                          void createProject({
-                            name,
-                            regionConfig,
-                            numberOfDistricts,
-                            districtsDefinition,
-                            chamber,
-                            projectTemplate: { id }
-                          }).then((project: IProject) => history.push(`/projects/${project.id}`));
-                        }}
-                      >
+                      <Button onClick={() => createProjectFromTemplate(template)}>
                         Use this template
                       </Button>
                     </Flex>

--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -65,7 +65,8 @@ export class AuthService {
       name: user.name,
       email: user.email,
       isEmailVerified: user.isEmailVerified,
-      hasSeenTour: user.hasSeenTour
+      hasSeenTour: user.hasSeenTour,
+      organizations: user.organizations
     };
     return this.jwtService.sign(payload);
   }

--- a/src/server/src/users/controllers/users.controller.ts
+++ b/src/server/src/users/controllers/users.controller.ts
@@ -11,7 +11,13 @@ import { UsersService } from "../services/users.service";
     type: User
   },
   query: {
-    exclude: ["passwordHash"]
+    exclude: ["passwordHash"],
+    join: {
+      organizations: {
+        allow: ["slug"],
+        eager: true
+      }
+    }
   },
   routes: {
     only: ["getOneBase", "updateOneBase"]

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -4,12 +4,15 @@ export type UserId = string;
 
 export type PublicUserProperties = "id" | "name";
 
+export type OrganizationNest = Pick<IOrganization, "slug" | "id">;
+
 export interface IUser {
   readonly id: UserId;
   readonly email: string;
   readonly name: string;
   readonly isEmailVerified: boolean;
   readonly hasSeenTour: boolean;
+  readonly organizations: readonly OrganizationNest[];
 }
 
 export type UpdateUserData = Pick<IUser, "name" | "hasSeenTour">;


### PR DESCRIPTION
## Overview

- When a user has not joined an organization and they click on "Join Organization" on that organization's page, there is a confirmation modal that displays text and asks them to confirm joining the organization
- When a user has not joined an organization and they click on any "Use this template" button on that organization's page, there is a confirmation modal that displays text and asks them to confirm joining the organization.
-  The user cannot start a template map for an organization without joining

### Checklist

- [ x ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/108896349-cd28e480-75e2-11eb-830a-170453fdc62f.png)

### Notes

Does it make sense to possibly disable the 'Use Template' button and have a tooltip text indicating that the user must join and organization first? Like we did in #591 

## Testing Instructions

- Navigate to an organization page and attempt to join
- Expected: JoinOrganization modal should open. If you are logged in, there will be a confirmation dialog asking you to confirm your understanding of how organizations work


Closes #587 
