### PR TITLE
Display organizations dropdown in SiteHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require users to confirm before joining an organization [#593](https://github.com/PublicMapping/districtbuilder/pull/593) & [#615](https://github.com/PublicMapping/districtbuilder/pull/615)
 - Show not found page for missing projects and organizations [#613](https://github.com/PublicMapping/districtbuilder/pull/613)
 - Add paintbrush drawing tool [#611](https://github.com/PublicMapping/districtbuilder/pull/611)
+- Display organizations dropdown in header [#620](https://github.com/PublicMapping/districtbuilder/pull/620)
 
 ### Changed
 

--- a/src/client/components/OrganizationDropdown.tsx
+++ b/src/client/components/OrganizationDropdown.tsx
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui";
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import Icon from "../components/Icon";
+import { invertStyles, style } from "./MenuButton.styles";
+import { OrganizationNest } from "../../shared/entities";
+import * as H from "history";
+import { useHistory } from "react-router-dom";
+
+interface Props {
+  readonly organizations: readonly OrganizationNest[];
+}
+
+const OrganizationDropdown = ({ organizations }: Props) => {
+  const history = useHistory();
+  return (
+    <Wrapper sx={{ position: "relative", pr: 1 }} onSelection={handleSelection(history)}>
+      <MenuButton
+        sx={{
+          ...{ variant: "buttons.ghost", fontWeight: "light" },
+          ...style.menuButton,
+          ...invertStyles({ invert: true }),
+          ...{ color: "black" }
+        }}
+        className="organization-menu"
+      >
+        My Organizations
+        <Icon name="chevron-down" />
+      </MenuButton>
+      <Menu sx={style.menu}>
+        <ul sx={style.menuList}>
+          {organizations.map(o => (
+            <li key={o.slug}>
+              <MenuItem value={o.slug} sx={style.menuListItem}>
+                {o.name}
+              </MenuItem>
+            </li>
+          ))}
+        </ul>
+      </Menu>
+    </Wrapper>
+  );
+};
+
+const handleSelection = (history: H.History) => (slug: string) => {
+  history.push(`/o/${slug}`);
+};
+
+export default OrganizationDropdown;

--- a/src/client/components/SiteHeader.tsx
+++ b/src/client/components/SiteHeader.tsx
@@ -6,6 +6,7 @@ import { Link, useHistory } from "react-router-dom";
 import * as H from "history";
 import Icon from "../components/Icon";
 import SupportMenu from "../components/SupportMenu";
+import OrganizationDropdown from "../components/OrganizationDropdown";
 import { Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
 import { ReactComponent as Logo } from "../media/logos/logo.svg";
 
@@ -132,6 +133,9 @@ const SiteHeader = ({ user }: Props) => {
       ) : "resource" in user ? (
         <React.Fragment>
           <SupportMenu />
+          {user.resource.organizations.length > 0 && (
+            <OrganizationDropdown organizations={user.resource.organizations} />
+          )}
           <Wrapper onSelection={handleSelection(history)} sx={{ ml: 3 }}>
             <MenuButton sx={style.menuButton}>
               <Avatar

--- a/src/server/src/users/controllers/users.controller.ts
+++ b/src/server/src/users/controllers/users.controller.ts
@@ -14,7 +14,7 @@ import { UsersService } from "../services/users.service";
     exclude: ["passwordHash"],
     join: {
       organizations: {
-        allow: ["slug"],
+        allow: ["slug", "name"],
         eager: true
       }
     }
@@ -43,6 +43,7 @@ import { UsersService } from "../services/users.service";
 })
 @UseGuards(JwtAuthGuard)
 @Controller("api/user")
+// @ts-ignore
 export class UsersController implements CrudController<User> {
   constructor(public service: UsersService) {}
 }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -4,7 +4,7 @@ export type UserId = string;
 
 export type PublicUserProperties = "id" | "name";
 
-export type OrganizationNest = Pick<IOrganization, "slug" | "id">;
+export type OrganizationNest = Pick<IOrganization, "slug" | "id" | "name">;
 
 export interface IUser {
   readonly id: UserId;


### PR DESCRIPTION
## Overview

Displays a list of all of the organizations that a user is currently a member of in a dropdown menu in the `SiteHeader` component

### Checklist

- [] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/110521900-53aeed00-80de-11eb-808c-49ee112b07ef.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Login as a user who is a member of an organization
- Attempt to navigate to one of their organization's pages

Closes #589 
