### PR TITLE
Fix showing join organization for logged in users

### DIFF
--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -12,7 +12,6 @@ import { AuthModalContent } from "./AuthComponents";
 import ConfirmJoinOrganization from "./ConfirmJoinOrganization";
 import { Resource } from "../resource";
 import { CreateProjectData } from "../../shared/entities";
-import { useEffect } from "react";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -49,10 +48,6 @@ const JoinOrganizationModal = ({
   readonly projectTemplate?: CreateProjectData;
 }) => {
   const hideModal = () => store.dispatch(showCopyMapModal(false));
-
-  useEffect(() => {
-    "resource" in user && showModal && store.dispatch(showCopyMapModal(false));
-  }, [user, showModal]);
 
   return showModal ? (
     <AriaModal


### PR DESCRIPTION
## Overview

Removes seemingly unneeded useEffect that would hide the modal immediately after it was shown.

This was introduced in https://github.com/PublicMapping/districtbuilder/commit/32ffcb6cf0e8fdfd6391941503b49cc90fcdee57 though I can't figure out what it was intended to do.

## Testing Instructions

- Log in as a verified user
- Go to an organization you are not a member of
- Try and join - on `develop` the modal will open and then immediately close, on this branch it will open and stay open
