### PR TITLE
Fix race conditions on ImportProjectScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build out scaffolding for Project Evaluate view [#623](https://github.com/PublicMapping/districtbuilder/pull/623)
 - Add flag on project templates to mark as active or inactive [#626](https://github.com/PublicMapping/districtbuilder/pull/626)
 - Display featured projects on Organization page [#633](https://github.com/PublicMapping/districtbuilder/pull/633)
-- Add import plan page [#639](https://github.com/PublicMapping/districtbuilder/pull/639)
+- Add import plan page [#639](https://github.com/PublicMapping/districtbuilder/pull/639) & [#670](https://github.com/PublicMapping/districtbuilder/pull/670)
 - Add project evaluate view for compactness [#646](https://github.com/PublicMapping/districtbuilder/pull/646)
 - Allow user to create a project with an organization template from Create Project screen [#638](https://github.com/PublicMapping/districtbuilder/pull/638)
 

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -23,12 +23,13 @@ interface StateProps {
   readonly regionConfigs: RegionConfigState;
 }
 
-const validate = (form: ConfigurableForm, importResource: ImportResource) => {
+const validate = (form: ConfigurableForm, importResource: ImportResource): ProjectForm => {
   const regionConfig = importResource.data;
   const districtsDefinition = "resource" in importResource ? importResource.resource : null;
-  return form.numberOfDistricts !== null && importResource.data && "resource" in importResource
-    ? ({ ...form, regionConfig, districtsDefinition, valid: true } as ValidForm)
-    : ({ ...form, regionConfig, districtsDefinition, valid: false } as InvalidForm);
+  const numberOfDistricts = form.numberOfDistricts;
+  return numberOfDistricts && regionConfig && districtsDefinition
+    ? { numberOfDistricts, regionConfig, districtsDefinition, valid: true }
+    : { numberOfDistricts, regionConfig, districtsDefinition, valid: false };
 };
 
 type ImportResource = WriteResource<IRegionConfig | null, DistrictsDefinition>;
@@ -36,6 +37,8 @@ type ImportResource = WriteResource<IRegionConfig | null, DistrictsDefinition>;
 interface ConfigurableForm {
   readonly numberOfDistricts: number | null;
 }
+
+type ProjectForm = ValidForm | InvalidForm;
 
 interface ValidForm {
   readonly regionConfig: IRegionConfig;
@@ -50,6 +53,10 @@ interface InvalidForm {
   readonly numberOfDistricts: number | null;
   readonly valid: false;
 }
+
+const blankForm: ConfigurableForm = {
+  numberOfDistricts: null
+};
 
 const style: ThemeUIStyleObject = {
   header: {
@@ -153,9 +160,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
   const [createProjectResource, setCreateProjectResource] = useState<
     WriteResource<ConfigurableForm, IProject>
   >({
-    data: {
-      numberOfDistricts: null
-    }
+    data: blankForm
   });
   const regionConfig = importResource.data;
   const formData = createProjectResource.data;
@@ -278,11 +283,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                       setImportResource({
                         data: null
                       });
-                      setCreateProjectResource({
-                        data: {
-                          numberOfDistricts: null
-                        }
-                      });
+                      setCreateProjectResource({ data: blankForm });
                     }}
                   >
                     <Icon name="undo" />

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -318,7 +318,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                 </Card>
                 <Card sx={{ variant: "card.flat" }}>
                   <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
-                    Distrcts
+                    Districts
                   </legend>
                   <fieldset sx={style.fieldset}>
                     <Flex>

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { FileDrop } from "react-file-drop";
 import { connect } from "react-redux";
 import { Link, Redirect } from "react-router-dom";
-import { Box, Button, Card, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+import { Box, Button, Card, Flex, Heading, jsx, Spinner, ThemeUIStyleObject } from "theme-ui";
 
 import { FIPS } from "../../shared/constants";
 import { DistrictsDefinition, IProject, IRegionConfig } from "../../shared/entities";
@@ -23,14 +23,17 @@ interface StateProps {
   readonly regionConfigs: RegionConfigState;
 }
 
-const validate = (form: ProjectForm) =>
-  form.numberOfDistricts !== null && form.regionConfig !== null && form.districtsDefinition !== null
-    ? ({ ...form, valid: true } as ValidForm)
-    : ({ ...form, valid: false } as InvalidForm);
+const validate = (form: ConfigurableForm, importResource: ImportResource) => {
+  const regionConfig = importResource.data;
+  const districtsDefinition = "resource" in importResource ? importResource.resource : null;
+  return form.numberOfDistricts !== null && importResource.data && "resource" in importResource
+    ? ({ ...form, regionConfig, districtsDefinition, valid: true } as ValidForm)
+    : ({ ...form, regionConfig, districtsDefinition, valid: false } as InvalidForm);
+};
 
-interface ProjectForm {
-  readonly regionConfig: IRegionConfig | null;
-  readonly districtsDefinition: DistrictsDefinition | null;
+type ImportResource = WriteResource<IRegionConfig | null, DistrictsDefinition>;
+
+interface ConfigurableForm {
   readonly numberOfDistricts: number | null;
 }
 
@@ -41,7 +44,10 @@ interface ValidForm {
   readonly valid: true;
 }
 
-interface InvalidForm extends ProjectForm {
+interface InvalidForm {
+  readonly regionConfig: IRegionConfig | null;
+  readonly districtsDefinition: DistrictsDefinition | null;
+  readonly numberOfDistricts: number | null;
   readonly valid: false;
 }
 
@@ -140,33 +146,46 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
   }, []);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const importNumberRef = useRef(0);
+  const [importResource, setImportResource] = useState<ImportResource>({
+    data: null
+  });
   const [createProjectResource, setCreateProjectResource] = useState<
-    WriteResource<ProjectForm, IProject>
+    WriteResource<ConfigurableForm, IProject>
   >({
     data: {
-      regionConfig: null,
-      districtsDefinition: null,
       numberOfDistricts: null
     }
   });
-  const { data } = createProjectResource;
+  const regionConfig = importResource.data;
+  const formData = createProjectResource.data;
 
   const setFile = useCallback(
     (file: Blob) => {
       async function setConfigFromFile() {
         if (file && "resource" in regionConfigs) {
           const stateAbbrev = await getStateFromCsv(file);
+          // eslint-disable-next-line
+          importNumberRef.current = importNumberRef.current + 1;
+          const importNumber = importNumberRef.current;
+
           const regionConfig =
             regionConfigs.resource.find(config => config.regionCode === stateAbbrev) || null;
-          const dataWithRegion = { ...data, regionConfig };
-          setCreateProjectResource({ data: dataWithRegion });
-          const districtsDefinition = await importCsv(file);
-          setCreateProjectResource({ data: { ...dataWithRegion, districtsDefinition } });
+          if (regionConfig) {
+            setImportResource({ data: regionConfig, isPending: true });
+            const districtsDefinition = await importCsv(file);
+            // Don't set the districtsDefinition if upload was cancelled while we were fetching it
+            if (importNumberRef.current === importNumber) {
+              setImportResource({ data: regionConfig, resource: districtsDefinition });
+            }
+          } else {
+            setImportResource({ data: null });
+          }
         }
       }
       void setConfigFromFile();
     },
-    [data, regionConfigs]
+    [regionConfigs, importNumberRef]
   );
 
   return "resource" in createProjectResource ? (
@@ -205,17 +224,17 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
             sx={{ flexDirection: "column" }}
             onSubmit={(e: React.FormEvent) => {
               e.preventDefault();
-              const validatedForm = validate(data);
+              const validatedForm = validate(formData, importResource);
               if (validatedForm.valid === true) {
-                setCreateProjectResource({ data, isPending: true });
+                setCreateProjectResource({ data: formData, isPending: true });
                 createProject({
                   ...validatedForm,
                   name: validatedForm.regionConfig.name
                 })
                   .then((project: IProject) =>
-                    setCreateProjectResource({ data, resource: project })
+                    setCreateProjectResource({ data: formData, resource: project })
                   )
-                  .catch(errors => setCreateProjectResource({ data, errors }));
+                  .catch(errors => setCreateProjectResource({ data: formData, errors }));
               }
             }}
           >
@@ -238,16 +257,29 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                 accept=".csv"
                 style={{ display: "none" }}
               />
-              {data.regionConfig ? (
+              {regionConfig ? (
                 <Box sx={style.uploadSuccess}>
-                  <b>Upload successful!</b>
+                  {"resource" in importResource ? (
+                    <b>Upload success</b>
+                  ) : (
+                    <span>
+                      <Spinner variant="spinner.small" /> Uploading
+                    </span>
+                  )}
                   <Button
                     sx={{ variant: "buttons.linkStyle" }}
                     onClick={() => {
+                      // eslint-disable-next-line
+                      importNumberRef.current += 1;
+                      if (fileInputRef.current) {
+                        // eslint-disable-next-line
+                        fileInputRef.current.value = "";
+                      }
+                      setImportResource({
+                        data: null
+                      });
                       setCreateProjectResource({
                         data: {
-                          regionConfig: null,
-                          districtsDefinition: null,
                           numberOfDistricts: null
                         }
                       });
@@ -275,14 +307,14 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                 </FileDrop>
               )}
             </Card>
-            {data.regionConfig && (
+            {regionConfig && (
               <React.Fragment>
                 <Card sx={{ variant: "card.flat" }}>
                   <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
                     State
                   </legend>
-                  We detected block data for <b>{data.regionConfig.name}</b>. To pick a different
-                  state, upload a new file.
+                  We detected block data for <b>{regionConfig.name}</b>. To pick a different state,
+                  upload a new file.
                 </Card>
                 <Card sx={{ variant: "card.flat" }}>
                   <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
@@ -301,7 +333,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                               const numberOfDistricts = isNaN(value) ? null : value;
                               setCreateProjectResource({
                                 data: {
-                                  ...data,
+                                  ...formData,
                                   numberOfDistricts
                                 }
                               });
@@ -316,8 +348,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                   <Button
                     type="submit"
                     disabled={
-                      (("isPending" in createProjectResource && createProjectResource.isPending) ||
-                        !validate(data).valid) &&
+                      !validate(formData, importResource).valid &&
                       !("errorMessage" in createProjectResource)
                     }
                   >


### PR DESCRIPTION
## Overview

 - Handle case where upload is cancelled while AJAX call is in-transit
 - Make sure button is un-disabled after AJAX call completes
 - Show spinner when CSV upload is in-transit

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![output](https://user-images.githubusercontent.com/4432106/113438563-cf871700-93b6-11eb-9961-49eba65c802d.gif)


### Notes

I decided against the implementation described (the button is always enabled, a spinner is shown on the button) in the issue in favor of something more in line with the original wireframes (the spinner is next to the file, the button is disabled until the upload is complete), for ease of implementation as well as to lay the groundwork for #629 

## Testing Instructions

- `scripts/server`
- Upload a valid CSV
  - It should show a spinner while it is uploading
  - Click redo while it is uploading - it should reset the UI, and remain reset when the API call completes
  - If you fill in the # of districts before the file is done uploading, the Save button should be enabled once the upload is complete

Closes #652 
Closes #655 
