### PR TITLE
Make password validation visible in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Display unassigned areas as transparent fill in Evaluate mode map [#694](https://github.com/PublicMapping/districtbuilder/pull/699)
-
+- Make password validation visible in modal [#706](https://github.com/PublicMapping/districtbuilder/pull/706)
 
 ## [1.4.0] - 2021-04-12
 

--- a/src/client/components/CopyMapModal.tsx
+++ b/src/client/components/CopyMapModal.tsx
@@ -34,7 +34,7 @@ const style: ThemeUIStyleObject = {
     p: 5,
     width: "small",
     maxWidth: "90vw",
-    overflow: "hidden"
+    overflow: "visible"
   }
 };
 

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -136,8 +136,10 @@ const PasswordConstraint = ({
 }) => {
   const color = invalid ? "warning" : "inherit";
   return (
-    <Flex sx={{ flexDirection: "row", flex: 1 }}>
-      <Box sx={{ color: "success.4", width: "1rem", height: "1rem" }}>{!invalid && "✓"}</Box>
+    <Flex sx={{ flexDirection: "row", flex: 1, "&:not(:last-child)": { mb: "2" } }}>
+      <Box sx={{ color: "success.4", flexShrink: 0, width: "1rem", height: "1rem" }}>
+        {!invalid && "✓"}
+      </Box>
       <Box sx={{ flex: "auto", color }}>{children}</Box>
     </Flex>
   );
@@ -186,6 +188,8 @@ export function PasswordField<D, R>({
                 borderColor: "gray.2",
                 boxShadow: "small",
                 borderRadius: "small",
+                textTransform: "none",
+                lineHeight: "1.2",
                 "@media screen and (min-width: 1040px)": {
                   transform: "translateY(-50%)",
                   left: "100%",
@@ -193,7 +197,7 @@ export function PasswordField<D, R>({
                   top: "50%",
                   mb: "0",
                   ml: 2,
-                  width: "350px"
+                  width: "200px"
                 }
               }}
             >

--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -32,7 +32,7 @@ const style: ThemeUIStyleObject = {
     p: 5,
     width: "small",
     maxWidth: "90vw",
-    overflow: "hidden"
+    overflow: "visible"
   }
 };
 

--- a/src/client/screens/RegistrationScreen.tsx
+++ b/src/client/screens/RegistrationScreen.tsx
@@ -37,7 +37,7 @@ const RegistrationScreen = ({ user }: StateProps) => {
           <Card sx={{ variant: "card.floating" }}>
             <RegisterContent>
               <Heading as="h2" sx={{ mb: 5, textAlign: "left" }}>
-                Create an account
+                Create an account!
               </Heading>
               {showStartProjectAlert && (
                 <Alert sx={{ mb: 3 }}>


### PR DESCRIPTION


## Overview

The password validation panel was being cut off by the modal's `overflow: hidden` property. I
removed `overflow: hidden` from the modal. I also reformatted the validation panel to take up less
space, which should help us avoid situations where it would expand to the edge of the browser
window.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-04-23 at 9 36 17 AM](https://user-images.githubusercontent.com/1809908/115879181-6162cc80-a417-11eb-8bd0-a97510997e98.png)

### Notes

I experimented with rendering this panel above and below the field, but in both cases it blocked and
prevented interaction with other important elements on the page. I think this solution will work
well in a majority of cases.

## Testing Instructions

- If logged in, log out of DistrictBuilder
- Navigate to a map page
- Click on "Share" and then "Create an account"
- Click in the password input; a panel should appear explaining password requirements
- Confirm that the password requirements are a.) visible; b.) formatted like in the demo screenshot

Closes #579
