### PR TITLE
Toggle map pan tool with spacebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
 
 - Add project evaluate view for Equal Population [#685](https://github.com/PublicMapping/districtbuilder/pull/685)
-
+- Toggle map pan tool when holding down spacebar in rectangle / paintbrush select mode [#687](https://github.com/PublicMapping/districtbuilder/pull/687)
 
 ### Changed
 
-
 ### Fixed
-
 
 ## [1.4.0] - 2021-04-12
 
@@ -66,11 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug where projects are created after closing Join Organization modal triggered from an organization's template [#673](https://github.com/PublicMapping/districtbuilder/pull/673)
 
 ### Fixed
+
 - Allow last district to be locked [#677](https://github.com/PublicMapping/districtbuilder/pull/677)
 - Allow editing at lower geolevels after toggling evaluate mode [#679](https://github.com/PublicMapping/districtbuilder/pull/679)
 - Fix off screen geounits deselected when using rectangle tool [#680](https://github.com/PublicMapping/districtbuilder/pull/680)
 - Set project as unfeatured if private [#686](https://github.com/PublicMapping/districtbuilder/pull/686)
-
 
 ## [1.3.0] - 2021-01-26
 

--- a/src/client/components/map/PaintBrushSelectionTool.ts
+++ b/src/client/components/map/PaintBrushSelectionTool.ts
@@ -1,6 +1,5 @@
 import throttle from "lodash/throttle";
 import MapboxGL from "mapbox-gl";
-
 import {
   DistrictsDefinition,
   FeatureId,
@@ -38,7 +37,8 @@ const PaintBrushSelectionTool: ISelectionTool = {
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
-    staticGeoLevels: UintArrays
+    staticGeoLevels: UintArrays,
+    setActive: (isActive: boolean) => void
   ) {
     map.boxZoom.disable();
     map.dragPan.disable();
@@ -117,7 +117,7 @@ const PaintBrushSelectionTool: ISelectionTool = {
       // Call functions for the following events
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
-
+      setActive(true);
       updateSelection(e);
     }
 
@@ -129,6 +129,7 @@ const PaintBrushSelectionTool: ISelectionTool = {
       // Remove these events now that finish has been called.
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
+      setActive(false);
     }
 
     function getFeaturesAtPoint(

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -47,7 +47,8 @@ const RectangleSelectionTool: ISelectionTool = {
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
-    staticGeoLevels: UintArrays
+    staticGeoLevels: UintArrays,
+    setActive: (isActive: boolean) => void
   ) {
     map.boxZoom.disable();
     map.dragPan.disable();
@@ -188,7 +189,7 @@ const RectangleSelectionTool: ISelectionTool = {
       // Call functions for the following events
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
-
+      setActive(true);
       initiallySelectedGeoUnits = featuresToUnlockedGeoUnits(
         getAllSelectedFeatures(),
         staticMetadata,
@@ -207,6 +208,7 @@ const RectangleSelectionTool: ISelectionTool = {
     }
 
     function onMouseUp(e: MouseEvent) {
+      setActive(false);
       // Capture xy coordinates
       finish([start, mousePos(e)]);
     }


### PR DESCRIPTION
## Overview

Toggles to the map pan ('grab') tool from the rectangle or paintbrush select tool when the spacebar is held.

- Prevent toggle when the user is actively selecting new elements with the rectangle tool

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible



## Testing Instructions

- `./scripts/server`
- Start selecting elements with the rectangle selection or paintbrush
- Hit spacebar - expect cursor to become map pan tool
- Hit spacebar again - expect cursor to return to rectangle select
- Continue selecting more elements, and hit the spacebar as you are selecting more elements. Expect - nothing happens

Closes #429 
