### PR TITLE
Add updates to README for loading organization data and project templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ This will proxy local all requests directed at `/api` to `https://staging.distri
 
 ### Development Data
 
+#### Using pre-processed data for existing regions organization and project templates
+
+1. Load region configs with `$ ./scripts/load-region-configs`
+1. Open up a new psql shell, `# SELECT * FROM region_config;`, and pick one of the regions to use as your testing region
+1. Copy the organization yaml template `$ cp src/manage/dev-data/org.template.yaml src/manage/data/org.yaml`
+1. Open the `manage/data/org.yaml` file in a text editor, add a name and slug and edit the `regionConfig` line to match with the ID of the region config you selected
+1. Once you have the server running, create a new user on the web frontend and confirm your email
+1. Open up a new psql shell, `SELECT * FROM "user";`, and copy your user's id to the `admin` line of `mikes.yaml`
+1. Create your organization and project templates by running `./scripts/manage/update-organization data/org.yaml`
+
+#### Processing your own data for custom regions
+
 To have data to work with, you'll need to do a two step process:
 
 1. Process the GeoJSON for your state/region (this outputs all the static files DistrictBuilder needs to work in a local directory)
@@ -129,6 +141,7 @@ In order to allow for code-sharing across the frontend and backend in conjunctio
 | `cipublish` | Publish container images to Elastic Container Registry.                   |
 | `dbshell`   | Enter a database shell.                                                   |
 | `infra`     | Execute Terraform subcommands with remote state management.               |
+| `load-region-configs`     | Loads region configurations for testing                     |
 | `manage`    | Execute commands with the `manage` CLI tool.                              |
 | `migration` | Execute TypeORM migration CLI commands.                                   |
 | `server`    | Bring up all of the services required for the project to function.        |

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ This will proxy local all requests directed at `/api` to `https://staging.distri
 #### Using pre-processed data for existing regions organization and project templates
 
 1. Load region configs with `$ ./scripts/load-region-configs`
-1. Open up a new psql shell, `# SELECT * FROM region_config;`, and pick one of the regions to use as your testing region
 1. Copy the organization yaml template `$ cp src/manage/dev-data/org.template.yaml src/manage/data/org.yaml`
+1. Open up a new psql shell, `# SELECT * FROM region_config;`, and pick one of the regions to use as your testing region
 1. Open the `manage/data/org.yaml` file in a text editor, add a name and slug and edit the `regionConfig` line to match with the ID of the region config you selected
 1. Once you have the server running, create a new user on the web frontend and confirm your email
 1. Open up a new psql shell, `SELECT * FROM "user";`, and copy your user's id to the `admin` line of `mikes.yaml`
-1. Create your organization and project templates by running `./scripts/manage/update-organization data/org.yaml`
+1. Create your organization and project templates by running `./scripts/manage update-organization data/org.yaml`
 
 #### Processing your own data for custom regions
 

