### PR TITLE
Exclude the 'districts' column from Project detail response

### DIFF
--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -67,6 +67,8 @@ import { Errors } from "../../../../shared/types";
     }
   },
   query: {
+    // This is a pretty heavy column, and is exposed by the export/geojson endpoint separately
+    exclude: ["districts"],
     join: {
       projectTemplate: {
         exclude: ["districtsDefinition"],


### PR DESCRIPTION
## Overview

Realized this was accidentally being included in the project data, when the frontend ignores it and gets it through the existing `export/geojson` endpoint.

Probably best not to include it unnecessarily since this can be a potentially massive column.

This is an oversight from #567 

## Testing Instructions

- `scripts/server`
- The project page should continue to function
