### PR TITLE
Project districts geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geounit label made more generic to support Dane County wards [#573](https://github.com/PublicMapping/districtbuilder/pull/573)
 - Update ESLint rules to prohibit console.log, allow conditional statements [#580](https://github.com/PublicMapping/districtbuilder/pull/580)
 - Prevent unverified users from joining an organization or using a template [#591](https://github.com/PublicMapping/districtbuilder/pull/591)
+- Project districts geojson is now cached in the project table when updated [#594](https://github.com/PublicMapping/districtbuilder/pull/594)
 
 ### Fixed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -266,7 +266,7 @@ const SidebarRow = memo(
     readonly district: DistrictGeoJSON;
     readonly selected: boolean;
     readonly selectedPopulationDifference?: number;
-    readonly demographics: { readonly [id: string]: number };
+    readonly demographics: DemographicCounts;
     readonly deviation: number;
     readonly districtId: number;
     readonly isDistrictLocked?: boolean;
@@ -280,8 +280,7 @@ const SidebarRow = memo(
         ? positiveChangeColor
         : negativeChangeColor
       : "inherit";
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    const intermediatePopulation = district.properties.population + selectedDifference;
+    const intermediatePopulation = demographics.population + selectedDifference;
     const intermediateDeviation = deviation + selectedDifference;
     const populationDisplay = intermediatePopulation.toLocaleString();
     const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
@@ -461,7 +460,6 @@ const SidebarRows = ({
       {geojson.features.map(feature => {
         const districtId = typeof feature.id === "number" ? feature.id : 0;
         const selected = districtId === selectedDistrictId;
-        const demographics = feature.properties;
         const selectedPopulation = selectedDemographics?.savedDistrict?.[districtId]?.population;
         const totalSelectedDemographics = selectedDemographics?.total;
         const selectedPopulationDifference =
@@ -475,15 +473,15 @@ const SidebarRows = ({
         // so it's deviation is equal to its population
         const deviation =
           districtId === 0
-            ? feature.properties.population
-            : feature.properties.population - averagePopulation;
+            ? feature.properties.demographics.population
+            : feature.properties.demographics.population - averagePopulation;
 
         return (
           <SidebarRow
             district={feature}
             selected={selected}
             selectedPopulationDifference={selectedPopulationDifference || 0}
-            demographics={demographics}
+            demographics={feature.properties.demographics}
             deviation={deviation}
             key={districtId}
             isDistrictLocked={lockedDistricts[districtId]}

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -109,7 +109,7 @@ export function assignGeounitsToDistrict(
 export function getTargetPopulation(geojson: DistrictsGeoJSON, project: IProject) {
   return (
     geojson.features.reduce(
-      (population, feature) => population + feature.properties.population,
+      (population, feature) => population + feature.properties.demographics.population,
       0
     ) / project.numberOfDistricts
   );

--- a/src/server/migrations/1614028839986-project_districts.ts
+++ b/src/server/migrations/1614028839986-project_districts.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class projectDistricts1614028839986 implements MigrationInterface {
+    name = 'projectDistricts1614028839986'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "districts" jsonb`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "districts"`, undefined);
+    }
+
+}

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -253,7 +253,7 @@ export class GeoUnitTopology {
         return {
           ...feature,
           properties: {
-            ...feature.properties,
+            demographics: feature.properties,
             compactness,
             contiguity
           }

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureCollection } from "geojson";
+import { Feature, MultiPolygon as GeoJSONMultiPolygon } from "geojson";
 import * as topojson from "topojson-client";
 import {
   GeometryCollection,
@@ -22,6 +22,7 @@ import {
 } from "../../../../shared/entities";
 import { getAllBaseIndices, getDemographics } from "../../../../shared/functions";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
+import { DistrictsGeoJSON } from "src/projects/entities/project.entity";
 
 interface GeoUnitHierarchy {
   geom: Polygon | MultiPolygon;
@@ -187,7 +188,7 @@ export class GeoUnitTopology {
    * Performs a merger of the specified districts into a GeoJSON collection,
    * or returns null if the district definition is invalid
    */
-  merge(definition: DistrictsDefinitionDto, numberOfDistricts: number): FeatureCollection | null {
+  merge(definition: DistrictsDefinitionDto, numberOfDistricts: number): DistrictsGeoJSON | null {
     // mutableDistrictGeoms contains the individual geometries prior to being merged
     // indexed by district id then by geolevel index
     const mutableDistrictGeoms: Array<Array<Array<MultiPolygon | Polygon>>> = Array.from(
@@ -249,9 +250,11 @@ export class GeoUnitTopology {
       ...featureCollection,
       features: featureCollection.features.map(feature => {
         const [compactness, contiguity] = calcPolsbyPopper(feature);
+        const geometry = feature.geometry as GeoJSONMultiPolygon;
 
         return {
           ...feature,
+          geometry,
           properties: {
             demographics: feature.properties,
             compactness,

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -291,6 +291,9 @@ export class ProjectsController implements CrudController<Project> {
         ...feature,
         properties: {
           ...feature.properties,
+          // Flatten nested demographics object so it is maintained when converting
+          demographics: undefined,
+          ...feature.properties.demographics,
           // The feature ID doesn't seem to make its way over as part of 'convert' natively
           id: feature.id
         }

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -31,8 +31,8 @@ import { GeometryCollection } from "topojson-specification";
 
 import { MakeDistrictsErrors } from "../../../../shared/constants";
 import {
+  DistrictsDefinition,
   GeoUnitHierarchy,
-  IProjectTemplate,
   ProjectId,
   PublicUserProperties
 } from "../../../../shared/entities";
@@ -41,9 +41,10 @@ import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.enti
 import { TopologyService } from "../../districts/services/topology.service";
 
 import { JwtAuthGuard, OptionalJwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { User } from "../../users/entities/user.entity";
 import { CreateProjectDto } from "../entities/create-project.dto";
-import { Project } from "../entities/project.entity";
+import { DistrictsGeoJSON, Project } from "../entities/project.entity";
 import { ProjectsService } from "../services/projects.service";
 import { RegionConfigsService } from "../../region-configs/services/region-configs.service";
 import { UpdateProjectDto } from "../entities/update-project.dto";
@@ -172,14 +173,31 @@ export class ProjectsController implements CrudController<Project> {
     @ParsedBody() dto: UpdateProjectDto
   ) {
     // @ts-ignore
-    const existingProject = await this.service.findOne({ id });
+    const existingProject = await this.service.findOne({ id }, { relations: ["regionConfig"] });
     if (dto.lockedDistricts && existingProject?.numberOfDistricts !== dto.lockedDistricts.length) {
       throw new BadRequestException({
         error: "Bad Request",
         message: { lockedDistricts: [`Length of array does not match "number_of_districts"`] }
       } as Errors<UpdateProjectDto>);
     }
-    return this.service.updateOne(req, dto);
+
+    // Update districts GeoJSON if the definition has changed or there is no cached value yet
+    const data =
+      existingProject &&
+      dto.districtsDefinition &&
+      (!existingProject.districts ||
+        !_.isEqual(dto.districtsDefinition, existingProject.districtsDefinition))
+        ? {
+            ...dto,
+            districts: await this.getGeojson({
+              regionConfig: existingProject.regionConfig,
+              numberOfDistricts: existingProject.numberOfDistricts,
+              districtsDefinition: dto.districtsDefinition
+            })
+          }
+        : dto;
+
+    return this.service.updateOne(req, data);
   }
 
   @Override()
@@ -202,12 +220,21 @@ export class ProjectsController implements CrudController<Project> {
         );
       }
 
+      // Districts definition is optional. Use it if supplied, otherwise use all-unassigned.
+      const districtsDefinition =
+        dto.districtsDefinition || new Array(geoCollection.hierarchy.length).fill(0);
+      const lockedDistricts = new Array(dto.numberOfDistricts).fill(false);
+      const districts = await this.getGeojson({
+        numberOfDistricts: dto.numberOfDistricts,
+        districtsDefinition,
+        regionConfig
+      });
+
       return this.service.createOne(req, {
         ...dto,
-        // Districts definition is optional. Use it if supplied, otherwise use all-unassigned.
-        districtsDefinition:
-          dto.districtsDefinition || new Array(geoCollection.hierarchy.length).fill(0),
-        lockedDistricts: new Array(dto.numberOfDistricts).fill(false),
+        districtsDefinition,
+        districts,
+        lockedDistricts,
         user: req.parsed.authPersist.userId
       });
     } catch (error) {
@@ -241,21 +268,19 @@ export class ProjectsController implements CrudController<Project> {
     return geoCollection;
   }
 
-  @UseInterceptors(CrudRequestInterceptor)
-  @UseGuards(OptionalJwtAuthGuard)
-  @Get(":id/export/geojson")
-  async exportGeoJSON(
-    @ParsedRequest() req: CrudRequest,
-    @Param("id") projectId: ProjectId
-  ): Promise<FeatureCollection> {
-    const project = await this.getProject(req, projectId);
-    const geoCollection = await this.getGeoUnitTopology(project.regionConfig.s3URI);
-    const geojson = geoCollection.merge(
-      { districts: project.districtsDefinition },
-      project.numberOfDistricts
-    );
+  async getGeojson({
+    districtsDefinition,
+    numberOfDistricts,
+    regionConfig
+  }: {
+    readonly districtsDefinition: DistrictsDefinition;
+    readonly numberOfDistricts: number;
+    readonly regionConfig: RegionConfig;
+  }): Promise<DistrictsGeoJSON> {
+    const geoCollection = await this.getGeoUnitTopology(regionConfig.s3URI);
+    const geojson = geoCollection.merge({ districts: districtsDefinition }, numberOfDistricts);
     if (geojson === null) {
-      this.logger.error(`Invalid districts definition for project ${projectId}`);
+      this.logger.error(`Invalid districts definition for project`);
       throw new BadRequestException(
         "District definition is invalid",
         MakeDistrictsErrors.INVALID_DEFINITION
@@ -266,25 +291,31 @@ export class ProjectsController implements CrudController<Project> {
 
   @UseInterceptors(CrudRequestInterceptor)
   @UseGuards(OptionalJwtAuthGuard)
+  @Get(":id/export/geojson")
+  async exportGeoJSON(
+    @ParsedRequest() req: CrudRequest,
+    @Param("id") projectId: ProjectId
+  ): Promise<DistrictsGeoJSON> {
+    const project = await this.getProject(req, projectId);
+    if (!project.districtsDefinition) {
+      throw new BadRequestException(
+        "District definition is invalid",
+        MakeDistrictsErrors.INVALID_DEFINITION
+      );
+    }
+
+    return project.districts || (await this.getGeojson({ ...project }));
+  }
+
+  @UseInterceptors(CrudRequestInterceptor)
+  @UseGuards(OptionalJwtAuthGuard)
   @Get(":id/export/shp")
   async exportShapefile(
     @ParsedRequest() req: CrudRequest,
     @Param("id") projectId: ProjectId,
     @Res() response: Response
   ): Promise<void> {
-    const project = await this.getProject(req, projectId);
-    const geoCollection = await this.getGeoUnitTopology(project.regionConfig.s3URI);
-    const geojson = geoCollection.merge(
-      { districts: project.districtsDefinition },
-      project.numberOfDistricts
-    );
-    if (geojson === null) {
-      this.logger.error(`Invalid districts definition for project ${projectId}`);
-      throw new BadRequestException(
-        "District definition is invalid",
-        MakeDistrictsErrors.INVALID_DEFINITION
-      );
-    }
+    const geojson = await this.exportGeoJSON(req, projectId);
     const formattedGeojson = {
       ...geojson,
       features: geojson.features.map(feature => ({

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -1,5 +1,5 @@
+import { FeatureCollection, MultiPolygon } from "geojson";
 import {
-  Check,
   Column,
   Entity,
   JoinColumn,
@@ -9,11 +9,14 @@ import {
 } from "typeorm";
 
 import { ProjectVisibility } from "../../../../shared/constants";
-import { DistrictsDefinition, IProject } from "../../../../shared/entities";
+import { DistrictProperties, DistrictsDefinition, IProject } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
 import { ProjectTemplate } from "src/project-templates/entities/project-template.entity";
+
+// TODO #179: Move to shared/entities
+export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
 
 @Entity()
 export class Project implements IProject {
@@ -44,6 +47,13 @@ export class Project implements IProject {
     nullable: true
   })
   districtsDefinition: DistrictsDefinition;
+
+  @Column({
+    type: "jsonb",
+    name: "districts",
+    nullable: true
+  })
+  districts: DistrictsGeoJSON;
 
   @ManyToOne(() => User, { nullable: false })
   @JoinColumn({ name: "user_id" })

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -55,11 +55,16 @@ export interface IDistrictsDefinition {
   readonly districts: DistrictsDefinition;
 }
 
+export interface DemographicCounts {
+  // key is demographic group (eg. population, white, black, etc)
+  // value is the number of people in that group
+  readonly [id: string]: number;
+}
+
 export type DistrictProperties = {
   readonly contiguity: "contiguous" | "non-contiguous" | "";
   readonly compactness: number;
-} & {
-  readonly [name: string]: number;
+  readonly demographics: DemographicCounts;
 };
 
 export interface IStaticFile {
@@ -207,12 +212,6 @@ export type Contiguity = "" | "contiguous" | "non-contiguous";
 export type DistrictId = number;
 
 export type LockedDistricts = readonly boolean[];
-
-export interface DemographicCounts {
-  // key is demographic group (eg. population, white, black, etc)
-  // value is the number of people in that group
-  [id: string]: number; // eslint-disable-line
-}
 
 export type UintArray = Uint8Array | Uint16Array | Uint32Array;
 export type UintArrays = ReadonlyArray<UintArray>;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -39,20 +39,13 @@ export function getDemographics(
   staticDemographics: readonly UintArray[]
 ): DemographicCounts {
   // Aggregate demographic data for the IDs
-  return staticMetadata.demographics.reduce(
-    (data, demographic, ind) => {
-      let count: number = 0; // eslint-disable-line
-      baseIndices.forEach((v: number) => {
-        // eslint-disable-next-line
-        if (!isNaN(staticDemographics[ind][v])) {
-          count += staticDemographics[ind][v];
-        }
-      });
-      // eslint-disable-next-line
-      data[demographic.id] = count;
-      return data;
-    },
-    // eslint-disable-next-line
-    {} as DemographicCounts
-  );
+  return staticMetadata.demographics.reduce((data, demographic, ind) => {
+    let count: number = 0; // eslint-disable-line
+    baseIndices.forEach((v: number) => {
+      if (!isNaN(staticDemographics[ind][v])) {
+        count += staticDemographics[ind][v];
+      }
+    });
+    return { ...data, [demographic.id]: count };
+  }, {} as DemographicCounts);
 }


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Cached `district` field can be seen in debugger:
![image](https://user-images.githubusercontent.com/4432106/108912321-7decaf00-75f6-11eb-8a42-514ddcacdd3e.png)


### Notes

Note the `districts` is excluded from the main project detail endpoint and I also left it off of the `IProject` interface - instead access continues to go through the `/export/geojson` endpoint. This solves two issues:
 - We can't import from `geojson` in the shared module yet (see #179) so I can't move the `DistrictsGeoJSON` type there
 - Including the geojson on the list page would unnecessarily slow down things
 
There are definitely downsides to this approach though, and I think we could refactor this further to eliminate the need for the `/export/geojson` endpoint.

## Testing Instructions

- `scripts/update`
- Displaying and updating districts should continue to work as normal

Closes #567 
