### PR TITLE
Fix showing organization logo

### DIFF
--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -36,6 +36,7 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
         "organization.name",
         "organization.description",
         "organization.linkUrl",
+        "organization.logoUrl",
         "organization.municipality",
         "organization.region",
         "users.id",


### PR DESCRIPTION
## Overview

This field was mistakenly omitted when converting from using `nestjsx-crud` to using TypeORM directly, and was breaking loading the logo on the organization screen.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

Closes #XXX
