### PR TITLE
Make featured maps in OrganizationScreen clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project districts geojson is now cached in the project table when updated [#594](https://github.com/PublicMapping/districtbuilder/pull/594)
 - Upgrade NestJS deps [#637](https://github.com/PublicMapping/districtbuilder/pull/637)
 - Refactor project evaluate mode views [#642](https://github.com/PublicMapping/districtbuilder/pull/642)
+- Link featured projects in Organization screen to project detail pages [#657](https://github.com/PublicMapping/districtbuilder/pull/657)
 
 ### Fixed
 

--- a/src/client/components/FeaturedProjectCard.tsx
+++ b/src/client/components/FeaturedProjectCard.tsx
@@ -5,6 +5,7 @@ import MapboxGL from "mapbox-gl";
 import { useEffect, useRef, useState } from "react";
 import bbox from "@turf/bbox";
 import { getDistrictColor } from "../constants/colors";
+import { useHistory } from "react-router-dom";
 
 import { BBox2d } from "@turf/helpers/lib/geojson";
 
@@ -13,7 +14,10 @@ const style = {
     flexDirection: "column",
     bg: "#fff",
     borderRadius: "2px",
-    boxShadow: "small"
+    boxShadow: "small",
+    "&:hover": {
+      cursor: "pointer"
+    }
   },
   mapContainer: {
     width: "100%",
@@ -39,6 +43,11 @@ const style = {
 const FeaturedProjectCard = ({ project }: { readonly project: OrgProject }) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
+  const history = useHistory();
+
+  function goToProject(project: OrgProject) {
+    history.push(`/projects/${project.id}`);
+  }
 
   useEffect(() => {
     if (mapRef.current === null) {
@@ -87,7 +96,7 @@ const FeaturedProjectCard = ({ project }: { readonly project: OrgProject }) => {
   }, [mapRef, project.districts]);
 
   return (
-    <Flex sx={style.featuredProject}>
+    <Flex sx={style.featuredProject} onClick={() => goToProject(project)}>
       <Box sx={style.mapContainer}>
         <Box ref={mapRef} sx={style.map}></Box>
       </Box>


### PR DESCRIPTION
## Overview

- Adds functionality to link Featured Project cards displayed in the `OrganizationScreen` for navigating to the project detail view when clicked
- Adds a hover cursor to featured projects to identify link functionality

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

@tgilcrest @jfrankl There is the possibility of encountering an error here, if an admin has set a project as featured that has not  set the project's visibility as Visible or Published. If a user tries to navigate to a featured project that is Private, they currently receive a 404 error and "Project not found". We should probably add some logic in either:

a) (likely) The `OrganizationAdminProjectsTable` to not listed projects that have not been published yet
b) The `OrganizationScreen` to filter out unpublished projects

## Testing Instructions

- Go to an organization with featured projects
- Click on a project that is either one of your own projects, or another user's project that is Visible / Published
- Expect: You are navigated to the project detail view for the selected project

Closes #650 
