### PR TITLE
Display Evaluate Mode metric view for County Splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add import plan page [#639](https://github.com/PublicMapping/districtbuilder/pull/639)
 - Add project evaluate view for compactness [#646](https://github.com/PublicMapping/districtbuilder/pull/646)
 - Allow user to create a project with an organization template from Create Project screen [#638](https://github.com/PublicMapping/districtbuilder/pull/638)
+- Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
 
 ### Changed
 

--- a/src/client/actions/regionConfig.ts
+++ b/src/client/actions/regionConfig.ts
@@ -1,8 +1,19 @@
 import { createAction } from "typesafe-actions";
-import { IRegionConfig } from "../../shared/entities";
+import { IRegionConfig, RegionConfigId, RegionLookupProperties } from "../../shared/entities";
 
 export const regionConfigsFetch = createAction("Region configs fetch")();
 export const regionConfigsFetchSuccess = createAction("Region configs fetch success")<
   readonly IRegionConfig[]
 >();
 export const regionConfigsFetchFailure = createAction("Region configs fetch failure")<string>();
+
+export const regionPropertiesFetch = createAction("Region properties fetch")<{
+  readonly regionConfigId: RegionConfigId;
+  readonly geoLevel: string;
+}>();
+export const regionPropertiesFetchSuccess = createAction("Region properties fetch success")<
+  readonly RegionLookupProperties[]
+>();
+export const regionPropertiesFetchFailure = createAction("Region properties fetch failure")<
+  string
+>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -14,7 +14,8 @@ import {
   UpdateProjectData,
   UpdateUserData,
   UserId,
-  DistrictsDefinition
+  DistrictsDefinition,
+  RegionConfigId
 } from "../shared/entities";
 import { DistrictsGeoJSON, DynamicProjectData, OrgProject } from "./types";
 import { getJWT, setJWT } from "./jwt";
@@ -185,6 +186,20 @@ export async function fetchRegionConfigs(): Promise<IRegionConfig> {
     apiAxios
       .get("/api/region-configs?sort=name,ASC")
       .then(response => resolve(response.data))
+      .catch(error => reject(error.message));
+  });
+}
+
+export async function fetchRegionProperties(
+  region: RegionConfigId,
+  geoLevel: string
+): Promise<readonly Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .get(`/api/region-configs/${region}/properties/${geoLevel}?fields=name`)
+      .then(response => {
+        resolve(response.data);
+      })
       .catch(error => reject(error.message));
   });
 }

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -1,12 +1,18 @@
 /** @jsx jsx */
 import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading } from "theme-ui";
-
-import { EvaluateMetric } from "../../../shared/entities";
+import {
+  EvaluateMetric,
+  IProject,
+  IStaticMetadata,
+  RegionLookupProperties
+} from "../../../shared/entities";
 import Icon from "../Icon";
 import { DistrictsGeoJSON } from "../../types";
 import store from "../../store";
 import { selectEvaluationMetric } from "../../actions/districtDrawing";
 import CompactnessMetricDetail from "./detail/Compactness";
