### PR TITLE
Update index of locked districts to make the last district lockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug where projects are created after closing Join Organization modal triggered from an organization's template [#673](https://github.com/PublicMapping/districtbuilder/pull/673)
 
 ### Fixed
+- Allow last district to be locked [#677](https://github.com/PublicMapping/districtbuilder/pull/677)
+
 
 ## [1.3.0] - 2021-01-26
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -295,7 +295,7 @@ const SidebarRow = memo(
     const toggleHover = () => setHover(!isHovered);
     const toggleLocked = (e: React.MouseEvent) => {
       e.stopPropagation();
-      store.dispatch(toggleDistrictLocked(districtId));
+      store.dispatch(toggleDistrictLocked(districtId - 1));
     };
     return (
       <Styled.tr
@@ -364,16 +364,18 @@ const SidebarRow = memo(
               </Button>
             </Tooltip>
           ) : (
-            <Tooltip content="Lock this district">
-              <Button
-                variant="icon"
-                style={{ visibility: isHovered ? "visible" : "hidden" }}
-                onClick={toggleLocked}
-                sx={style.lockButton}
-              >
-                <Icon name="lock-unlocked" size={0.75} />
-              </Button>
-            </Tooltip>
+            districtId > 0 && (
+              <Tooltip content="Lock this district">
+                <Button
+                  variant="icon"
+                  style={{ visibility: isHovered ? "visible" : "hidden" }}
+                  onClick={toggleLocked}
+                  sx={style.lockButton}
+                >
+                  <Icon name="lock-unlocked" size={0.75} />
+                </Button>
+              </Tooltip>
+            )
           )}
         </Styled.td>
       </Styled.tr>
@@ -484,7 +486,7 @@ const SidebarRows = ({
             demographics={feature.properties.demographics}
             deviation={deviation}
             key={districtId}
-            isDistrictLocked={lockedDistricts[districtId]}
+            isDistrictLocked={lockedDistricts[districtId - 1]}
             districtId={districtId}
             isReadOnly={isReadOnly}
           />

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -361,7 +361,7 @@ const DistrictsMap = ({
     map &&
       [...new Array(project.numberOfDistricts + 1).keys()].forEach(districtId =>
         map.setFeatureState(featureStateDistricts(districtId), {
-          locked: lockedDistricts[districtId]
+          locked: lockedDistricts[districtId - 1]
         })
       );
   }, [map, project, lockedDistricts]);

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -5,9 +5,7 @@ import {
   IStaticMetadata,
   UintArrays,
   GeoUnitHierarchy,
-  DistrictProperties,
-  DistrictsDefinition,
-  ProjectId
+  DistrictProperties
 } from "../shared/entities";
 
 export type DistrictGeoJSON = Feature<MultiPolygon, DistrictProperties>;

--- a/src/server/migrations/1617656641073-locked-districts.ts
+++ b/src/server/migrations/1617656641073-locked-districts.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+'use strict';
+
+export class lockedDistricts1617656641073 implements MigrationInterface {
+    name = 'lockedDistricts1617656641073'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE project SET locked_districts = locked_districts[2:] || false;`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE project SET locked_districts = false || locked_districts[:cardinality(locked_districts) - 1];`, undefined);
+    }
+
+}


### PR DESCRIPTION
## Overview

Fixes a bug identified in #666 where the last district in the list cannot be locked by updating the IDs of districts in the list. Previously, the ø / unassigned district was associated with the first value in the locked districts list, when in reality it should never be lockable. By updating the indices of the locked districts in the sidebar and map to be n-1, all districts are now able to be locked. 

Also, the ability to lock the unassigned district was removed.


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo


![image](https://user-images.githubusercontent.com/66973361/113621206-5cd1a200-9629-11eb-997f-e58299ae4026.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Create a map with a full set of districts, and attempt to lock all of the districts individually. All of the districts should be lockable, and their lock state should be reflected in the map as well as the sidebar


Closes #666 
