### PR TITLE
Dont allow featuring unpublished maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add paintbrush drawing tool [#611](https://github.com/PublicMapping/districtbuilder/pull/611)
 - Add verify and join link to user verification email [#616](https://github.com/PublicMapping/districtbuilder/pull/616)
 - Display organizations dropdown in header [#620](https://github.com/PublicMapping/districtbuilder/pull/620)
-- Organization Admin page and featured map workflow [#614](https://github.com/PublicMapping/districtbuilder/pull/614)
+- Organization Admin page and featured map workflow [#614](https://github.com/PublicMapping/districtbuilder/pull/614) &  [#671](https://github.com/PublicMapping/districtbuilder/pull/671)
 - Build out scaffolding for Project Evaluate view [#623](https://github.com/PublicMapping/districtbuilder/pull/623)
 - Add flag on project templates to mark as active or inactive [#626](https://github.com/PublicMapping/districtbuilder/pull/626)
 - Display featured projects on Organization page [#633](https://github.com/PublicMapping/districtbuilder/pull/633)

--- a/src/client/actions/organizationProjects.ts
+++ b/src/client/actions/organizationProjects.ts
@@ -1,6 +1,10 @@
 import { createAction } from "typesafe-actions";
-import { IProjectTemplateWithProjects, OrganizationSlug, IProject } from "../../shared/entities";
-import { OrgProject } from "../types";
+import {
+  IProjectTemplateWithProjects,
+  OrganizationSlug,
+  IProject,
+  ProjectNest
+} from "../../shared/entities";
 import { ResourceFailure } from "../resource";
 
 export const organizationProjectsFetch = createAction("Organization projects fetch")<
@@ -24,7 +28,7 @@ export const organizationFeaturedProjectsFetchFailure = createAction(
 )<ResourceFailure>();
 
 export const toggleProjectFeatured = createAction("Toggle project featured")<{
-  readonly project: OrgProject;
+  readonly project: ProjectNest;
   readonly organization: OrganizationSlug;
 }>();
 export const toggleProjectFeaturedSuccess = createAction("Toggle project featured success")<{

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -15,9 +15,10 @@ import {
   UpdateUserData,
   UserId,
   DistrictsDefinition,
-  RegionConfigId
+  RegionConfigId,
+  ProjectNest
 } from "../shared/entities";
-import { DistrictsGeoJSON, DynamicProjectData, OrgProject } from "./types";
+import { DistrictsGeoJSON, DynamicProjectData } from "./types";
 import { getJWT, setJWT } from "./jwt";
 
 const apiAxios = axios.create();
@@ -317,7 +318,7 @@ export async function fetchOrganizationFeaturedProjects(
   });
 }
 
-export async function saveProjectFeatured(project: OrgProject): Promise<IOrganization> {
+export async function saveProjectFeatured(project: ProjectNest): Promise<IOrganization> {
   return new Promise((resolve, reject) => {
     const projectPost = {
       isFeatured: !project.isFeatured

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -1,14 +1,17 @@
 /** @jsx jsx */
 import { useMemo } from "react";
-import { Button, Flex, jsx, Styled } from "theme-ui";
-import store from "../store";
-import { toggleProjectFeatured } from "../actions/organizationProjects";
-import { OrganizationSlug } from "../../shared/entities";
 import { useTable, Row, HeaderGroup, Cell, useSortBy } from "react-table";
 import { Link } from "react-router-dom";
-import { OrgProject } from "../types";
+import { Button, Flex, jsx, Styled } from "theme-ui";
+
+import { OrganizationSlug, ProjectNest } from "../../shared/entities";
+
+import { toggleProjectFeatured } from "../actions/organizationProjects";
+import store from "../store";
+import { ProjectVisibility } from "../../shared/constants";
+
 interface ProjectsTableProps {
-  readonly projects: readonly OrgProject[];
+  readonly projects: readonly ProjectNest[];
   readonly organizationSlug: OrganizationSlug;
 }
 
@@ -29,7 +32,7 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
       {
         Header: "Map",
         accessor: "project", // accessor is the "key" in the data,
-        Cell: (p: Cell<OrgProject>) => {
+        Cell: (p: Cell<ProjectNest>) => {
           return (
             <Styled.a as={Link} to={`/projects/${p.value.id}`} target="_blank">
               {p.value.name}
@@ -48,7 +51,7 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
       {
         Header: "Creator email",
         accessor: "creator.email",
-        Cell: (p: Cell<OrgProject>) => {
+        Cell: (p: Cell<ProjectNest>) => {
           return <a href={`mailto:${p.value}`}>{p.value}</a>;
         }
       },
@@ -61,7 +64,9 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
   );
   const data = useMemo(() => projects, [projects]);
   // ts-ignore needed below bc react-table requires mutable types, even though it doesn't mutate them?
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable<OrgProject>(
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable<
+    ProjectNest
+  >(
     {
       // @ts-ignore
       columns,
@@ -71,7 +76,7 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
     useSortBy
   );
 
-  function projectFeaturedToggle(row: Row<OrgProject>) {
+  function projectFeaturedToggle(row: Row<ProjectNest>) {
     store.dispatch(
       toggleProjectFeatured({ project: row.original, organization: organizationSlug })
     );
@@ -84,9 +89,9 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
     <Flex sx={{ flexDirection: "column" }}>
       <table {...getTableProps()} style={{ border: "solid 1px blue" }}>
         <thead>
-          {headerGroups.map((headerGroup: HeaderGroup<OrgProject>) => (
+          {headerGroups.map((headerGroup: HeaderGroup<ProjectNest>) => (
             <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column: HeaderGroup<OrgProject>) => (
+              {headerGroup.headers.map((column: HeaderGroup<ProjectNest>) => (
                 <th
                   {...column.getHeaderProps(column.getSortByToggleProps())}
                   sx={style.columnHeader}
@@ -100,11 +105,11 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
           ))}
         </thead>
         <tbody {...getTableBodyProps()}>
-          {rows.map((row: Row<OrgProject>) => {
+          {rows.map((row: Row<ProjectNest>) => {
             prepareRow(row);
             return (
               <tr {...row.getRowProps()}>
-                {row.cells.map((cell: Cell<OrgProject>) => {
+                {row.cells.map((cell: Cell<ProjectNest>) => {
                   return (
                     <td
                       {...cell.getCellProps()}

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -122,10 +122,14 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
                     </td>
                   );
                 })}
-                <td>
-                  <Button onClick={() => projectFeaturedToggle(row)}>
-                    {row.original.isFeatured ? "Unfeature" : "Feature"}
-                  </Button>
+                <td sx={{ textAlign: "center" }}>
+                  {row.original.visibility === ProjectVisibility.Published ? (
+                    <Button onClick={() => projectFeaturedToggle(row)}>
+                      {row.original.isFeatured ? "Unfeature" : "Feature"}
+                    </Button>
+                  ) : (
+                    "Unpublished"
+                  )}
                 </td>
               </tr>
             );

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -17,8 +17,7 @@ import { UserState } from "../reducers/user";
 import { OrganizationProjectsState } from "../reducers/organizationProjects";
 import store from "../store";
 
-import { CreateProjectData, IOrganization, IUser } from "../../shared/entities";
-import { OrgProject } from "../types";
+import { CreateProjectData, IOrganization, IUser, ProjectNest } from "../../shared/entities";
 
 import Icon from "../components/Icon";
 import JoinOrganizationModal from "../components/JoinOrganizationModal";
@@ -302,7 +301,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
                   </Text>
                   <Box sx={style.featuredProjectContainer}>
                     {featuredProjects.length > 0 ? (
-                      featuredProjects.map((project: OrgProject) => (
+                      featuredProjects.map((project: ProjectNest) => (
                         <FeaturedProjectCard project={project} key={project.id} />
                       ))
                     ) : (

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -36,21 +36,3 @@ export type SavingState = "unsaved" | "saving" | "saved" | "failed";
 export interface AuthLocationState {
   readonly from: H.Location;
 }
-
-interface OrgProject {
-  readonly id: ProjectId;
-  readonly project: {
-    readonly id: ProjectId;
-    readonly name: string;
-  };
-  readonly creator: {
-    readonly name: string;
-    readonly email: string;
-  };
-  readonly templateName: string;
-  readonly updatedAgo: string;
-  readonly isFeatured: boolean;
-  readonly user: Pick<IUser, PublicUserProperties>;
-  readonly districts?: DistrictsGeoJSON;
-  readonly districtsDefinition?: DistrictsDefinition;
-}

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -29,6 +29,7 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
         "projects.isFeatured",
         "projects.id",
         "projects.updatedDt",
+        "projects.visibility",
         "regionConfig.name",
         "user.name",
         "user.email"

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -185,10 +185,10 @@ export type ProjectNest = Pick<
   | "id"
   | "updatedDt"
   | "numberOfDistricts"
-  | "chamber"
   | "name"
   | "regionConfig"
   | "isFeatured"
+  | "visibility"
 > & {
   readonly regionConfig: Pick<IRegionConfig, "name">;
 };


### PR DESCRIPTION
## Overview

Prevents organization admins from featuring unpublished maps.

Also refactors to remove the client-only `OrgProject` type in favor of the shared (and more accurate) `ProjectNest` type.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_o_azavea_admin](https://user-images.githubusercontent.com/4432106/113446546-f6991500-93c5-11eb-8bce-e43a6b1ebef9.png)


## Testing Instructions

- `scripts/server`
- Go to the org admin page - all maps listed there previously should still be there, but the Feature/Unfeature button should only be visible if the map is published

Closes #635 
