### PR TITLE
Allow a user to create a project from an organization's template from the Create Project screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display featured projects on Organization page [#633](https://github.com/PublicMapping/districtbuilder/pull/633)
 - Add import plan page [#639](https://github.com/PublicMapping/districtbuilder/pull/639)
 - Add project evaluate view for compactness [#646](https://github.com/PublicMapping/districtbuilder/pull/646)
+- Allow user to create a project with an organization template from Create Project screen [#638](https://github.com/PublicMapping/districtbuilder/pull/638)
 
 ### Changed
 

--- a/src/client/components/OrganizationTemplates.tsx
+++ b/src/client/components/OrganizationTemplates.tsx
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+import { IOrganization, IUser, CreateProjectData } from "../../shared/entities";
+import { Box, Heading, jsx } from "theme-ui";
+import TemplateCard from "./TemplateCard";
+
+interface Props {
+  readonly organization: IOrganization;
+  readonly user: IUser | undefined;
+}
+
+interface IProps {
+  readonly setTemplate?: (template: CreateProjectData) => void;
+}
+
+const style = {
+  templates: {
+    py: 5
+  },
+  container: {
+    flexDirection: "row",
+    width: "large",
+    mx: "auto",
+    "> *": {
+      mx: 5
+    },
+    "> *:last-of-type": {
+      mr: 0
+    },
+    "> *:first-of-type": {
+      ml: 0
+    }
+  },
+  templateContainer: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, 1fr)",
+    gridGap: "15px",
+    justifyContent: "space-between",
+    marginTop: "4"
+  }
+} as const;
+
+const OrganizationTemplates = ({ organization, user, setTemplate }: Props & IProps) => {
+  return (
+    <Box sx={style.container}>
+      {organization.projectTemplates.length > 0 && (
+        <Box sx={style.templates}>
+          <Heading as="h2" sx={{ mb: "3" }}>
+            Templates
+          </Heading>
+          Start a new map using the official settings from {organization.name}
+          <Box sx={style.templateContainer}>
+            {organization.projectTemplates.map(template => (
+              <TemplateCard
+                template={template}
+                key={template.id}
+                setTemplate={setTemplate}
+                organization={organization}
+                user={user}
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default OrganizationTemplates;

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -1,0 +1,134 @@
+/** @jsx jsx */
+import {
+  IOrganization,
+  IProjectTemplate,
+  IUser,
+  CreateProjectData,
+  IProject
+} from "../../shared/entities";
+import { Box, Button, Flex, Heading, jsx, Text } from "theme-ui";
+import { useHistory } from "react-router-dom";
+import { createProject } from "../api";
+import { getJWT } from "../jwt";
+import Tooltip from "./Tooltip";
+import store from "../store";
+import { showCopyMapModal } from "../actions/districtDrawing";
+
+const style = {
+  template: {
+    flexDirection: "column",
+    padding: "15px",
+    bg: "#fff",
+    borderRadius: "2px",
+    boxShadow: "small"
+  },
+  useTemplateBtn: {
+    width: "100%",
+    background: "lightgray",
+    color: "black"
+  }
+} as const;
+
+function checkIfUserInOrg(org: IOrganization, user: IUser) {
+  const userExists = org.users.filter(u => {
+    return u.id === user.id;
+  });
+  return userExists.length > 0;
+}
+
+const TemplateCard = ({
+  template,
+  user,
+  organization,
+  setTemplate
+}: {
+  readonly template: IProjectTemplate;
+  readonly organization: IOrganization;
+  readonly user: IUser | undefined;
+  readonly setTemplate: ((template: CreateProjectData) => void) | undefined;
+}) => {
+  const userIsVerified = user?.isEmailVerified;
+  const isLoggedIn = getJWT() !== null;
+  const userInOrg = user && checkIfUserInOrg(organization, user);
+  const history = useHistory();
+
+  function createProjectFromTemplate(template: CreateProjectData) {
+    void createProject(template).then((project: IProject) =>
+      history.push(`/projects/${project.id}`)
+    );
+  }
+
+  function setupProjectFromTemplate(template: IProjectTemplate) {
+    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
+    const currentTemplate: CreateProjectData = {
+      name,
+      regionConfig,
+      numberOfDistricts,
+      districtsDefinition,
+      chamber,
+      projectTemplate: { id }
+    };
+    setTemplate && setTemplate(currentTemplate);
+    userInOrg ? createProjectFromTemplate(currentTemplate) : store.dispatch(showCopyMapModal(true));
+  }
+
+  const useButton = (
+    <Button
+      disabled={isLoggedIn && !userIsVerified}
+      onClick={() => setupProjectFromTemplate(template)}
+      sx={style.useTemplateBtn}
+    >
+      Use this template
+    </Button>
+  );
+
+  return (
+    <Flex sx={style.template}>
+      <Heading
+        as="h3"
+        sx={{
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          mb: "0"
+        }}
+      >
+        {template.name}
+      </Heading>
+      <Text
+        sx={{
+          fontSize: "2",
+          margin: "4px 0 2px"
+        }}
+      >
+        {template.regionConfig.name} · {template.numberOfDistricts}
+      </Text>
+      <Text
+        sx={{
+          fontSize: "1",
+          mb: "3"
+        }}
+      >
+        {template.description}
+      </Text>
+      {userIsVerified || !isLoggedIn ? (
+        useButton
+      ) : (
+        <Tooltip
+          key={template.id}
+          content={
+            <div>
+              {userInOrg
+                ? "You must confirm your email before using your organization's template"
+                : "You must confirm your email before using this organization's template"}
+            </div>
+          }
+        >
+          <Box>{useButton}</Box>
+        </Tooltip>
+      )}
+    </Flex>
+  );
+};
+
+export default TemplateCard;

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -106,28 +106,6 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
   };
 
   const style: ThemeUIStyleObject = {
-    orgCard: {
-      left: "40%",
-      flexDirection: "column",
-      padding: "15px",
-      bg: "#fff",
-      borderRadius: "2px",
-      mx: "auto",
-      my: "20px",
-      maxWidth: "medium",
-      boxShadow: "small"
-    },
-    userOrgs: {
-      left: "40%",
-      display: "block",
-      minHeight: "100px",
-      border: "1px solid black",
-      width: "100%",
-      maxWidth: "medium",
-      my: 7,
-      mx: "auto",
-      padding: "10px"
-    },
     header: {
       py: 3,
       px: 5,
@@ -203,7 +181,6 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       mb: "10px"
     },
     orgTemplates: {
-      left: "40%",
       display: "block",
       minHeight: "100px",
       pl: "5px",
@@ -212,7 +189,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       },
       mx: "auto",
       width: "100%",
-      maxWidth: "medium",
+      maxWidth: "large",
       borderTop: "1px solid lightgray",
       my: 7
     }
@@ -253,57 +230,59 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
         </Heading>
       </Flex>
       <Flex as="main" sx={{ width: "100%", display: "block" }}>
-        {"resource" in user && user.resource.organizations.length > 0 && (
-          <Box sx={style.orgCard}>
-            <Heading as="h3" sx={style.orgCardLabel}>
-              Organization
-            </Heading>
-            <Box sx={style.orgCardSubtitle}>
-              Are you making a new map with an organization you&apos;ve joined?
-            </Box>
-            <div
-              sx={{
-                flex: "0 0 50%",
-                "@media screen and (max-width: 770px)": {
-                  flex: "0 0 100%"
-                }
-              }}
-              key="custom"
-            >
-              <Label>
-                <Radio
-                  name="organization"
-                  value=""
-                  onChange={onOrgChanged}
-                  checked={organizationSlug === undefined}
-                />
-                <Flex as="span" sx={{ flexDirection: "column" }}>
-                  <div sx={style.radioHeading}>No organization</div>
-                  <div sx={style.radioSubHeading}>Continue without an organization</div>
-                </Flex>
-              </Label>
-            </div>
-            {user.resource.organizations.map(org => (
-              <Label
-                key={org.slug}
+        <Flex sx={style.formContainer}>
+          {"resource" in user && user.resource.organizations.length > 0 && (
+            <Card sx={{ variant: "card.flat" }}>
+              <Heading as="h3" sx={style.orgCardLabel}>
+                Organization
+              </Heading>
+              <Box sx={style.orgCardSubtitle}>
+                Are you making a new map with an organization you&apos;ve joined?
+              </Box>
+              <div
                 sx={{
-                  display: "inline-flex",
-                  "@media screen and (min-width: 750px)": {
-                    flex: "0 0 48%",
-                    "&:nth-of-type(even)": {
-                      mr: "2%"
-                    }
+                  flex: "0 0 50%",
+                  "@media screen and (max-width: 770px)": {
+                    flex: "0 0 100%"
                   }
                 }}
+                key="custom"
               >
-                <Radio name="organization" value={org.slug} onChange={onOrgChanged} />
-                <Flex as="span" sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}>
-                  <div sx={style.radioHeading}>{org.name}</div>
-                </Flex>
-              </Label>
-            ))}
-          </Box>
-        )}
+                <Label>
+                  <Radio
+                    name="organization"
+                    value=""
+                    onChange={onOrgChanged}
+                    checked={organizationSlug === undefined}
+                  />
+                  <Flex as="span" sx={{ flexDirection: "column" }}>
+                    <div sx={style.radioHeading}>No organization</div>
+                    <div sx={style.radioSubHeading}>Continue without an organization</div>
+                  </Flex>
+                </Label>
+              </div>
+              {user.resource.organizations.map(org => (
+                <Label
+                  key={org.slug}
+                  sx={{
+                    display: "inline-flex",
+                    "@media screen and (min-width: 750px)": {
+                      flex: "0 0 48%",
+                      "&:nth-of-type(even)": {
+                        mr: "2%"
+                      }
+                    }
+                  }}
+                >
+                  <Radio name="organization" value={org.slug} onChange={onOrgChanged} />
+                  <Flex as="span" sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}>
+                    <div sx={style.radioHeading}>{org.name}</div>
+                  </Flex>
+                </Label>
+              ))}
+            </Card>
+          )}
+        </Flex>
         {"resource" in organization && "resource" in user && organizationSlug && (
           <Box sx={style.orgTemplates}>
             <OrganizationTemplates user={user.resource} organization={organization.resource} />

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -106,6 +106,28 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
   };
 
   const style: ThemeUIStyleObject = {
+    orgCard: {
+      left: "40%",
+      flexDirection: "column",
+      padding: "15px",
+      bg: "#fff",
+      borderRadius: "2px",
+      mx: "auto",
+      my: "20px",
+      maxWidth: "medium",
+      boxShadow: "small"
+    },
+    userOrgs: {
+      left: "40%",
+      display: "block",
+      minHeight: "100px",
+      border: "1px solid black",
+      width: "100%",
+      maxWidth: "medium",
+      my: 7,
+      mx: "auto",
+      padding: "10px"
+    },
     header: {
       py: 3,
       px: 5,
@@ -174,17 +196,6 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       paddingInlineEnd: "0",
       paddingBlockEnd: "0"
     },
-    userOrgs: {
-      left: "40%",
-      display: "block",
-      minHeight: "100px",
-      border: "1px solid black",
-      width: "100%",
-      maxWidth: "medium",
-      my: 7,
-      mx: "auto",
-      padding: "10px"
-    },
     orgCardLabel: {
       mt: "5px"
     },
@@ -202,6 +213,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       mx: "auto",
       width: "100%",
       maxWidth: "medium",
+      borderTop: "1px solid lightgray",
       my: 7
     }
   };
@@ -242,7 +254,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       </Flex>
       <Flex as="main" sx={{ width: "100%", display: "block" }}>
         {"resource" in user && user.resource.organizations.length > 0 && (
-          <Flex sx={style.userOrgs}>
+          <Box sx={style.orgCard}>
             <Heading as="h3" sx={style.orgCardLabel}>
               Organization
             </Heading>
@@ -287,11 +299,10 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                 <Radio name="organization" value={org.slug} onChange={onOrgChanged} />
                 <Flex as="span" sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}>
                   <div sx={style.radioHeading}>{org.name}</div>
-                  <div sx={style.radioSubHeading}>{org.slug}</div>
                 </Flex>
               </Label>
             ))}
-          </Flex>
+          </Box>
         )}
         {"resource" in organization && "resource" in user && organizationSlug && (
           <Box sx={style.orgTemplates}>


### PR DESCRIPTION
## Overview

- Refactors `OrganizationTemplates` and `TemplateCard` into a new component outside of `OrganizationScreen`
- Renders `OrganizationTemplates` component in `CreateProjectScreen` to allow users to create a project from a template

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

### Notes

- I still haven't tested this with multiple templates / multiple organizations, but I see no reason why it shouldn't work, conceptually. May need to do a bit of styling fix-up, but I think it's in the right direction currently.
- There are gonna be some gnarly merge conflicts with #633 here on `OrganizationScreen`. Am wondering which way it will be easier to resolve these - since the refactor of `OrganizationTemplates` is in this branch, it might make sense to merge this one in first?


## Testing Instructions

- With a user who has joined an organization that has at least one template - click 'New Map' from the home screen
- Expect: list of organizations you are a part of to be displayed
- Select the radio button for one of your organizations
- Expect: organization project templates displayed
- Click on a template to create a new project
- Expect: new project created from template

Closes #598 
