### PR TITLE
Set map as unfeatured if private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow last district to be locked [#677](https://github.com/PublicMapping/districtbuilder/pull/677)
 - Allow editing at lower geolevels after toggling evaluate mode [#679](https://github.com/PublicMapping/districtbuilder/pull/679)
 - Fix off screen geounits deselected when using rectangle tool [#680](https://github.com/PublicMapping/districtbuilder/pull/680)
+- Set project as unfeatured if private [#686](https://github.com/PublicMapping/districtbuilder/pull/686)
 
 
 ## [1.3.0] - 2021-01-26

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -224,10 +224,13 @@ export class ProjectsController implements CrudController<Project> {
     ];
     const fields = whitelistedFields.filter(field => field in dto);
     const data = _.isEqual(_.pick(dataWithDefinitions, fields), _.pick(existingProject, fields))
-      ? dataWithDefinitions
+      ? { ...dataWithDefinitions }
       : { ...dataWithDefinitions, updatedDt: new Date() };
 
-    return this.service.updateOne(req, data);
+    return this.service.updateOne(req, {
+      ...data,
+      isFeatured: dto.visibility === ProjectVisibility.Private ? false : existingProject?.isFeatured
+    });
   }
 
   @Override()


### PR DESCRIPTION
## Overview

If a map is currently featured and then set to private, `isFeatured` is set to false and the map is no longer displayed on the Organization Screen

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


## Testing Instructions

- Login as an org admin and create a project
- Set a project as 'Published' from the Project screen
- Set that project to be featured from the Org admin page
- Go back to the project, and set it's visibility to 'Private'
- Go back to Org screen - expect that the project is no longer displayed there

Closes #684 
