### PR TITLE
Build out scaffolding for Project Evaluate view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add verify and join link to user verification email [#616](https://github.com/PublicMapping/districtbuilder/pull/616)
 - Display organizations dropdown in header [#620](https://github.com/PublicMapping/districtbuilder/pull/620)
 - Organization Admin page and featured map workflow [#614](https://github.com/PublicMapping/districtbuilder/pull/614)
+- Build out scaffolding for Project Evaluate view [#623](https://github.com/PublicMapping/districtbuilder/pull/623)
 
 ### Changed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,5 +1,5 @@
 import { createAction } from "typesafe-actions";
-import { DistrictId, GeoUnits } from "../../shared/entities";
+import { DistrictId, EvaluateMetric, GeoUnits } from "../../shared/entities";
 import { SavingState } from "../types";
 
 export enum SelectionTool {
@@ -55,6 +55,11 @@ export const redo = createAction("Redo project action")();
 export const toggleFind = createAction("Toggle find menu visibility")<boolean>();
 export const setFindType = createAction("Set find menu search type")<FindTool>();
 export const setFindIndex = createAction("Set find menu polygon index")<number | undefined>();
+
+export const toggleEvaluate = createAction("Toggle evaluate mode")<boolean>();
+export const selectEvaluationMetric = createAction("Select evaluation metric")<
+  EvaluateMetric | undefined
+>();
 
 export const saveDistrictsDefinition = createAction("Save districts definition")();
 

--- a/src/client/components/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/ProjectEvaluateMetricDetail.tsx
@@ -1,0 +1,102 @@
+/** @jsx jsx */
+import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading } from "theme-ui";
+
+import { EvaluateMetric } from "../../shared/entities";
+import Icon from "./Icon";
+import { DistrictsGeoJSON } from "../types";
+import store from "../store";
+import { selectEvaluationMetric } from "../actions/districtDrawing";
+
+const style: ThemeUIStyleObject = {
+  td: {
+    fontWeight: "body",
+    color: "gray.8",
+    fontSize: 1,
+    p: 2,
+    textAlign: "left",
+    verticalAlign: "bottom"
+  },
+  header: {
+    variant: "header.app",
+    borderBottom: "1px solid",
+    borderColor: "gray.2",
+    paddingBottom: "20px",
+    flexDirection: "column",
+    m: "0"
+  },
+  closeBtn: {
+    position: "absolute",
+    right: "20px"
+  },
+  metricRow: {
+    p: 1,
+    width: "100%",
+    mb: "10px",
+    "&:hover": {
+      cursor: "pointer"
+    },
+    flexDirection: "row"
+  },
+  evaluateMetricsList: {
+    overflowY: "auto",
+    flex: 1,
+    flexDirection: "column",
+    mt: "50px"
+  },
+  metricValue: {
+    variant: "header.right",
+    position: "relative",
+    mr: "20px",
+    textAlign: "right"
+  },
+  metricText: {
+    fontSize: "10",
+    ml: "50px",
+    minHeight: "50px"
+  }
+};
+
+const ProjectEvaluateMetricDetail = ({
+  geojson,
+  metric
+}: {
+  readonly geojson?: DistrictsGeoJSON;
+  readonly metric: EvaluateMetric;
+}) => {
+  return (
+    <Flex sx={{ flexDirection: "column", height: "100vh" }}>
+      <Flex sx={style.header} className="evaluate-metric-header">
+        <Box sx={{ display: "block" }}>
+          <Button onClick={() => store.dispatch(selectEvaluationMetric(undefined))}>
+            <Icon name="chevron-left" /> Back to summary
+          </Button>
+        </Box>
+      </Flex>
+      <Box sx={{ display: "block", m: "20px", borderBottom: "1px solid gray" }}>
+        <Heading as="h2" sx={{ variant: "text.h4", m: "0" }}>
+          <Icon name={"check"} /> {metric.name}
+        </Heading>
+        <Flex sx={{ minHeight: "100px" }} className="metric-description">
+          Lorem ipsum lorem ipsum
+        </Flex>
+      </Box>
+      <Box sx={{ ml: "20px" }}>
+        <Heading as="h4" sx={{ variant: "text.h4", display: "block" }}>
+          7 / 10 districts {metric.description}
+        </Heading>
+        <Flex sx={{ flexDirection: "column" }}>
+          {geojson?.features.map(
+            d =>
+              d.properties.contiguity !== "" && (
+                <Box sx={{ display: "block" }} key={d.id}>
+                  {d.id}
+                </Box>
+              )
+          )}
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};
+
+export default ProjectEvaluateMetricDetail;

--- a/src/client/components/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/ProjectEvaluateSidebar.tsx
@@ -1,0 +1,199 @@
+/** @jsx jsx */
+import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading, Container } from "theme-ui";
+
+import { EvaluateMetric } from "../../shared/entities";
+import Icon from "./Icon";
+import { DistrictsGeoJSON } from "../types";
+import store from "../store";
+import { selectEvaluationMetric, toggleEvaluate } from "../actions/districtDrawing";
+import ProjectEvaluateMetricDetail from "./ProjectEvaluateMetricDetail";
+
+const style: ThemeUIStyleObject = {
+  sidebar: {
+    bg: "muted",
+    boxShadow: "0 0 0 1px rgba(16,22,26,.1), 0 0 0 rgba(16,22,26,0), 0 1px 1px rgba(16,22,26,.2)",
+    display: "flex",
+    flexDirection: "column",
+    flexShrink: 0,
+    height: "100%",
+    minWidth: "430px",
+    maxWidth: "35%",
+    position: "relative",
+    ml: "0",
+    color: "gray.8",
+    zIndex: 200
+  },
+  td: {
+    fontWeight: "body",
+    color: "gray.8",
+    fontSize: 1,
+    p: 2,
+    textAlign: "left",
+    verticalAlign: "bottom"
+  },
+  header: {
+    variant: "header.app",
+    borderBottom: "1px solid",
+    borderColor: "gray.2",
+    paddingBottom: "20px",
+    flexDirection: "column",
+    m: "0"
+  },
+  closeBtn: {
+    position: "absolute",
+    right: "20px"
+  },
+  metricRow: {
+    p: 1,
+    width: "100%",
+    mb: "10px",
+    "&:hover": {
+      cursor: "pointer"
+    },
+    flexDirection: "row"
+  },
+  evaluateMetricsList: {
+    overflowY: "auto",
+    flex: 1,
+    flexDirection: "column",
+    mt: "50px"
+  },
+  metricValue: {
+    variant: "header.right",
+    position: "relative",
+    mr: "20px",
+    textAlign: "right"
+  },
+  metricText: {
+    fontSize: "10",
+    ml: "50px",
+    minHeight: "50px"
+  }
+};
+
+const requiredMetrics: readonly EvaluateMetric[] = [
+  {
+    name: "Equal Population",
+    status: false,
+    description: "have equal population",
+    type: "fraction",
+    value: 17
+  },
+  {
+    name: "Contiguity",
+    status: true,
+    description: "are contiguous",
+    type: "fraction",
+    value: 18
+  }
+];
+
+const optionalMetrics: readonly EvaluateMetric[] = [
+  {
+    name: "Competitiveness",
+    description: "are competitive"
+  },
+  {
+    name: "Compactness",
+    type: "percent",
+    description: "are compact",
+    value: 56.2
+  },
+  {
+    name: "Minority-Majority",
+    type: "fraction",
+    description: "are minority-majority",
+    value: 1
+  },
+  {
+    name: "County splits",
+    type: "count",
+    description: "are split",
+    value: 15
+  }
+];
+
+const ProjectEvaluateSidebar = ({
+  geojson,
+  metric
+}: {
+  readonly geojson?: DistrictsGeoJSON;
+  readonly metric: EvaluateMetric | undefined;
+}) => {
+  function formatMetricValue(metric: EvaluateMetric): string {
+    switch (metric.type) {
+      case "fraction":
+        return `${metric.value} / 18`;
+      case "percent":
+        return `${metric.value}%`;
+      case "count":
+        return `${metric.value}`;
+      default:
+        return "";
+    }
+  }
+  return (
+    <Container sx={style.sidebar} className="evaluate-sidebar">
+      {!metric ? (
+        <Flex sx={{ flexDirection: "column", height: "100vh" }}>
+          <Flex sx={style.header} className="evaluate-header">
+            <Flex sx={{ variant: "header.left" }}>
+              <Flex>
+                <Heading as="h2" sx={{ variant: "text.h4" }}>
+                  Evaluate
+                </Heading>
+              </Flex>
+              <Flex sx={style.closeBtn}>
+                <Button onClick={() => store.dispatch(toggleEvaluate(false))}>X</Button>
+              </Flex>
+            </Flex>
+          </Flex>
+          <Flex sx={style.evaluateMetricsList}>
+            <Heading as="h4" sx={{ variant: "text.h4", ml: "15px" }}>
+              Required
+            </Heading>
+            {requiredMetrics.map(metric => (
+              <Box
+                sx={style.metricRow}
+                onClick={() => store.dispatch(selectEvaluationMetric(metric))}
+                key={metric.name}
+              >
+                <Flex sx={style.metricRow}>
+                  <Box sx={{ mr: "50px" }}>
+                    {metric.status ? <Icon name={"check"} /> : <Icon name={"question-circle"} />}
+                  </Box>
+                  <Box>{metric.name}</Box>
+                  <Box sx={style.metricValue}>{`${metric.value} / 18`}</Box>
+                </Flex>
+                <Flex sx={style.metricText}>Lorem ipsum dolor</Flex>
+              </Box>
+            ))}
+          </Flex>
+          <Flex sx={style.evaluateMetricsList}>
+            <Heading as="h4" sx={{ variant: "text.h4", ml: "15px" }}>
+              Optional
+            </Heading>
+            {optionalMetrics.map(metric => (
+              <Flex key={metric.name}>
+                <Box
+                  sx={style.metricRow}
+                  onClick={() => store.dispatch(selectEvaluationMetric(metric))}
+                >
+                  <Flex sx={style.metricRow}>
+                    <Box sx={{ ml: "50px" }}>{metric.name}</Box>
+                    <Box sx={style.metricValue}>{formatMetricValue(metric)}</Box>
+                  </Flex>
+                  <Flex sx={style.metricText}>Lorem ipsum dolor</Flex>
+                </Box>
+              </Flex>
+            ))}
+          </Flex>
+        </Flex>
+      ) : (
+        <ProjectEvaluateMetricDetail geojson={geojson} metric={metric} />
+      )}
+    </Container>
+  );
+};
+
+export default ProjectEvaluateSidebar;

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
 import { Box, Button, Flex, jsx, ThemeUIStyleObject } from "theme-ui";
 import { IProject } from "../../shared/entities";
-import { undo, redo, toggleFind } from "../actions/districtDrawing";
+import { undo, redo, toggleFind, toggleEvaluate } from "../actions/districtDrawing";
 import { heights } from "../theme";
 import CopyMapButton from "../components/CopyMapButton";
 import ExportMenu from "../components/ExportMenu";
@@ -52,11 +52,13 @@ const HeaderDivider = () => {
 
 interface StateProps {
   readonly findMenuOpen: boolean;
+  readonly evaluateMode: boolean;
   readonly undoHistory: UndoHistory;
 }
 
 const ProjectHeader = ({
   findMenuOpen,
+  evaluateMode,
   map,
   project,
   isReadOnly,
@@ -105,7 +107,7 @@ const ProjectHeader = ({
           <ShareMenu invert={true} project={project} />
           <SupportMenu invert={true} />
           {project ? <ExportMenu invert={true} project={project} /> : null}
-          <Box sx={{ position: "relative" }}>
+          <Box sx={{ position: "relative", mr: "5px" }}>
             <Button
               sx={{
                 ...{
@@ -127,6 +129,28 @@ const ProjectHeader = ({
               </Box>
             </Button>
           </Box>
+          <Box sx={{ position: "relative" }}>
+            <Button
+              sx={{
+                ...{
+                  variant: "buttons.ghost",
+                  fontWeight: "light"
+                },
+                ...menuButtonStyle.menuButton
+              }}
+              onClick={() => store.dispatch(toggleEvaluate(!evaluateMode))}
+            >
+              <Box
+                sx={{
+                  borderBottom: evaluateMode ? "solid 1px" : "none",
+                  borderBottomColor: "muted",
+                  mb: !evaluateMode ? "-1px" : "0"
+                }}
+              >
+                Evaluate
+              </Box>
+            </Button>
+          </Box>
         </React.Fragment>
       ) : (
         <React.Fragment>
@@ -140,6 +164,7 @@ const ProjectHeader = ({
 function mapStateToProps(state: State): StateProps {
   return {
     findMenuOpen: state.project.findMenuOpen,
+    evaluateMode: state.project.evaluateMode,
     undoHistory: state.project.undoHistory
   };
 }

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -23,16 +23,24 @@ import {
   undo,
   replaceSelectedGeounits,
   toggleFind,
+  toggleEvaluate,
   setFindIndex,
   setFindType,
   saveDistrictsDefinition,
   setSavingState,
-  FindTool
+  FindTool,
+  selectEvaluationMetric
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
-import { DistrictId, GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entities";
+import {
+  DistrictId,
+  EvaluateMetric,
+  GeoUnits,
+  GeoUnitsForLevel,
+  LockedDistricts
+} from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import {
   pushEffect,
@@ -99,6 +107,8 @@ export interface DistrictDrawingState {
   readonly showAdvancedEditingModal: boolean;
   readonly showCopyMapModal: boolean;
   readonly findMenuOpen: boolean;
+  readonly evaluateMode: boolean;
+  readonly evaluateMetric: EvaluateMetric | undefined;
   readonly findIndex?: number;
   readonly findTool: FindTool;
   readonly saving: SavingState;
@@ -112,6 +122,8 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   showAdvancedEditingModal: false,
   showCopyMapModal: false,
   findMenuOpen: false,
+  evaluateMode: false,
+  evaluateMetric: undefined,
   findTool: FindTool.Unassigned,
   saving: "unsaved",
   undoHistory: {
@@ -250,6 +262,16 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
         ...state,
         findMenuOpen: action.payload,
         findIndex: undefined
+      };
+    case getType(toggleEvaluate):
+      return {
+        ...state,
+        evaluateMode: action.payload
+      };
+    case getType(selectEvaluationMetric):
+      return {
+        ...state,
+        evaluateMetric: action.payload
       };
     case getType(setFindIndex):
       return {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -15,6 +15,14 @@ export interface IUser {
   readonly organizations: readonly OrganizationNest[];
 }
 
+export type EvaluateMetric = {
+  readonly name: string;
+  readonly type?: "fraction" | "percent" | "count";
+  readonly value?: number;
+  readonly status?: boolean;
+  readonly description: string;
+};
+
 export type UpdateUserData = Pick<IUser, "name" | "hasSeenTour">;
 
 export type OrganizationSlug = string;


### PR DESCRIPTION
## Overview

- Add new EvaluateMetric type
- Add ProjectEvaluateView
- Add ProjectEvaluateMetricDetail
- Build out actions for toggling evaluate mode and switching between metrics


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/110825262-dad89e00-8261-11eb-8b01-df5917368851.png)

![image](https://user-images.githubusercontent.com/66973361/110825304-e1671580-8261-11eb-8ff1-ed694e843958.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Open a project
- Click the evaluate button in the header
- _Expect_: Evaluate view displayed, with metrics listed in sidebar
- Click a metric in the sidebar
- _Expect_: Metric detail view displayed

Closes #603
