### PR TITLE
Add Evaluate Mode view for Equal Population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add project evaluate view for Equal Population [#685](https://github.com/PublicMapping/districtbuilder/pull/685)
+
 
 ### Changed
 
@@ -48,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
 - Display Import Map button on home screen when a user has not created maps yet [#674](https://github.com/PublicMapping/districtbuilder/pull/674)
 - Display export button in project header for published projects from other users [#681](https://github.com/PublicMapping/districtbuilder/pull/681)
+
 
 ### Changed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -15,8 +15,8 @@ import { DistrictGeoJSON, DistrictsGeoJSON, SavingState } from "../types";
 import {
   areAnyGeoUnitsSelected,
   assertNever,
-  getTargetPopulation,
-  mergeGeoUnits
+  mergeGeoUnits,
+  getTargetPopulation
 } from "../functions";
 import {
   getSavedDistrictSelectedDemographics,

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -13,6 +13,7 @@ import { selectEvaluationMetric } from "../../actions/districtDrawing";
 import ContiguityMetricDetail from "./detail/Contiguity";
 import CompactnessMetricDetail from "./detail/Compactness";
 import CountySplitMetricDetail from "./detail/CountySplit";
+import EqualPopulationMetricDetail from "./detail/EqualPopulation";
 import { Resource } from "../../resource";
 
 const style: ThemeUIStyleObject = {
@@ -113,6 +114,8 @@ const ProjectEvaluateMetricDetail = ({
           <CompactnessMetricDetail metric={metric} geojson={geojson} />
         ) : metric && "type" in metric && metric.key === "contiguity" ? (
           <ContiguityMetricDetail metric={metric} geojson={geojson} />
+        ) : metric && "type" in metric && metric.key === "equalPopulation" ? (
+          <EqualPopulationMetricDetail metric={metric} geojson={geojson} />
         ) : (
           <Box sx={{ ml: "20px" }}>
             <Heading as="h4" sx={{ variant: "text.h4", display: "block" }}>

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -256,7 +256,9 @@ export class GeoUnitTopology {
           ...feature,
           geometry,
           properties: {
-            demographics: feature.properties,
+            demographics: {
+              ...feature.properties
+            },
             compactness,
             contiguity
           }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -35,6 +35,8 @@ export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
   readonly type: "fraction" | "percent" | "count";
   readonly value: number;
   readonly total?: number;
+  readonly avgPopulation?: number;
+  readonly popThreshold?: number;
   readonly status?: boolean;
   // eslint-disable-next-line
   readonly [key: string]: any;
@@ -96,6 +98,8 @@ export type DistrictProperties = {
   readonly contiguity: "contiguous" | "non-contiguous" | "";
   readonly compactness: number;
   readonly demographics: DemographicCounts;
+  readonly percentDeviation?: number;
+  readonly populationDeviation?: number;
 };
 
 export interface IStaticFile {


### PR DESCRIPTION
## Overview

Adds Evaluate Mode view for Equal Population

- Add new screen
- Compute population deviation on backend and add to GeoJSON so we can style the map based on it
- Add diverging scale on map to display the deviation from the the expected population for a district

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Scenario A - incomplete project

![image](https://user-images.githubusercontent.com/66973361/114432889-2ba82300-9b8f-11eb-879f-92f86ccd7ebf.png)
![image](https://user-images.githubusercontent.com/66973361/114435115-cbff4700-9b91-11eb-8c13-c9c3ecf067be.png)


Holes in the map are no longer displayed 👍 
Each choropleth step is displayed properly 👍 

Scenario B - 'completed' project

![image](https://user-images.githubusercontent.com/66973361/114433052-5d20ee80-9b8f-11eb-84d4-8504d93df60d.png)
![image](https://user-images.githubusercontent.com/66973361/114435192-e20d0780-9b91-11eb-8498-da4253349127.png)




### Notes

~1) All areas which are not assigned to a district should ideally be no fill... any idea how we can do this?~

~2) It seems like the choropleth stops are getting a little messed up in some instances - but _only_ in the map, not the sidebar view. Namely, districts which are within the +/- 5% bucket appear to be getting knocked down a step?~


## Testing Instructions

- `./scripts/server`
- Open a project, click Evaluate -> Equal Population


Closes #606 
