### PR TITLE
Fix 404 page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display error page for 404 errors [#582](https://github.com/PublicMapping/districtbuilder/pull/582)
 - Allow users to join and leave an organization [#226](https://github.com/PublicMapping/districtbuilder/pull/578)
 - Require users to confirm before joining an organization [#593](https://github.com/PublicMapping/districtbuilder/pull/593)
+- Show not found page for missing projects and organizations [#613](https://github.com/PublicMapping/districtbuilder/pull/613)
 
 ### Changed
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -142,7 +142,7 @@ async function fetchProject(id: ProjectId): Promise<IProject> {
       .get(`/api/projects/${id}`)
       .then(response => resolve(response.data))
       .catch(error =>
-        reject({ errorMessage: error.response.message, statusCode: error.response.status })
+        reject({ errorMessage: error.response.data, statusCode: error.response.status })
       );
   });
 }
@@ -244,7 +244,7 @@ export async function fetchOrganization(slug: OrganizationSlug): Promise<IOrgani
       .get(`/api/organization/${slug}`)
       .then(response => resolve(response.data))
       .catch(error => {
-        reject(error.response.data);
+        reject({ errorMessage: error.response.data, statusCode: error.response.status });
       });
   });
 }

--- a/src/client/reducers/organization.ts
+++ b/src/client/reducers/organization.ts
@@ -44,7 +44,9 @@ const organizationReducer: LoopReducer<OrganizationState, Action> = (
         {
           ...action.payload
         },
-        Cmd.run(showResourceFailedToast)
+        action.payload.statusCode && action.payload.statusCode >= 500
+          ? Cmd.run(showResourceFailedToast)
+          : Cmd.none
       );
     default:
       return state;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -188,7 +188,9 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
           ...state,
           projectData: action.payload
         },
-        Cmd.run(showResourceFailedToast)
+        action.payload.statusCode && action.payload.statusCode >= 500
+          ? Cmd.run(showResourceFailedToast)
+          : Cmd.none
       );
     case getType(staticDataFetchSuccess):
       return {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -202,10 +202,8 @@ function mapStateToProps(state: State): StateProps {
     isLoading:
       ("isPending" in state.project.projectData && state.project.projectData.isPending) ||
       ("isPending" in state.project.staticData && state.project.staticData.isPending),
-    projectNotFound: !!(
-      ("statusCode" in state.project.projectData && state.project.projectData.statusCode === 400) ||
-      ("statusCode" in state.project.staticData && state.project.staticData.statusCode === 400)
-    ),
+    projectNotFound:
+      "statusCode" in state.project.projectData && state.project.projectData.statusCode === 404,
     isReadOnly:
       !("resource" in state.user) ||
       (project !== undefined && state.user.resource.id !== project.user.id),


### PR DESCRIPTION
## Overview

 - Fixes the backend to properly return 404 in all cases for invalid project URLS or missing IDs

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Got to a project
  - Changing one character in ID in the URL, so you have a _valid_ UUID which is not in our database, and refreshing the page, should return a 404 from backend and displaying the Not Found component
  - Replacing the ID in the URL, so you have an _invalid_ UUID, and refreshing the page, should return a 404 from backend and displaying the Not Found component
- Attempting to visit an organization for a slug not in our DB should result in displaying the Not Found component
- Neither of the above should display failure toasts

Closes #595 
