### PR TITLE
Admin page improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade NestJS deps [#637](https://github.com/PublicMapping/districtbuilder/pull/637)
 - Refactor project evaluate mode views [#642](https://github.com/PublicMapping/districtbuilder/pull/642)
 - Link featured projects in Organization screen to project detail pages [#657](https://github.com/PublicMapping/districtbuilder/pull/657)
+- Add creator email and project link to Org Admin screen [#664](https://github.com/PublicMapping/districtbuilder/pull/664)
 
 ### Fixed
 

--- a/src/client/components/FeaturedProjectCard.tsx
+++ b/src/client/components/FeaturedProjectCard.tsx
@@ -116,7 +116,7 @@ const FeaturedProjectCard = ({ project }: { readonly project: OrgProject }) => {
             mb: "1"
           }}
         >
-          {project.name}
+          {project.project.name}
         </Heading>
         <Text
           sx={{

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
 import { useMemo } from "react";
-import { Button, Flex, jsx } from "theme-ui";
+import { Button, Flex, jsx, Styled } from "theme-ui";
 import store from "../store";
 import { toggleProjectFeatured } from "../actions/organizationProjects";
 import { OrganizationSlug } from "../../shared/entities";
 import { useTable, Row, HeaderGroup, Cell, useSortBy } from "react-table";
+import { Link } from "react-router-dom";
 import { OrgProject } from "../types";
 interface ProjectsTableProps {
   readonly projects: readonly OrgProject[];
@@ -27,7 +28,14 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
     () => [
       {
         Header: "Map",
-        accessor: "name" // accessor is the "key" in the data
+        accessor: "project", // accessor is the "key" in the data,
+        Cell: (p: Cell<OrgProject>) => {
+          return (
+            <Styled.a as={Link} to={`/projects/${p.value.id}`} target="_blank">
+              {p.value.name}
+            </Styled.a>
+          );
+        }
       },
       {
         Header: "Template",
@@ -35,7 +43,14 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
       },
       {
         Header: "Creator",
-        accessor: "creator"
+        accessor: "creator.name"
+      },
+      {
+        Header: "Creator email",
+        accessor: "creator.email",
+        Cell: (p: Cell<OrgProject>) => {
+          return <a href={`mailto:${p.value}`}>{p.value}</a>;
+        }
       },
       {
         Header: "Updated on",

--- a/src/client/reducers/organizationProjects.ts
+++ b/src/client/reducers/organizationProjects.ts
@@ -93,8 +93,7 @@ const organizationProjectsReducer: LoopReducer<OrganizationProjectsState, Action
     case getType(toggleProjectFeatured): {
       return loop(
         {
-          ...state,
-          featuredProjects: { isPending: true }
+          ...state
         },
         Cmd.run(
           () =>

--- a/src/client/screens/OrganizationAdminScreen.tsx
+++ b/src/client/screens/OrganizationAdminScreen.tsx
@@ -92,8 +92,10 @@ const OrganizationAdminScreen = ({ organization, user, organizationProjects }: S
             return pt.projects.map(p => {
               return {
                 ...p,
+                project: { name: p.name, id: p.id },
                 updatedAgo: formatDate(p.updatedDt),
-                creator: p.user.name,
+                creator: { name: p.user.name, email: p.user.email },
+                id: p.id,
                 templateName: pt.name,
                 regionConfig: pt.regionConfig,
                 numberOfDistricts: pt.numberOfDistricts

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -146,7 +146,8 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
               return {
                 ...p,
                 updatedAgo: formatDate(p.updatedDt),
-                creator: p.user.name,
+                creator: { name: p.user.name, email: p.user.email },
+                project: { name: p.name, id: p.id },
                 templateName: pt.name,
                 regionConfig: pt.regionConfig,
                 numberOfDistricts: pt.numberOfDistricts

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -6,7 +6,8 @@ import {
   UintArrays,
   GeoUnitHierarchy,
   DistrictProperties,
-  DistrictsDefinition
+  DistrictsDefinition,
+  ProjectId
 } from "../shared/entities";
 
 export type DistrictGeoJSON = Feature<MultiPolygon, DistrictProperties>;
@@ -38,12 +39,18 @@ export interface AuthLocationState {
 
 interface OrgProject {
   readonly id: ProjectId;
-  readonly name: string;
+  readonly project: {
+    readonly id: ProjectId;
+    readonly name: string;
+  };
+  readonly creator: {
+    readonly name: string;
+    readonly email: string;
+  };
   readonly templateName: string;
   readonly updatedAgo: string;
   readonly isFeatured: boolean;
   readonly user: Pick<IUser, PublicUserProperties>;
   readonly districts?: DistrictsGeoJSON;
   readonly districtsDefinition?: DistrictsDefinition;
-  readonly creator: string;
 }

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -30,8 +30,10 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
         "projects.id",
         "projects.updatedDt",
         "regionConfig.name",
-        "user.name"
+        "user.name",
+        "user.email"
       ])
+      .orderBy("projects.name")
       .getMany();
     return data;
   }
@@ -58,6 +60,7 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
         "regionConfig.name",
         "user.name"
       ])
+      .orderBy("projects.name")
       .getMany();
     return data;
   }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -2,7 +2,7 @@ import { ProjectVisibility } from "./constants";
 
 export type UserId = string;
 
-export type PublicUserProperties = "id" | "name";
+export type PublicUserProperties = "id" | "name" | "email";
 
 export type OrganizationNest = Pick<IOrganization, "slug" | "id" | "name" | "logoUrl">;
 


### PR DESCRIPTION
## Overview

- Adds creator email to admin project table
- Adds a link to project screen from admin project table
- (Somewhat) fixes issue with the table flickering*

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/113057421-04a72580-917b-11eb-95b8-5ce9fe528455.png)


### Notes

* Since we are currently using an endpoint on the `project_templates` controller (since the relationship linking a Project -> Organization is thru a template) but displaying projects in this table, this update operation is a bit tricky. I improved the flickering a bit by not setting `isPending` to `true` in [organizationProjects.ts](https://github.com/PublicMapping/districtbuilder/blob/dc58abc7194a80dbeb25e4959f308654a8f4f946/src/client/reducers/organizationProjects.ts), but there is still a slight flicker occurring when the table updates.

## Testing Instructions

- `./scripts/server`
- Login with an admin user
- Navigate to Org Admin page
- Expect: Table fields align with demo screenshot

Closes #659, closes #658 