+import CountySplitMetricDetail from "./detail/CountySplit";
+import { Resource } from "../../resource";
 
 const style: ThemeUIStyleObject = {
   td: {
@@ -52,53 +58,77 @@ const style: ThemeUIStyleObject = {
   },
   metricText: {
     fontSize: "10",
+    ml: "50px",
     minHeight: "100px",
     fontWeight: "400"
+  },
+  metricDescription: {
+    fontWeight: "500",
+    color: "gray.8",
+    minHeight: "200px"
   }
 };
 
 const ProjectEvaluateMetricDetail = ({
   geojson,
-  metric
+  metric,
+  project,
+  regionProperties,
+  geoLevel,
+  staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
   readonly metric: EvaluateMetric;
+  readonly project?: IProject;
+  readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
+  readonly geoLevel: string;
+  readonly staticMetadata?: IStaticMetadata;
 }) => {
   return (
-    <Flex sx={{ flexDirection: "column", height: "100vh" }}>
-      <Flex sx={style.header} className="evaluate-metric-header">
-        <Box sx={{ display: "block" }}>
-          <Button onClick={() => store.dispatch(selectEvaluationMetric(undefined))}>
-            <Icon name="chevron-left" /> Back to summary
-          </Button>
-        </Box>
-      </Flex>
-      <Box sx={{ display: "block", m: "20px", borderBottom: "1px solid gray" }}>
-        <Heading as="h2" sx={{ variant: "text.h4", m: "0" }}>
-          <Icon name={"check"} /> {metric.name}
-        </Heading>
-        <Flex sx={style.metricText}>{metric.longText || "Lorem ipsum lorem ipsum"}</Flex>
-      </Box>
-      {metric && "type" in metric && metric.key === "compactness" ? (
-        <CompactnessMetricDetail metric={metric} geojson={geojson} />
-      ) : (
-        <Box sx={{ ml: "20px" }}>
-          <Heading as="h4" sx={{ variant: "text.h4", display: "block" }}>
-            7 / 10 districts {metric.description}
+    <Box>
+      <Flex sx={{ flexDirection: "column", height: "100vh" }}>
+        <Flex sx={style.header} className="evaluate-metric-header">
+          <Box sx={{ display: "block" }}>
+            <Button onClick={() => store.dispatch(selectEvaluationMetric(undefined))}>
+              <Icon name="chevron-left" /> Back to summary
+            </Button>
+          </Box>
+        </Flex>
+        <Box sx={{ display: "block", m: "20px", borderBottom: "1px solid gray" }}>
+          <Heading as="h2" sx={{ variant: "text.h4", m: "0", textTransform: "capitalize" }}>
+            <Icon name={"check"} /> {metric.name}
           </Heading>
-          <Flex sx={{ flexDirection: "column" }}>
-            {geojson?.features.map(
-              d =>
-                d.properties.contiguity !== "" && (
-                  <Box sx={{ display: "block" }} key={d.id}>
-                    {d.id}
-                  </Box>
-                )
-            )}
-          </Flex>
+          <Flex sx={style.metricDescription}>{metric.longText || "Lorem ipsum lorem ipsum"} </Flex>
         </Box>
-      )}
-    </Flex>
+        {metric && "type" in metric && metric.key === "countySplits" ? (
+          <CountySplitMetricDetail
+            project={project}
+            metric={metric}
+            geoLevel={geoLevel}
+            regionProperties={regionProperties}
+            staticMetadata={staticMetadata}
+          />
+        ) : metric && "type" in metric && metric.key === "compactness" ? (
+          <CompactnessMetricDetail metric={metric} geojson={geojson} />
+        ) : (
+          <Box sx={{ ml: "20px" }}>
+            <Heading as="h4" sx={{ variant: "text.h4", display: "block" }}>
+              7 / 10 districts {metric.description}
+            </Heading>
+            <Flex sx={{ flexDirection: "column" }}>
+              {geojson?.features.map(
+                d =>
+                  d.properties.contiguity !== "" && (
+                    <Box sx={{ display: "block" }} key={d.id}>
+                      {d.id}
+                    </Box>
+                  )
+              )}
+            </Flex>
+          </Box>
+        )}
+      </Flex>
+    </Box>
   );
 };
 

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -145,7 +145,7 @@ const ProjectEvaluateView = ({
               onClick={() => store.dispatch(selectEvaluationMetric(metric))}
             >
               <Flex sx={style.metricRow}>
-                <Box sx={{ ml: "50px" }}>{metric.name}</Box>
+                <Box sx={{ ml: "50px", textTransform: "capitalize" }}>{metric.name}</Box>
                 <Box sx={style.metricValue}>
                   {"type" in metric ? formatMetricValue(metric) : ""}
                 </Box>

--- a/src/client/components/evaluate/detail/CountySplit.tsx
+++ b/src/client/components/evaluate/detail/CountySplit.tsx
@@ -1,0 +1,102 @@
+/** @jsx jsx */
+import { Box, Flex, jsx, ThemeUIStyleObject, Heading } from "theme-ui";
+import {
+  EvaluateMetricWithValue,
+  IProject,
+  IStaticMetadata,
+  RegionLookupProperties
+} from "../../../../shared/entities";
+import { useState, useEffect } from "react";
+import { getLabelLookup } from "../../map/labels";
+import { Resource } from "../../../resource";
+import { geoLevelLabel } from "../../../functions";
+
+const style: ThemeUIStyleObject = {
+  td: {
+    fontWeight: "body",
+    color: "gray.8",
+    fontSize: 1,
+    p: 2,
+    textAlign: "left",
+    verticalAlign: "bottom",
+    minWidth: "20px",
+    maxWidth: "200px",
+    mr: "10px"
+  },
+  fillBox: {
+    height: "10px",
+    width: "10px",
+    background: "#fed8b1",
+    opacity: "0.5",
+    outline: "1px solid black"
+  },
+  unfilledBox: {
+    height: "10px",
+    width: "10px",
+    background: "none",
+    outline: "1px solid black"
+  }
+};
+
+type CountyLookup = ReadonlyArray<string | undefined>;
+
+const CountySplitMetricDetail = ({
+  metric,
+  project,
+  staticMetadata,
+  regionProperties,
+  geoLevel
+}: {
+  readonly metric: EvaluateMetricWithValue;
+  readonly project?: IProject;
+  readonly geoLevel: string;
+  readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
+  readonly staticMetadata?: IStaticMetadata;
+}) => {
+  const [countyLookup, setCountyLookup] = useState<CountyLookup | undefined>(undefined);
+
+  useEffect(() => {
+    if ("resource" in regionProperties && !countyLookup) {
+      setCountyLookup(
+        regionProperties.resource.map(c => (typeof c.name === "string" ? c.name : undefined))
+      );
+    }
+  }, [regionProperties, countyLookup]);
+
+  return (
+    <Box sx={{ ml: "20px", overflowY: "scroll" }}>
+      <Heading as="h4" sx={{ variant: "text.h4", display: "block" }}>
+        {metric.value} / {metric.total} {geoLevelLabel(geoLevel)} {metric.description}
+      </Heading>
+      <Flex sx={{ flexDirection: "column", width: "60%" }}>
+        <table>
+          <tbody>
+            {countyLookup ? (
+              project?.districtsDefinition.map((d, id) => (
+                <tr key={id}>
+                  <td sx={style.tableElement}>
+                    {countyLookup && id in countyLookup && staticMetadata
+                      ? getLabelLookup(geoLevel, countyLookup[id])
+                      : staticMetadata
+                      ? getLabelLookup(geoLevel, undefined, id)
+                      : ""}
+                  </td>
+                  <td sx={style.tableElement}>
+                    <Box sx={Array.isArray(d) ? style.fillBox : style.unfilledBox}></Box>
+                  </td>
+                  <td sx={style.tableElement}>{Array.isArray(d) ? "Split" : "Not split"}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td>Loading...</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </Flex>
+    </Box>
+  );
+};
+
+export default CountySplitMetricDetail;

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -12,6 +12,7 @@ import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
 import DemographicsTooltip from "../DemographicsTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
+import { getLabel } from "./labels";
 
 const style: ThemeUIStyleObject = {
   tooltip: {
@@ -147,15 +148,7 @@ const MapTooltip = ({
           ));
 
         const featureLabel = () => (
-          <span sx={{ textTransform: "capitalize" }}>
-            {feature && feature.properties && typeof feature.properties.name === "string" ? (
-              feature.properties.name
-            ) : feature ? (
-              <span sx={{ textTransform: "capitalize" }}>{`${geoLevelId} #${feature.id}`}</span>
-            ) : (
-              ""
-            )}
-          </span>
+          <span sx={{ textTransform: "capitalize" }}>{getLabel(geoLevelId, feature)}</span>
         );
         const highlightedGeounitsForLevel = highlightedGeounits[geoLevelId];
         const heading =

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -29,6 +29,12 @@ export const DISTRICTS_LAYER_ID = "districts";
 export const DISTRICTS_OUTLINE_LAYER_ID = "districts-outline";
 // Id for districts layer outline used in evaluate mode
 export const DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID = "districts-compactness";
+// Id for districts layer outline used in evaluate mode
+export const DISTRICTS_EVALUATE_LAYER_ID = "districts-evaluate";
+// Id for topmost geolevel layer in Evaluate
+export const TOPMOST_GEOLEVEL_EVALUATE_SPLIT_ID = "topmost-geo-evaluate-split";
+// Id for topmost geolevel layer fill in Evaluate
+export const TOPMOST_GEOLEVEL_EVALUATE_FILL_SPLIT_ID = "topmost-geo-evaluate-split-fill";
 // Used only to make districts appear in the correct position in the layer stack
 export const DISTRICTS_PLACEHOLDER_LAYER_ID = "district-placeholder";
 // Used only to make highlights appear in the correct position in the layer stack
@@ -181,6 +187,21 @@ export function generateMapLayers(
 
   map.addLayer(
     {
+      id: DISTRICTS_EVALUATE_LAYER_ID,
+      type: "line",
+      source: DISTRICTS_SOURCE_ID,
+      layout: { visibility: "none" },
+      paint: {
+        "line-color": "#000",
+        "line-opacity": 1,
+        "line-width": ["interpolate", ["linear"], ["zoom"], 6, 2, 14, 5]
+      }
+    },
+    LABELS_PLACEHOLDER_LAYER_ID
+  );
+
+  map.addLayer(
+    {
       id: "districts-locked",
       type: "fill",
       source: DISTRICTS_SOURCE_ID,
@@ -191,6 +212,37 @@ export function generateMapLayers(
       }
     },
     DISTRICTS_PLACEHOLDER_LAYER_ID
+  );
+  map.addLayer(
+    {
+      id: TOPMOST_GEOLEVEL_EVALUATE_SPLIT_ID,
+      type: "line",
+      source: GEOLEVELS_SOURCE_ID,
+      "source-layer": geoLevels[geoLevels.length - 1].id,
+      layout: { visibility: "none" },
+      paint: {
+        "line-color": "#D3D3D3",
+        "line-opacity": 1,
+        "line-width": ["interpolate", ["linear"], ["zoom"], 6, 2, 14, 5]
+      }
+    },
+    LINES_PLACEHOLDER_LAYER_ID
+  );
+
+  map.addLayer(
+    {
+      id: TOPMOST_GEOLEVEL_EVALUATE_FILL_SPLIT_ID,
+      source: GEOLEVELS_SOURCE_ID,
+      type: "fill",
+      "source-layer": geoLevels[geoLevels.length - 1].id,
+      layout: { visibility: "none" },
+      paint: {
+        "fill-color": "#fed8b1",
+        "fill-opacity": ["case", ["boolean", ["feature-state", "split"], false], 0.5, 0.0],
+        "fill-antialias": false
+      }
+    },
+    LINES_PLACEHOLDER_LAYER_ID
   );
 
   geoLevels.forEach(level => {

--- a/src/client/components/map/labels.ts
+++ b/src/client/components/map/labels.ts
@@ -1,0 +1,22 @@
+import { MapboxGeoJSONFeature } from "mapbox-gl";
+import { geoLevelLabelSingular } from "../../functions";
+
+export function getLabel(geoLevelId?: string, feature?: MapboxGeoJSONFeature) {
+  if (feature && feature.properties && typeof feature.properties.name === "string") {
+    return feature.properties.name;
+  } else if (feature && geoLevelId) {
+    return `${geoLevelId} #${feature.id}`;
+  } else {
+    return "";
+  }
+}
+
+export function getLabelLookup(geoLevelId?: string, label?: string, index?: number) {
+  if (label) {
+    return label;
+  } else if (geoLevelId && index) {
+    return `${geoLevelLabelSingular(geoLevelId)} #${index}`;
+  } else {
+    return "";
+  }
+}

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -136,6 +136,15 @@ export const geoLevelLabel = (id: string): string => {
   }
 };
 
+export const geoLevelLabelSingular = (id: string): string => {
+  switch (id) {
+    case "county":
+      return "County";
+    default:
+      return id[0].toUpperCase() + id.slice(1);
+  }
+};
+
 export function getSelectedGeoLevel(geoLevelHierarchy: GeoLevelHierarchy, geoLevelIndex: number) {
   return geoLevelHierarchy[geoLevelHierarchy.length - 1 - geoLevelIndex];
 }

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -26,14 +26,13 @@ import { InputField, SelectField } from "../components/Field";
 import FormError from "../components/FormError";
 import { State } from "../reducers";
 import { UserState } from "../reducers/user";
-import { RegionConfigState } from "../reducers/regionConfig";
-import { WriteResource } from "../resource";
+import { WriteResource, Resource } from "../resource";
 import store from "../store";
 import { OrganizationState } from "../reducers/organization";
 import OrganizationTemplates from "../components/OrganizationTemplates";
 
 interface StateProps {
-  readonly regionConfigs: RegionConfigState;
+  readonly regionConfigs: Resource<readonly IRegionConfig[]>;
   readonly organization: OrganizationState;
   readonly user: UserState;
 }
@@ -507,7 +506,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
 
 function mapStateToProps(state: State): StateProps {
   return {
-    regionConfigs: state.regionConfig,
+    regionConfigs: state.regionConfig.regionConfigs,
     organization: state.organization,
     user: state.user
   };

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -15,12 +15,11 @@ import { InputField } from "../components/Field";
 import Icon from "../components/Icon";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 import { State } from "../reducers";
-import { RegionConfigState } from "../reducers/regionConfig";
-import { WriteResource } from "../resource";
+import { WriteResource, Resource } from "../resource";
 import store from "../store";
 
 interface StateProps {
-  readonly regionConfigs: RegionConfigState;
+  readonly regionConfigs: Resource<readonly IRegionConfig[]>;
 }
 
 const validate = (form: ProjectForm) =>
@@ -337,7 +336,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
 
 function mapStateToProps(state: State): StateProps {
   return {
-    regionConfigs: state.regionConfig
+    regionConfigs: state.regionConfig.regionConfigs
   };
 }
 

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -11,6 +11,7 @@ import {
   GeoUnitHierarchy,
   IProject,
   IStaticMetadata,
+  RegionLookupProperties,
   IUser,
   UintArrays,
   EvaluateMetric
@@ -43,6 +44,7 @@ interface StateProps {
   readonly staticMetadata?: IStaticMetadata;
   readonly staticGeoLevels: UintArrays;
   readonly projectNotFound?: boolean;
+  readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly evaluateMode: boolean;
   readonly evaluateMetric: EvaluateMetric | undefined;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
@@ -71,6 +73,7 @@ const ProjectScreen = ({
   staticGeoLevels,
   evaluateMode,
   evaluateMetric,
+  regionProperties,
   projectNotFound,
   geoUnitHierarchy,
   districtDrawing,
@@ -146,7 +149,13 @@ const ProjectScreen = ({
             isReadOnly={isReadOnly}
           />
         ) : (
-          <ProjectEvaluateSidebar geojson={geojson} metric={evaluateMetric} project={project} />
+          <ProjectEvaluateSidebar
+            geojson={geojson}
+            metric={evaluateMetric}
+            project={project}
+            regionProperties={regionProperties}
+            staticMetadata={staticMetadata}
+          />
         )}
         <Flex sx={{ flexDirection: "column", flex: 1, background: "#fff" }}>
           {!evaluateMode ? (
@@ -218,6 +227,7 @@ function mapStateToProps(state: State): StateProps {
     evaluateMode: state.project.evaluateMode,
     evaluateMetric: state.project.evaluateMetric,
     districtDrawing: state.project,
+    regionProperties: state.regionConfig.regionProperties,
     isLoading:
       ("isPending" in state.project.projectData && state.project.projectData.isPending) ||
       ("isPending" in state.project.staticData && state.project.staticData.isPending),

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,8 +1,11 @@
 import {
   BadRequestException,
   Controller,
+  Get,
   InternalServerErrorException,
   Logger,
+  Param,
+  Query,
   UseGuards
 } from "@nestjs/common";
 import {
@@ -13,11 +16,15 @@ import {
   ParsedBody,
   ParsedRequest
 } from "@nestjsx/crud";
+import { OptionalJwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { TopologyService } from "../../districts/services/topology.service";
 import { QueryFailedError } from "typeorm";
-
+import { RegionLookupProperties } from "../../../../shared/entities";
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RegionConfig } from "../entities/region-config.entity";
 import { RegionConfigsService } from "../services/region-configs.service";
+import { GeometryCollection } from "topojson-specification";
+import * as _ from "lodash";
 
 @Crud({
   model: {
@@ -35,7 +42,6 @@ import { RegionConfigsService } from "../services/region-configs.service";
     only: ["createOneBase", "getManyBase"]
   }
 })
-@UseGuards(JwtAuthGuard)
 @Controller("api/region-configs")
 // @ts-ignore
 export class RegionConfigsController implements CrudController<RegionConfig> {
@@ -43,9 +49,10 @@ export class RegionConfigsController implements CrudController<RegionConfig> {
     return this;
   }
   private readonly logger = new Logger(RegionConfigsController.name);
-  constructor(public service: RegionConfigsService) {}
+  constructor(public service: RegionConfigsService, public topologyService: TopologyService) {}
 
   @Override()
+  @UseGuards(JwtAuthGuard)
   async createOne(
     @ParsedRequest() req: CrudRequest,
     @ParsedBody() dto: RegionConfig
@@ -65,6 +72,35 @@ export class RegionConfigsController implements CrudController<RegionConfig> {
         this.logger.error(`Error creating region config: ${error}`);
         throw new InternalServerErrorException();
       }
+    }
+  }
+
+  @Get(":regionId/properties/:geounit")
+  @UseGuards(OptionalJwtAuthGuard)
+  async getRegionProperties(
+    @Param("regionId") regionId: string,
+    @Param("geounit") geounit: string,
+    @Query("fields") fields: string[]
+  ): Promise<RegionLookupProperties[]> {
+    const regionConfig = await this.service.findOne({ id: regionId });
+
+    const geoCollection = regionConfig && (await this.topologyService.get(regionConfig.s3URI));
+    if (!geoCollection) {
+      throw new InternalServerErrorException();
+    }
+    const geoUnitLayer = geoCollection.topology.objects[geounit] as GeometryCollection;
+    if (fields) {
+      return geoUnitLayer.geometries.map(f => {
+        if (f.properties) {
+          return _.pick(f.properties, fields);
+        } else {
+          return {};
+        }
+      });
+    } else {
+      return geoUnitLayer.geometries.map(f => {
+        return f?.properties || {};
+      });
     }
   }
 }

--- a/src/server/src/region-configs/region-configs.module.ts
+++ b/src/server/src/region-configs/region-configs.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { RegionConfigsController } from "./controllers/region-configs.controller";
 import { RegionConfig } from "./entities/region-config.entity";
 import { RegionConfigsService } from "./services/region-configs.service";
+import { TopologyService } from "../districts/services/topology.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([RegionConfig])],
   controllers: [RegionConfigsController],
-  providers: [RegionConfigsService],
+  providers: [RegionConfigsService, TopologyService],
   exports: [RegionConfigsService, TypeOrmModule]
 })
 export class RegionConfigsModule {}

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -266,3 +266,4 @@ export type LockedDistricts = readonly boolean[];
 
 export type UintArray = Uint8Array | Uint16Array | Uint32Array;
 export type UintArrays = ReadonlyArray<UintArray>;
+export type RegionLookupProperties = Record<string, unknown>;


### PR DESCRIPTION
## Overview

- Displays the number of counties / top-level geounits that are split across multiple districts in `ProjectEvaluateSummary`
- Adds a new sidebar display, `CountySplit`, with a list of all counties / geo-units* by name and a marker identifying the counties that are split across multiple districts
- Updates the map view when the County Split metric is selected to display a layer of the counties that are split across multiple districts
- Adds a legend to the map

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/112385003-7556c980-8cc5-11eb-827f-161d622a96f4.png)


### Notes

* For Dane County, do the blockgroups have a `name` property?
~** I'm encountering a slight bug here where the county names are lost if you close the metric and re-open it... I know that there is a React Hook-based solution I could employ here, but figured I'd get a draft PR up now for you to take a look~ Fixed 💯 , now ready for review


## Testing Instructions

- `./scripts/server`
- Select a project that has counties split across multiple districts, and click 'Evaluate'
- Expect: County Split metric is displayed with a real computed value
- Click the 'County Split' metric
- Expect: County Split view is displayed as above

Closes #608 
