### PR TITLE
Fix display for contiguity and compactness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
@@ -16,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
+- Display unassigned areas as transparent fill in Evaluate mode map [#694](https://github.com/PublicMapping/districtbuilder/pull/699)
+
 
 ## [1.4.0] - 2021-04-12
 
@@ -47,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project evaluate view for County Splits [#644](https://github.com/PublicMapping/districtbuilder/pull/644)
 - Display Import Map button on home screen when a user has not created maps yet [#674](https://github.com/PublicMapping/districtbuilder/pull/674)
 - Display export button in project header for published projects from other users [#681](https://github.com/PublicMapping/districtbuilder/pull/681)
-
 
 ### Changed
 

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -166,7 +166,9 @@ const ProjectEvaluateSidebar = ({
         "All parts of a district must be in physical contact with some other part of the district",
       type: "fraction",
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
-      value: geojson?.features.filter(f => f.properties.contiguity === "contiguous").length || 0
+      value:
+        geojson?.features.filter(f => f.properties.contiguity === "contiguous" && f.id !== 0)
+          .length || 0
     }
   ];
   const optionalMetrics: readonly EvaluateMetric[] = [

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -317,6 +317,7 @@ export function generateMapLayers(
       type: "fill",
       source: DISTRICTS_SOURCE_ID,
       layout: { visibility: "none" },
+      filter: ["match", ["get", "color"], ["transparent"], false, true],
       paint: {
         "fill-color": [
           "match",


### PR DESCRIPTION
## Overview

Fixes the display for contiguity and compactness by rendering unassigned areas with a transparent fill. Although the issue was originally tagged for only Contiguity display, this issue was also occurring in Compactness as well (and was already fixed as part of #685 for equal population)

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![image](https://user-images.githubusercontent.com/66973361/115298687-c672a580-a12b-11eb-82d4-f73c9d528b67.png)


![image](https://user-images.githubusercontent.com/66973361/115296847-7b579300-a129-11eb-92d2-476f9f6791d6.png)


## Testing Instructions

- Create a district, and then cut a hole in the district and add that back to the unassigned areas
- Open evaluate mode
- Expect: count of contiguous districts does not include unassigned area
- Expect: unassigned area is rendered as transparent fill in contiguity and compactness views

Closes #694 
