### PR TITLE
Display import map button on home screen when no maps have been created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add button to Organization page to link to Organization Admin page for admin users [#669](https://github.com/PublicMapping/districtbuilder/pull/669)
 - Add project evaluate view for contiguity [#648](https://github.com/PublicMapping/districtbuilder/pull/648)
 - Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
+- Display Import Map button on home screen when a user has not created maps yet [#674](https://github.com/PublicMapping/districtbuilder/pull/674)
 
 ### Changed
 

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -162,6 +162,13 @@ const HomeScreen = ({ projects, user }: StateProps) => {
                 <Icon name="plus-circle" />
                 Create a map
               </Styled.a>
+              <Styled.a
+                as={Link}
+                to="/import-project"
+                sx={{ variant: "links.secondaryButton", fontSize: 3, px: 6, py: 2, mt: 2 }}
+              >
+                Import map
+              </Styled.a>
             </Flex>
           )
         ) : null}


### PR DESCRIPTION
## Overview

Displays the import button on the home screen, even when a user has not created any maps yet.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/113598144-aced3c00-960a-11eb-9bb8-f47d283c0aef.png)


### Notes

@jfrankl @tgilcrest  Two things I'm a little uncertain about here:

1. What color should this button be? I have it as gray / `links.secondaryButton` currently, but this wasn't explicitly noted in the issue
2. Do we want any icon here? It looks a little weird with an icon on the 'Create a map' button, but not on this button.


## Testing Instructions

- Create a new user account and login
- Expect: Import button displayed on home screen underneath 'Create a map button', which opens the import map dialog when clicked

Closes #643 
