### PR TITLE
Fix accidental duplicate loading of topology service

### DIFF
--- a/src/server/src/healthcheck/healthcheck.module.ts
+++ b/src/server/src/healthcheck/healthcheck.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TerminusModule } from "@nestjs/terminus";
 
 import { DistrictsModule } from "../districts/districts.module";
@@ -7,7 +7,7 @@ import TopologyLoadedIndicator from "./topology-loaded.indicator";
 
 @Module({
   controllers: [HealthcheckController],
-  imports: [TerminusModule, DistrictsModule],
+  imports: [TerminusModule, forwardRef(() => DistrictsModule)],
   providers: [TopologyLoadedIndicator]
 })
 export class HealthCheckModule {}

--- a/src/server/src/region-configs/region-configs.module.ts
+++ b/src/server/src/region-configs/region-configs.module.ts
@@ -1,14 +1,14 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { RegionConfigsController } from "./controllers/region-configs.controller";
 import { RegionConfig } from "./entities/region-config.entity";
 import { RegionConfigsService } from "./services/region-configs.service";
-import { TopologyService } from "../districts/services/topology.service";
+import { DistrictsModule } from "../districts/districts.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RegionConfig])],
+  imports: [TypeOrmModule.forFeature([RegionConfig]), forwardRef(() => DistrictsModule)],
   controllers: [RegionConfigsController],
-  providers: [RegionConfigsService, TopologyService],
+  providers: [RegionConfigsService],
   exports: [RegionConfigsService, TypeOrmModule]
 })
 export class RegionConfigsModule {}


### PR DESCRIPTION
## Overview

NestJS won't ensure the service class is a singleton unless it is imported via it's module.

Services should rarely (if ever) be directly imported.


### Notes

I believe this problem has bitten us before.

Is it possible to add a lint rule or something similar to prevent this? Even something as simple as grepping for `imports:.*Service` would have caught this 😢 

### Testing

On this branch your `server` console output should look like this:
```
server_1    | [Nest] 239   - 04/13/2021, 5:43:48 PM   [RouterExplorer] Mapped {/api/project_templates, GET} route +0ms                                                                     
server_1    | [Nest] 239   - 04/13/2021, 5:43:48 PM   [NestApplication] Nest application successfully started +7ms                                                                         
server_1    | query: SELECT "RegionConfig"."id" AS "RegionConfig_id", "RegionConfig"."name" AS "RegionConfig_name", "RegionConfig"."country_code" AS "RegionConfig_country_code", "RegionConfig"."region_code" AS "RegionConfig_region_code", "RegionConfig"."s3_uri" AS "RegionConfig_s3_uri", "RegionConfig"."version" AS "RegionConfig_version", "RegionConfig"."hidden" AS "RegionConfig_hidden" FROM "region_config" "RegionConfig"
```

On the `release` branch it looks like this (note the duplicate SELECT ... FROM region_config):
```
server_1    | [Nest] 254   - 04/13/2021, 5:44:25 PM   [RouterExplorer] Mapped {/api/project_templates, GET} route +1ms                                                                     
server_1    | [Nest] 254   - 04/13/2021, 5:44:25 PM   [NestApplication] Nest application successfully started +6ms                                                                         
server_1    | query: SELECT "RegionConfig"."id" AS "RegionConfig_id", "RegionConfig"."name" AS "RegionConfig_name", "RegionConfig"."country_code" AS "RegionConfig_country_code", "RegionConfig"."region_code" AS "RegionConfig_region_code", "RegionConfig"."s3_uri" AS "RegionConfig_s3_uri", "RegionConfig"."version" AS "RegionConfig_version", "RegionConfig"."hidden" AS "RegionConfig_hidden" FROM "region_config" "RegionConfig"                                                                                                                                         
server_1    | query: SELECT "RegionConfig"."id" AS "RegionConfig_id", "RegionConfig"."name" AS "RegionConfig_name", "RegionConfig"."country_code" AS "RegionConfig_country_code", "RegionConfig"."region_code" AS "RegionConfig_region_code", "RegionConfig"."s3_uri" AS "RegionConfig_s3_uri", "RegionConfig"."version" AS "RegionConfig_version", "RegionConfig"."hidden" AS "RegionConfig_hidden" FROM "region_config" "RegionConfig"
```

Connects to #689 