### PR TITLE
Fix evaluate mode toggle to no longer break project editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Allow last district to be locked [#677](https://github.com/PublicMapping/districtbuilder/pull/677)
+- Allow editing at lower geolevels after toggling evaluate mode [#679](https://github.com/PublicMapping/districtbuilder/pull/679)
 - Fix off screen geounits deselected when using rectangle tool [#680](https://github.com/PublicMapping/districtbuilder/pull/680)
 
 


### PR DESCRIPTION
## Overview

- Fix bug identified in #660 around toggling evaluate mode breaking project editing for lower-level geounits
- Hides editing tools when in evaluate mode
- Hides legend when not in evaluate mode

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


## Testing Instructions

- Open a project, and select 'Block group' editing level
- Toggle editing mode and select a view (e.g., compactness)
- Expect: Cursor becomes the map pan tool when in evaluate mode
- Turn evaluate mode off
- Expect: You are able to edit the project at the Block group level after opening evaluate mode

Closes #660 
