### PR TITLE
Don't create a new map when joining an organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link featured projects in Organization screen to project detail pages [#657](https://github.com/PublicMapping/districtbuilder/pull/657)
 - Add creator email and project link to Org Admin screen [#664](https://github.com/PublicMapping/districtbuilder/pull/664)
 - Allow admins to view projects created from organization template [#672](https://github.com/PublicMapping/districtbuilder/pull/672)
+- Fix bug where projects are created after closing Join Organization modal triggered from an organization's template [#673](https://github.com/PublicMapping/districtbuilder/pull/673)
 
 ### Fixed
 

--- a/src/client/components/ConfirmJoinOrganization.tsx
+++ b/src/client/components/ConfirmJoinOrganization.tsx
@@ -38,13 +38,14 @@ const style: ThemeUIStyleObject = {
 const ConfirmJoinOrganization = ({
   organization,
   user,
-  projectTemplate
+  projectTemplate,
+  onCancel
 }: {
   readonly organization: IOrganization;
   readonly user: Resource<IUser>;
   readonly projectTemplate?: CreateProjectData;
+  readonly onCancel: () => void;
 }) => {
-  const hideModal = () => store.dispatch(showCopyMapModal(false));
   const history = useHistory();
 
   function joinOrg() {
@@ -56,6 +57,11 @@ const ConfirmJoinOrganization = ({
       store.dispatch(showCopyMapModal(false));
 
     projectTemplate && createProjectFromTemplate();
+  }
+
+  function closeModal() {
+    onCancel();
+    store.dispatch(showCopyMapModal(false));
   }
 
   function createProjectFromTemplate() {
@@ -91,7 +97,7 @@ const ConfirmJoinOrganization = ({
           </Button>
           <Button
             id="cancel-copy-map-modal"
-            onClick={hideModal}
+            onClick={closeModal}
             sx={{ variant: "buttons.linkStyle", margin: "0 auto" }}
           >
             Go back

--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -40,14 +40,19 @@ const JoinOrganizationModal = ({
   organization,
   user,
   showModal,
-  projectTemplate
+  projectTemplate,
+  onCancel
 }: {
   readonly organization: IOrganization;
   readonly showModal: boolean;
   readonly user: Resource<IUser>;
   readonly projectTemplate?: CreateProjectData;
+  readonly onCancel: () => void;
 }) => {
-  const hideModal = () => store.dispatch(showCopyMapModal(false));
+  const hideModal = () => {
+    onCancel();
+    store.dispatch(showCopyMapModal(false));
+  };
 
   return showModal ? (
     <AriaModal
@@ -59,7 +64,11 @@ const JoinOrganizationModal = ({
     >
       <Box sx={style.modal}>
         {"resource" in user ? (
-          <ConfirmJoinOrganization organization={organization} projectTemplate={projectTemplate} />
+          <ConfirmJoinOrganization
+            organization={organization}
+            projectTemplate={projectTemplate}
+            onCancel={onCancel}
+          />
         ) : (
           <AuthModalContent organization={organization} />
         )}

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -187,6 +187,10 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
     }
   }
 
+  function handleCancelModal() {
+    setProjectTemplate(undefined);
+  }
+
   const joinButton = (
     <Flex
       sx={{
@@ -353,6 +357,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
         <JoinOrganizationModal
           organization={organization.resource}
           projectTemplate={projectTemplate}
+          onCancel={handleCancelModal}
         />
       )}
     </Flex>


### PR DESCRIPTION
## Overview

Fixes a bug around projects being created when a user clicks 'Use template' on a project template after having left an an organization, and then rejoins (as initially identified by @jfrankl in #662)


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Login with a non-admin user who is a member of an organization
- Navigate to the organization screen, and leave an organization
- Click the 'Use template' button on a project template
- Click 'Cancel' on the ensuing dialog
- Click Join Organization; expect the organization to be joined, and no project to be created

Closes #662 
