### PR TITLE
Whitelist isFeatured field from triggering change to Project.updatedDt

### DIFF
--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -217,12 +217,13 @@ export class ProjectsController implements CrudController<Project> {
           }
         : dto;
 
-    // Update updatedDt field when non-whitelisted fields have changed
-    const whitelistedFields = ["isFeatured", "districts", "updatedDt"];
-    const data = _.isEqual(
-      _.omit(dataWithDefinitions, whitelistedFields),
-      _.omit(existingProject, whitelistedFields)
-    )
+    // Only change updatedDt field when whitelisted fields have changed
+    const whitelistedFields: ReadonlyArray<keyof UpdateProjectDto> = [
+      "districtsDefinition",
+      "name"
+    ];
+    const fields = whitelistedFields.filter(field => field in dto);
+    const data = _.isEqual(_.pick(dataWithDefinitions, fields), _.pick(existingProject, fields))
       ? dataWithDefinitions
       : { ...dataWithDefinitions, updatedDt: new Date() };
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -202,7 +202,7 @@ export class ProjectsController implements CrudController<Project> {
     }
 
     // Update districts GeoJSON if the definition has changed or there is no cached value yet
-    const data =
+    const dataWithDefinitions =
       existingProject &&
       dto.districtsDefinition &&
       (!existingProject.districts ||
@@ -216,6 +216,15 @@ export class ProjectsController implements CrudController<Project> {
             })
           }
         : dto;
+
+    // Update updatedDt field when non-whitelisted fields have changed
+    const whitelistedFields = ["isFeatured", "districts", "updatedDt"];
+    const data = _.isEqual(
+      _.omit(dataWithDefinitions, whitelistedFields),
+      _.omit(existingProject, whitelistedFields)
+    )
+      ? dataWithDefinitions
+      : { ...dataWithDefinitions, updatedDt: new Date() };
 
     return this.service.updateOne(req, data);
   }

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -1,12 +1,5 @@
 import { FeatureCollection, MultiPolygon } from "geojson";
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  ManyToOne,
-  PrimaryGeneratedColumn,
-  UpdateDateColumn
-} from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
 import { ProjectVisibility } from "../../../../shared/constants";
 import { DistrictProperties, DistrictsDefinition, IProject } from "../../../../shared/entities";

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -62,7 +62,7 @@ export class Project implements IProject {
   @Column({ type: "timestamp with time zone", name: "created_dt", default: () => "NOW()" })
   createdDt: Date;
 
-  @UpdateDateColumn({
+  @Column({
     type: "timestamp with time zone",
     name: "updated_dt",
     default: () => "NOW()"


### PR DESCRIPTION
## Overview

We want to track the most recently updated date for users projects, but organization admins setting the `isFeatured` flag should not be considered an update.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- On `develop`, toggling the Featured/Unfeatured flag will also update the `Project.updatedDt` field. On this branch it should not.
- Editing other project fields (name, districts, visibility, etc.) should continue to update the `updatedDt` field

Closes #668 
