### PR TITLE
Add button to link to admin screen on org page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add import plan page [#639](https://github.com/PublicMapping/districtbuilder/pull/639)
 - Add project evaluate view for compactness [#646](https://github.com/PublicMapping/districtbuilder/pull/646)
 - Allow user to create a project with an organization template from Create Project screen [#638](https://github.com/PublicMapping/districtbuilder/pull/638)
+- Add button to Organization page to link to Organization Admin page for admin users [#669](https://github.com/PublicMapping/districtbuilder/pull/669)
 - Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
 
 ### Changed

--- a/src/client/screens/OrganizationAdminScreen.tsx
+++ b/src/client/screens/OrganizationAdminScreen.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { useEffect } from "react";
 import { connect } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { Box, Flex, Heading, jsx } from "theme-ui";
 import { organizationFetch } from "../actions/organization";
 import { organizationProjectsFetch } from "../actions/organizationProjects";
@@ -126,7 +126,9 @@ const OrganizationAdminScreen = ({ organization, user, organizationProjects }: S
           <Box>
             <Flex sx={style.header}>
               <Box>
-                <Heading as="h3">{organization.resource.name}</Heading>
+                <Heading as="h3">
+                  <Link to={`/o/${organizationSlug}`}>{organization.resource.name}</Link>
+                </Heading>
                 <Heading>Maps</Heading>
                 <Box>
                   Published maps that were created by members of your organization. You can select

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 import { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { useParams } from "react-router-dom";
-import { Box, Button, Flex, Heading, Image, jsx, Link, Spinner, Text } from "theme-ui";
+import { useParams, Link as RouterLink } from "react-router-dom";
+import { Box, Button, Flex, Heading, Image, jsx, Spinner, Text, Link } from "theme-ui";
 import { formatDate } from "../functions";
 
 import { showCopyMapModal } from "../actions/districtDrawing";
@@ -115,6 +115,10 @@ const style = {
     width: "100%",
     background: "lightgray",
     color: "black"
+  },
+  viewAllBtn: {
+    fontSize: "14pt",
+    ml: 4
   }
 } as const;
 
@@ -130,6 +134,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
     checkIfUserInOrg(organization.resource, user.resource);
 
   const userIsVerified = "resource" in user && user.resource && user.resource.isEmailVerified;
+  const orgAdminUrl = `/o/${organizationSlug}/admin`;
 
   const featuredProjects =
     "resource" in organizationProjects.featuredProjects
@@ -174,6 +179,12 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
       return u.id === user.id;
     });
     return userExists.length > 0;
+  }
+
+  function userIsOrgAdmin(org: IOrganization, user: IUser) {
+    if (org && org.admin) {
+      return org.admin.id === user.id;
+    }
   }
 
   const joinButton = (
@@ -294,7 +305,20 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
               {featuredProjects ? (
                 <Box sx={{ ...style.featuredProjects, ...style.container }}>
                   <Heading as="h2" sx={{ mb: "3" }}>
-                    Featured maps
+                    <span>Featured maps</span>
+                    <span>
+                      {"resource" in user &&
+                        "resource" in organization &&
+                        organization.resource &&
+                        userIsOrgAdmin(organization.resource, user.resource) && (
+                          <RouterLink
+                            to={orgAdminUrl}
+                            sx={{ ...style.viewAllBtn, variant: "links.button" }}
+                          >
+                            View All
+                          </RouterLink>
+                        )}
+                    </span>
                   </Heading>
                   <Text>
                     A collection of highlighted maps built by members of{" "}


### PR DESCRIPTION
## Overview

- Adds a 'View all' button to Org Screen visible only for org admins to link to the Org Admin screen
- Adds a link on the Org Admin screen to navigate back to the public Org page

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Login as an org admin user and navigate to org page
- Expect: Button appears enabling you to navigate to admin screen
- Login as a non-admin user and navigate to org page
- Expect: Button is not visible

Closes #653 