--- a/src/manage/dev-data/org.template.yaml
+++ b/src/manage/dev-data/org.template.yaml
@@ -1,0 +1,21 @@
+name: {Your organization's name}
+slug:  {your-organization-slug}
+description:
+  HODOR HODOR! Hodor! Hodor hodor. Hodor? HODOR? Hodor, hodor, hodor hodor. Hodor? Hodor, hodor. Hodor. Hodor. Hodor! Hodor hodor.
+  Hodor, hodor, hodor hodor. Hodor hodor HODOR! Hodor. Hodor! Hodor hodor. HODOR? HODOR hodor, hodor. Hodor? Hodor, hodor. Hodor!
+logoUrl: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEoAAABLCAYAAADXjBHUAAACr0lEQVR4Ae3aAWQbURwG8FtbqgUAMBgAGIAB7F6zVVc6FDDAvQa7pGGAzcIMGFarLS/AGORsAENeqsDAwDCmBbUNStzLJrPB252l26GWL7KT/eP7+AtBJL98Hv7vAkZgam17J251+7WW7TTN21WKnIdkevcyJF+Yg/FYRCIWjkSsSZCIVW/ZuyASjkUkHItIOBaRcCwioVhEArCIBGARCcciEo5FJByLSDgWkXAsIuFYRMKxiARMzdiXREKgWnbovb9ApHFjeg/nF8nYT9nryfRt6j2e4ybZ583Dw6Uk8Yt1Y5/+K6TBTmXT6fDYRarj9eaqfCTvF4JR8rMFwxqDVF27mSH9SKPQj+bAN7ZX5gIJx5oQqYiVN0t0k+L15fwfx7BwJBxLANKXauWq0+FpqlV/UA1vAFgwEo4lACnV4fDsR7hIfUewcCQcSwwSgoUj4Vhl3eCWgoRg7Rq7kSFdx5FwLDlNArCKwZFwLFFNQrEmR8Kw5CABWFMhAVgikYpYTq/tZUD70yOBWHVjG3KQZjBa2V9tatmPRPr7fN25djmIjX1S0mbxNH59tHyG5JvNJafVZ2lILlIf8u8e5CuN/CncErD6jeTNym+oZHsx1epEFJIOj4fx+sVglNKw8n11/tl/dkLhlTQKByKRiIUjEQtHmhGWVk4YErEAJGJhSDPAio19BZxZMpBKb1a7eysoxGl1XyxSmVi7prcVFJLq8JFopFKwTHcvKGSgK1v5FkA8Eo5FJBwLv3ebXyQcC793k4+EYxEJxyISjkUkHItIKFbbPsuQ+nHbPiASGiLhcVptEAlIqtU7IkGNCveJBCS/D0u1Sog0ERaRcCwi4VhEArFcpDpEKgELQCIWgEQsFIlYOBKxsvePiHQOFo5ErBcjpPdjkJhvtyuXMrSF4D/LT5deJlztCVGzAAAAAElFTkSuQmCC
+linkUrl: azavea.com
+municipality: Philadelphia
+region: PA
+admin: {YOUR-USER-ID}
+projectTemplates:
+  - id: 34711584-2e4c-427d-91cf-706a14b5ddde
+    name: City Council
+    regionConfig: {YOUR-REGION-CONFIG-ID}
+    numberOfDistricts: 7
+    description: Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+    details:
+      Hodor... Hodor hodor. Hodor, hodor, hodor hodor. HODOR? Hodor, hodor. Hodor. Hodor. Hodor hodor. Hodor, hodor. Hodor. Hodor, hodor. Hodor. Hodor, hodor. Hodor. Hodor. Hodor, hodor. Hodor. Hodor. HODOR? HODOR?
+      HODOR HODOR! Hodor, hodor. Hodor. Hodor. Hodor, hodor. Hodor. Hodor. HODOR? HODOR HODOR!
+      HODOR HODOR! Hodor, hodor. Hodor. Hodor! Hodor hodor. Hodor... Hodor hodor. Hodor! Hodor hodor. Hodor hodor HODOR! Hodor. HODOR? Hodor hodor! Hodor... Hodor hodor. Hodor, hodor. Hodor. Hodor. Hodor! Hodor hodor. Hodor... Hodor hodor. Hodor... Hodor hodor.
+      Hodor? Hodor, hodor. Hodor. Hodor. Hodor hodor! Hodor, hodor, hodor hodor. Hodor? HODOR hodor, hodor. Hodor hodor! Hodor? Hodor, hodor, hodor hodor.


### PR DESCRIPTION
## Overview

We have a section in the README about loading custom regions, but haven't updated it since we added the `load-region-configs` script in #575 . We also haven't made any mentions of how to set up organizations, which is pretty essential for the ongoing dev work in the current sprint. 

Mike made a YAML file that I had been using locally, but it seems like it would be useful to have this as a template for others to create their own regions. Since `regionConfig` is a UUID, they will need to get this from the database each time they setup their project. Same with the `admin` / userId. 

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

As discussed with @maurizi , we may want to make an `manage` command to load some generic data here for an organization for external users, but I think that the ability to create an organization from a semi-filled in template is probably a nice thing to have available in the repo for the long term regardless.


