### PR TITLE
Add local eslint rule to detect impropert use of NestJS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toggle map pan tool when holding down spacebar in rectangle / paintbrush select mode [#687](https://github.com/PublicMapping/districtbuilder/pull/687)
 
 ### Changed
+- Change eslint config to detect misuse of NestJS services [#700](https://github.com/PublicMapping/districtbuilder/pull/700)
 
 ### Fixed
 

--- a/src/server/.eslintrc.js
+++ b/src/server/.eslintrc.js
@@ -35,6 +35,10 @@ module.exports = {
         }
       ],
       "no-console": [ "error" ],
+      "no-restricted-imports": ["error", {
+        // manage commands can't import server modules unless we always use relative imports
+        "patterns": ["src/*"]
+      }],
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/src/server/.eslintrc.js
+++ b/src/server/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
       "jsdoc",
       "prefer-arrow",
       "functional",
+      "eslint-plugin-local-rules"
     ],
     extends: [
       "eslint:recommended",
@@ -54,5 +55,6 @@ module.exports = {
       "functional/no-let": "off",
       "functional/no-loop-statement": "error",
       "functional/no-conditional-statement": ["off"],
+      "local-rules/no-providing-services-out-of-module": "error"
     }
   };

--- a/src/server/eslint-local-rules.js
+++ b/src/server/eslint-local-rules.js
@@ -1,0 +1,66 @@
+"use strict";
+
+function getDecoratorByName(node, name) {
+  const result = (("decorators" in node && node.decorators) || []).find(d => {
+    const expression = d.expression && d.expression.type === "CallExpression" && d.expression;
+    return expression && expression.callee.type === "Identifier" && expression.callee.name === name;
+  });
+  return result;
+}
+function getModuleProperty(node, option) {
+  const decorator = getDecoratorByName(node, "Module");
+  if (!decorator) {
+    return false;
+  }
+  const [argument] = decorator.expression.arguments;
+  const result =
+    argument.type === "ObjectExpression" &&
+    (argument.properties || []).find(property => {
+      return (
+        "key" in property && property.key.type === "Identifier" && property.key.name === option
+      );
+    });
+  return result && result.type === "Property" ? result : false;
+}
+const message =
+  "Don't use the `providers` property for services outside of the containing module. Instead, add the module the service is provided by to the `imports` property.";
+
+module.exports = {
+  "no-providing-services-out-of-module": {
+    meta: {
+      docs: {
+        description: "Dissallow directly importing services from other modules",
+        category: "Possible Errors",
+        recommended: true
+      },
+      schema: []
+    },
+    create: function(context) {
+      return {
+        ClassDeclaration: node => {
+          const property = getModuleProperty(node, "providers");
+          if (!property || property.value.type !== "ArrayExpression") {
+            return;
+          }
+          const servicesProvided = property.value.elements;
+          const outsideServiceProvided = servicesProvided.some(serviceId => {
+            const name = serviceId && serviceId.type === "Identifier" && serviceId.name;
+            const varSet = context.getScope().variableScope.set;
+            if (!name || !varSet.has(name)) {
+              return false;
+            }
+            const importPath = varSet
+              .get(name)
+              .defs.map(
+                def => def.parent.type === "ImportDeclaration" && def.parent.source.value
+              )[0];
+            return typeof importPath === "string" && importPath.startsWith("../");
+          });
+          if (outsideServiceProvided) {
+            context.report({ node: property, message: message });
+          }
+        }
+      };
+    }
+  }
+};

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-functional": "3.0.1",
     "eslint-plugin-import": "2.20.2",
     "eslint-plugin-jsdoc": "26.0.0",
+    "eslint-plugin-local-rules": "^1.1.0",
     "eslint-plugin-prefer-arrow": "1.2.1",
     "eslint-plugin-prettier": "3.1.3",
     "jest": "24.9.0",

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -21,8 +21,8 @@ import {
   IStaticMetadata
 } from "../../../../shared/entities";
 import { getAllBaseIndices, getDemographics } from "../../../../shared/functions";
+import { DistrictsGeoJSON } from "../../projects/entities/project.entity";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
-import { DistrictsGeoJSON } from "src/projects/entities/project.entity";
 
 interface GeoUnitHierarchy {
   geom: Polygon | MultiPolygon;

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -3211,6 +3211,11 @@ eslint-plugin-jsdoc@26.0.0:
     semver "^6.3.0"
     spdx-expression-parse "^3.0.1"
 
+eslint-plugin-local-rules@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.1.0.tgz#5f934f685b08c96eed40b92aee7b02f03cf55f7b"
+  integrity sha512-FdPyzxakUKgZkeNM3x/vvRcB6nCjTNbui5gWALhvcaH1R6aCiD37fWtdesagcyBpEe9S9XRHAJ8CJ4rUJ3K9tQ==
+
 eslint-plugin-prefer-arrow@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.1.tgz#9e2943cdae4476e41f94f50dd7a250f267db6865"


### PR DESCRIPTION
## Overview

Add local eslint rule to detect impropert use of NestJS services.

This is intended to prevent further occurrences of issues like #689, by checking statically to make sure we don't in the wrong module, which is a likely indicator that we are providing a service more than once (which when done with `TopologyService` has resulted in nearly doubling application memory requirements)

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

```
$ git diff | cat
diff --git a/src/server/src/healthcheck/healthcheck.module.ts b/src/server/src/healthcheck/healthcheck.module.ts
index 538ce94..8c7ca27 100644
--- a/src/server/src/healthcheck/healthcheck.module.ts
+++ b/src/server/src/healthcheck/healthcheck.module.ts
@@ -1,13 +1,13 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { TerminusModule } from "@nestjs/terminus";
 
-import { DistrictsModule } from "../districts/districts.module";
 import { HealthcheckController } from "./healthcheck.controller";
 import TopologyLoadedIndicator from "./topology-loaded.indicator";
+import { TopologyService } from "../districts/services/topology.service";
 
 @Module({
   controllers: [HealthcheckController],
-  imports: [TerminusModule, forwardRef(() => DistrictsModule)],
-  providers: [TopologyLoadedIndicator]
+  imports: [TerminusModule],
+  providers: [TopologyLoadedIndicator, TopologyService]
 })
 export class HealthCheckModule {}
$ ./scripts/yarn server lint
Creating districtbuilder_server_run ... done
yarn run v1.22.5
$ eslint 'src/**/*.{ts,tsx,json}'

/home/node/app/server/src/healthcheck/healthcheck.module.ts
  11:3  error  Don't use the `providers` property for services outside of the containing module. Instead, add the module the service is provided by to the `imports` property  local-rules/no-providing-services-out-of-module

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: 1
```

### Notes

I originally tried to write the rule in Typescript, but I couldn't figure out how to do that in a lightweight way (i.e. not requiring a separate _plugin_ with it's own `package.json` file) so I converted my rule to Javascript

## Testing Instructions


- `scripts/yarn server lint` should work and show no lint
- Switching a module from importing `DistrictsModule` in the `imports` option of `@Module({ ... })` to importing `TopologyService` directly and putting it in the `providers` option instead should trigger the bug from #689, and should also cause `scripts/yarn server lint` to detect the issue
