### PR TITLE
Fix off screen geounits deselected when using rectangle tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Allow last district to be locked [#677](https://github.com/PublicMapping/districtbuilder/pull/677)
+- Fix off screen geounits deselected when using rectangle tool [#680](https://github.com/PublicMapping/districtbuilder/pull/680)
 
 
 ## [1.3.0] - 2021-01-26

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -30,7 +30,6 @@ export const replaceSelectedGeounits = createAction("Replace selected geounits")
   readonly add?: GeoUnits;
   readonly remove?: GeoUnits;
 }>();
-export const setSelectedGeounits = createAction("Set selected geounits")<GeoUnits>();
 
 export const setHighlightedGeounits = createAction("Add highlighted geounit ids")<GeoUnits>();
 export const clearHighlightedGeounits = createAction("Clear highlighted geounit ids")();

--- a/src/client/components/map/PaintBrushSelectionTool.ts
+++ b/src/client/components/map/PaintBrushSelectionTool.ts
@@ -17,6 +17,7 @@ import store from "../../store";
 
 import {
   featuresToUnlockedGeoUnits,
+  filterGeoUnits,
   isFeatureSelected,
   levelToSelectionLayerId,
   ISelectionTool,
@@ -88,15 +89,6 @@ const PaintBrushSelectionTool: ISelectionTool = {
         lockedDistricts,
         staticGeoLevels
       );
-
-      // Helper for filtering matching geounits given an include function
-      const filterGeoUnits = (units: GeoUnits, includeFn: (id: number) => boolean) =>
-        Object.entries(units).reduce((newGeoUnits, [geoLevelId, geoUnitsForLevel]) => {
-          return {
-            ...newGeoUnits,
-            [geoLevelId]: new Map([...geoUnitsForLevel].filter(([id]) => includeFn(id)))
-          };
-        }, units);
 
       // New geounits (to select on map) are the highlighted ones that aren't already selected
       const newGeoUnits = filterGeoUnits(

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -11,11 +11,10 @@ import {
 } from "../../../shared/entities";
 
 import {
-  setSelectedGeounits,
+  addSelectedGeounits,
   clearHighlightedGeounits,
   setHighlightedGeounits
 } from "../../actions/districtDrawing";
-import { mergeGeoUnits } from "../../functions";
 import store from "../../store";
 
 import {
@@ -268,7 +267,7 @@ const RectangleSelectionTool: ISelectionTool = {
           staticGeoLevels
         );
         deselectChildGeounits(map, geoUnits, staticMetadata, staticGeoLevels);
-        store.dispatch(setSelectedGeounits(mergeGeoUnits(geoUnits, initiallySelectedGeoUnits)));
+        store.dispatch(addSelectedGeounits(geoUnits));
       }
       store.dispatch(clearHighlightedGeounits());
     }

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -97,7 +97,7 @@ const RectangleSelectionTool: ISelectionTool = {
      *
      * Highlight = make the feature be selected (dark overlay) temporarily to reflect UI interaction
      * (mouse move) which is used to recalculate stats dynamically without actually saving the
-     * selection. It can be though of as a preview of a potential selection.
+     * selection. It can be thought of as a preview of a potential selection.
      */
     function updateHighlighting(e: MouseEvent) {
       // Find features before updating `current` to later tell if any features were unhighlighted

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -20,6 +20,7 @@ import store from "../../store";
 
 import {
   featuresToUnlockedGeoUnits,
+  filterGeoUnits,
   GEOLEVELS_SOURCE_ID,
   isFeatureSelected,
   levelToSelectionLayerId,
@@ -135,15 +136,6 @@ const RectangleSelectionTool: ISelectionTool = {
         lockedDistricts,
         staticGeoLevels
       );
-
-      // Helper for filtering matching geounits given an include function
-      const filterGeoUnits = (units: GeoUnits, includeFn: (id: number) => boolean) =>
-        Object.entries(units).reduce((newGeoUnits, [geoLevelId, geoUnitsForLevel]) => {
-          return {
-            ...newGeoUnits,
-            [geoLevelId]: new Map([...geoUnitsForLevel].filter(([id]) => includeFn(id)))
-          };
-        }, units);
 
       // Highlighted shouldn't include the geounits initially selected
       const highlightedGeoUnits = filterGeoUnits(

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -244,6 +244,7 @@ const RectangleSelectionTool: ISelectionTool = {
     /*
      * Select highlighted features and clean up.
      */
+    // eslint-disable-next-line
     function finish(bbox?: [MapboxGL.PointLike, MapboxGL.PointLike]) {
       // Remove these events now that finish has been called.
       document.removeEventListener("mousemove", onMouseMove);

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -426,6 +426,18 @@ export function setFeaturesSelectedFromGeoUnits(
   });
 }
 
+/*
+ * Filter matching geounits given an include function
+ */
+export function filterGeoUnits(units: GeoUnits, includeFn: (id: number) => boolean) {
+  return Object.entries(units).reduce((newGeoUnits, [geoLevelId, geoUnitsForLevel]) => {
+    return {
+      ...newGeoUnits,
+      [geoLevelId]: new Map([...geoUnitsForLevel].filter(([id]) => includeFn(id)))
+    };
+  }, units);
+}
+
 export function deselectChildGeounits(
   map: MapboxGL.Map,
   geoUnits: GeoUnits,

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -16,7 +16,6 @@ import {
   setHighlightedGeounits,
   setSelectedDistrictId,
   setSelectionTool,
-  setSelectedGeounits,
   showAdvancedEditingModal,
   showCopyMapModal,
   toggleDistrictLocked,
@@ -191,10 +190,6 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
           action.payload.add,
           action.payload.remove
         )
-      });
-    case getType(setSelectedGeounits):
-      return pushStateUpdate(state, {
-        selectedGeounits: action.payload
       });
     case getType(clearSelectedGeounits): {
       const clearedViaCancel = action.payload;


### PR DESCRIPTION
## Overview
Fix off screen geounits deselected when using rectangle tool

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![db_fix_off_screen_rect_selection_tool_bug](https://user-images.githubusercontent.com/2926237/113908342-6f241b00-97a4-11eb-9131-39a08ab72e72.gif)

### Notes
This includes a little bit of cleanup (see 04c4f71) and adding of comments (see d8cfe2d; selecting vs. highlighting always gets me confused when I haven't looked at this code for a little while so hopefully this will help with that).

The fix is in 17a6e8f.

## Testing Instructions
Make sure the bug can't be reproduced.

Closes #667 
