### PR TITLE
Disable "Use this template" button if user email is unverified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Store chamber reference on project entity [#576](https://github.com/PublicMapping/districtbuilder/pull/576)
 - Display error page for 404 errors [#582](https://github.com/PublicMapping/districtbuilder/pull/582)
 - Allow users to join and leave an organization [#226](https://github.com/PublicMapping/districtbuilder/pull/578)
-- Require users to confirm before joining an organization [#593](https://github.com/PublicMapping/districtbuilder/pull/593)
+- Require users to confirm before joining an organization [#593](https://github.com/PublicMapping/districtbuilder/pull/593) & [#615](https://github.com/PublicMapping/districtbuilder/pull/615)
 - Show not found page for missing projects and organizations [#613](https://github.com/PublicMapping/districtbuilder/pull/613)
 - Add paintbrush drawing tool [#611](https://github.com/PublicMapping/districtbuilder/pull/611)
 

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -136,6 +136,47 @@ const OrganizationScreen = ({ organization, user }: StateProps) => {
     userInOrg ? createProjectFromTemplate() : store.dispatch(showCopyMapModal(true));
   }
 
+  const joinButton = (
+    <Flex sx={{ flexDirection: "column", flex: "none" }}>
+      <Button sx={style.join} disabled={isLoggedIn && !userIsVerified} onClick={signupAndJoinOrg}>
+        Join organization
+      </Button>
+      <Box sx={style.joinText}>Join to start making district maps with this organization</Box>
+    </Flex>
+  );
+
+  const TemplateCard = ({ template }: { readonly template: IProjectTemplate }) => {
+    const useButton = (
+      <Button
+        disabled={isLoggedIn && !userIsVerified}
+        onClick={() => setupProjectFromTemplate(template)}
+        sx={{ width: "100%" }}
+      >
+        Use this template
+      </Button>
+    );
+
+    return (
+      <Flex sx={style.template}>
+        <Heading>{template.name}</Heading>
+        <Text>
+          {template.regionConfig.name} · {template.numberOfDistricts}
+        </Text>
+        <Text>{template.description}</Text>
+        {!isLoggedIn || userIsVerified ? (
+          useButton
+        ) : (
+          <Tooltip
+            key={template.id}
+            content={<div>You must confirm your email before joining an organization</div>}
+          >
+            <Box>{useButton}</Box>
+          </Tooltip>
+        )}
+      </Flex>
+    );
+  };
+
   return (
     <Flex sx={{ flexDirection: "column" }}>
       <SiteHeader user={user} />
@@ -178,38 +219,17 @@ const OrganizationScreen = ({ organization, user }: StateProps) => {
                 </Flex>
               ) : "resource" in user && user.resource ? (
                 userIsVerified ? (
-                  <Flex sx={{ flexDirection: "column", flex: "none" }}>
-                    <Button sx={style.join} disabled={!userIsVerified} onClick={signupAndJoinOrg}>
-                      Join organization
-                    </Button>
-                    <Box sx={style.joinText}>
-                      Join to start making district maps with this organization
-                    </Box>
-                  </Flex>
+                  joinButton
                 ) : (
                   <Tooltip
                     key={1}
                     content={<div>You must confirm your email before joining an organization</div>}
                   >
-                    <Flex sx={{ flexDirection: "column", flex: "none" }}>
-                      <Button sx={style.join} disabled={!userIsVerified} onClick={signupAndJoinOrg}>
-                        Join organization
-                      </Button>
-                      <Box sx={style.joinText}>
-                        Join to start making district maps with this organization
-                      </Box>
-                    </Flex>
+                    {joinButton}
                   </Tooltip>
                 )
               ) : (
-                <Flex sx={{ flexDirection: "column", flex: "none" }}>
-                  <Button sx={style.join} onClick={signupAndJoinOrg}>
-                    Join organization
-                  </Button>
-                  <Box sx={style.joinText}>
-                    Register for an account to start making district maps with this organization
-                  </Box>
-                </Flex>
+                joinButton
               )}
             </Flex>
             {organization.resource.projectTemplates.length > 0 && (
@@ -218,16 +238,7 @@ const OrganizationScreen = ({ organization, user }: StateProps) => {
                 Start a new map using the official settings from {organization.resource.name}
                 <Box sx={style.templateContainer}>
                   {organization.resource.projectTemplates.map(template => (
-                    <Flex key={template.id} sx={style.template}>
-                      <Heading>{template.name}</Heading>
-                      <Text>
-                        {template.regionConfig.name} · {template.numberOfDistricts}
-                      </Text>
-                      <Text>{template.description}</Text>
-                      <Button onClick={() => setupProjectFromTemplate(template)}>
-                        Use this template
-                      </Button>
-                    </Flex>
+                    <TemplateCard template={template} key={template.id} />
                   ))}
                 </Box>
               </Box>

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -2,35 +2,35 @@
 import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { useHistory, useParams } from "react-router-dom";
-import { Box, Button, Flex, Heading, Image, Link, jsx, Text } from "theme-ui";
+import { Box, Button, Flex, Heading, Image, jsx, Link, Text } from "theme-ui";
 
+import {
+  CreateProjectData,
+  IOrganization,
+  IProject,
+  IProjectTemplate,
+  IUser
+} from "../../shared/entities";
+
+import { showCopyMapModal } from "../actions/districtDrawing";
 import { organizationFetch } from "../actions/organization";
 import { leaveOrganization } from "../actions/organizationJoin";
 import { userFetch } from "../actions/user";
+import { createProject } from "../api";
+import Icon from "../components/Icon";
+import JoinOrganizationModal from "../components/JoinOrganizationModal";
+import SiteHeader from "../components/SiteHeader";
+import Tooltip from "../components/Tooltip";
 import { getJWT } from "../jwt";
 import { State } from "../reducers";
 import { OrganizationState } from "../reducers/organization";
-import { ProjectState } from "../reducers/project";
 import { UserState } from "../reducers/user";
 import store from "../store";
-import SiteHeader from "../components/SiteHeader";
-import Icon from "../components/Icon";
-import { showCopyMapModal } from "../actions/districtDrawing";
-import JoinOrganizationModal from "../components/JoinOrganizationModal";
-import Tooltip from "../components/Tooltip";
-import {
-  IProject,
-  IOrganization,
-  IUser,
-  IProjectTemplate,
-  CreateProjectData
-} from "../../shared/entities";
-import { createProject } from "../api";
+
 import PageNotFoundScreen from "./PageNotFoundScreen";
 
 interface StateProps {
   readonly organization: OrganizationState;
-  readonly project: ProjectState;
   readonly user: UserState;
 }
 
@@ -77,7 +77,7 @@ const style = {
   }
 } as const;
 
-const OrganizationScreen = ({ organization, project, user }: StateProps) => {
+const OrganizationScreen = ({ organization, user }: StateProps) => {
   const { organizationSlug } = useParams();
   const [projectTemplate, setProjectTemplate] = useState<CreateProjectData | undefined>(undefined);
   const history = useHistory();
@@ -88,17 +88,8 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
     "resource" in organization &&
     organization.resource &&
     checkIfUserInOrg(organization.resource, user.resource);
-  const userLoggedIn = "resource" in user && user.resource;
 
   const userIsVerified = "resource" in user && user.resource && user.resource.isEmailVerified;
-
-  useEffect(() => {
-    !userLoggedIn &&
-      "resource" in user &&
-      user.resource &&
-      project.showCopyMapModal &&
-      store.dispatch(showCopyMapModal(false));
-  }, [user, project.showCopyMapModal]);
 
   useEffect(() => {
     isLoggedIn && store.dispatch(userFetch());
@@ -187,8 +178,8 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                 </Flex>
               ) : "resource" in user && user.resource ? (
                 userIsVerified ? (
-                  <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
-                    <Button sx={style.join} disabled={!userIsVerified}>
+                  <Flex sx={{ flexDirection: "column", flex: "none" }}>
+                    <Button sx={style.join} disabled={!userIsVerified} onClick={signupAndJoinOrg}>
                       Join organization
                     </Button>
                     <Box sx={style.joinText}>
@@ -200,8 +191,8 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                     key={1}
                     content={<div>You must confirm your email before joining an organization</div>}
                   >
-                    <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
-                      <Button sx={style.join} disabled={!userIsVerified}>
+                    <Flex sx={{ flexDirection: "column", flex: "none" }}>
+                      <Button sx={style.join} disabled={!userIsVerified} onClick={signupAndJoinOrg}>
                         Join organization
                       </Button>
                       <Box sx={style.joinText}>
@@ -211,8 +202,10 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
                   </Tooltip>
                 )
               ) : (
-                <Flex sx={{ flexDirection: "column", flex: "none" }} onClick={signupAndJoinOrg}>
-                  <Button sx={style.join}>Join organization</Button>
+                <Flex sx={{ flexDirection: "column", flex: "none" }}>
+                  <Button sx={style.join} onClick={signupAndJoinOrg}>
+                    Join organization
+                  </Button>
                   <Box sx={style.joinText}>
                     Register for an account to start making district maps with this organization
                   </Box>
@@ -259,7 +252,6 @@ const OrganizationScreen = ({ organization, project, user }: StateProps) => {
 function mapStateToProps(state: State): StateProps {
   return {
     organization: state.organization,
-    project: state.project,
     user: state.user
   };
 }


### PR DESCRIPTION
## Overview

We were already doing this for the "Join this organization" button, but now we also disable the "Use this template" button.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/110350209-7919f900-8001-11eb-8519-0a4f449e7938.png)


### Notes

This is only the first half of #610, opening this now to avoid conflicts w/ @kevinearldenny 

## Testing Instructions

- `scripts/server`

Connects to #610
