### PR TITLE
Display export button on shared projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project evaluate view for contiguity [#648](https://github.com/PublicMapping/districtbuilder/pull/648)
 - Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
 - Display Import Map button on home screen when a user has not created maps yet [#674](https://github.com/PublicMapping/districtbuilder/pull/674)
+- Display export button in project header for published projects from other users [#681](https://github.com/PublicMapping/districtbuilder/pull/681)
 
 ### Changed
 

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -155,6 +155,7 @@ const ProjectHeader = ({
       ) : (
         <React.Fragment>
           <CopyMapButton invert={true} />
+          {project && <ExportMenu invert={true} project={project} />}
         </React.Fragment>
       )}
     </Flex>


### PR DESCRIPTION
## Overview

Displays the export button on shared projects, like we had previously been including on an individual's created projects

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/113931991-20d14500-97c1-11eb-969e-ccaea56d3e82.png)


## Testing Instructions

- `./scripts/server`
- Create a project from an org template with a non-admin user and publish it
- Login as the org admin user, and go to the org admin page by clicking View All on the Org Page
- Select a project from another user
- Expect: Export menu is displayed in header and is fully functional

Closes #661 
