### PR TITLE
Allow admins to view projects created from organization template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor project evaluate mode views [#642](https://github.com/PublicMapping/districtbuilder/pull/642)
 - Link featured projects in Organization screen to project detail pages [#657](https://github.com/PublicMapping/districtbuilder/pull/657)
 - Add creator email and project link to Org Admin screen [#664](https://github.com/PublicMapping/districtbuilder/pull/664)
+- Allow admins to view projects created from organization template [#672](https://github.com/PublicMapping/districtbuilder/pull/672)
 
 ### Fixed
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -119,14 +119,22 @@ import { Errors } from "../../../../shared/types";
       };
     } else {
       // Unauthenticated access is allowed for individual projects if they are
-      // visible or published, and not archived
+      // visible or published, and not archived. Admins can also see projects created from templates
+      // for organizations that they administer.
+      const publicallyVisible = [
+        { visibility: ProjectVisibility.Published },
+        { visibility: ProjectVisibility.Visible }
+      ];
       const visibleFilter = user
         ? [
+            // User created project
             { user_id: user.id },
-            { visibility: ProjectVisibility.Published },
-            { visibility: ProjectVisibility.Visible }
+            // User is admin of project template organization
+            { "projectTemplate.organization.admin": user.id },
+            // Or it's public
+            ...publicallyVisible
           ]
-        : [{ visibility: ProjectVisibility.Published }, { visibility: ProjectVisibility.Visible }];
+        : publicallyVisible;
       return {
         $and: [
           {


### PR DESCRIPTION
## Overview
Allow admins to view projects created from project template for organizations they administer.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![db_admin_view_private_map](https://user-images.githubusercontent.com/2926237/113449156-39112080-93cb-11eb-87e1-7e542e71226f.gif)

## Notes
I took a half-hearted stab at writing an integration test to exercise the filtering login within project controller `@CrudAuth` but it seemed like it would take a while to get it working so I bailed.

## Testing Instructions
* Make sure an organization is created with a project template
* Log in as a different user or create a new user
* Join the organization
* Create a project from the template
* Log back in as the org admin and go to `/o/<org_slug>/admin`
* You should see the private project created by the other user in the list
* Ensure you can view it but cannot edit the map

Closes #665 
