### PR TITLE
Fix organization admin table sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display unassigned areas as transparent fill in Evaluate mode map [#694](https://github.com/PublicMapping/districtbuilder/pull/699)
 - Minor style cleanup for organizations page and dropdown [#709](https://github.com/PublicMapping/districtbuilder/pull/709)
 - Make password validation visible in modal [#706](https://github.com/PublicMapping/districtbuilder/pull/706)
+- Sorting on organization admin table [#711](https://github.com/PublicMapping/districtbuilder/pull/711)
 
 ## [1.4.0] - 2021-04-12
 

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -1,14 +1,16 @@
 /** @jsx jsx */
-import { useMemo } from "react";
-import { useTable, Row, HeaderGroup, Cell, useSortBy } from "react-table";
+import { useMemo, useEffect, useState } from "react";
+import { useTable, Row, HeaderGroup, Cell, useSortBy, SortingRule, Column } from "react-table";
 import { Link } from "react-router-dom";
 import { Button, Flex, jsx, Styled } from "theme-ui";
 
-import { OrganizationSlug, ProjectNest } from "../../shared/entities";
+import { ProjectVisibility } from "../../shared/constants";
+import { OrganizationSlug, ProjectNest, IProjectTemplateWithProjects } from "../../shared/entities";
 
 import { toggleProjectFeatured } from "../actions/organizationProjects";
+import { formatDate } from "../functions";
 import store from "../store";
-import { ProjectVisibility } from "../../shared/constants";
+import { isEqual } from "lodash";
 
 export interface ProjectRow extends ProjectNest {
   readonly project: { readonly name: string; readonly id: string };
@@ -17,7 +19,7 @@ export interface ProjectRow extends ProjectNest {
 }
 
 interface ProjectsTableProps {
-  readonly projects: readonly ProjectRow[];
+  readonly templates?: readonly IProjectTemplateWithProjects[];
   readonly organizationSlug: OrganizationSlug;
 }
 
@@ -32,12 +34,35 @@ const style = {
   columnRow: { padding: "10px", border: "solid 1px gray" }
 } as const;
 
-const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: ProjectsTableProps) => {
-  const columns = useMemo(
+const OrganizationAdminProjectsTable = ({ templates, organizationSlug }: ProjectsTableProps) => {
+  // eslint-disable-next-line
+  const [projects, setProjects] = useState<ProjectRow[]>([]);
+  useEffect(() => {
+    if (templates) {
+      const resourceProjects = templates
+        .map(pt => {
+          return pt.projects.map(p => {
+            return {
+              ...p,
+              project: { name: p.name, id: p.id },
+              updatedAgo: formatDate(p.updatedDt),
+              templateName: pt.name
+            };
+          });
+        })
+        .flat();
+      if (!isEqual(projects, resourceProjects)) {
+        setProjects(resourceProjects);
+      }
+    }
+  }, [projects, templates]);
+
+  // eslint-disable-next-line
+  let columns = useMemo<Array<Column<ProjectRow>>>(
     () => [
       {
         Header: "Map",
-        accessor: "project", // accessor is the "key" in the data,
+        accessor: "project" as const,
         Cell: (p: Cell<ProjectRow>) => {
           return (
             <Styled.a as={Link} to={`/projects/${p.value.id}`} target="_blank">
@@ -48,46 +73,60 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
       },
       {
         Header: "Template",
-        accessor: "templateName"
+        accessor: "templateName" as const
       },
       {
         Header: "Creator",
-        accessor: "user.name"
+        accessor: row => row.user.name
       },
       {
         Header: "Creator email",
-        accessor: "user.email",
+        accessor: row => row.user.email,
         Cell: (p: Cell<ProjectRow>) => {
           return <a href={`mailto:${p.value}`}>{p.value}</a>;
         }
       },
+
       {
         Header: "Updated on",
-        accessor: "updatedDt",
+        accessor: "updatedDt" as const,
         Cell: (p: Cell<ProjectRow>) => {
           return p.row.original.updatedAgo;
         }
+      },
+      {
+        Header: "",
+        accessor: "visibility" as const,
+        disableSortBy: true,
+        Cell: ({ row }: Cell<ProjectRow>) => {
+          return row.original.visibility === ProjectVisibility.Published ? (
+            <Button
+              onClick={() =>
+                store.dispatch(
+                  toggleProjectFeatured({ project: row.original, organization: organizationSlug })
+                )
+              }
+            >
+              {row.original.isFeatured ? "Unfeature" : "Feature"}
+            </Button>
+          ) : (
+            "Unpublished"
+          );
+        }
       }
     ],
-    []
+    [organizationSlug]
   );
-  const data = useMemo(() => projects, [projects]);
-  // ts-ignore needed below bc react-table requires mutable types, even though it doesn't mutate them?
+  // eslint-disable-next-line
+  let data = useMemo(() => projects, [projects]);
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable<ProjectRow>(
     {
-      // @ts-ignore
       columns,
       // @ts-ignore
       data
     },
     useSortBy
   );
-
-  function projectFeaturedToggle(row: Row<ProjectRow>) {
-    store.dispatch(
-      toggleProjectFeatured({ project: row.original, organization: organizationSlug })
-    );
-  }
 
   // The 'key' is provided by react-table - note that if you try to add one there is a separate
   // error about duplicate props. It seems eslint can't figure it out.
@@ -107,7 +146,6 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
                   <span>{column.isSorted ? (column.isSortedDesc ? " 🔽" : " 🔼") : ""}</span>
                 </th>
               ))}
-              <th sx={style.columnHeader}></th>
             </tr>
           ))}
         </thead>
@@ -129,15 +167,6 @@ const OrganizationAdminProjectsTable = ({ projects, organizationSlug }: Projects
                     </td>
                   );
                 })}
-                <td sx={{ textAlign: "center" }}>
-                  {row.original.visibility === ProjectVisibility.Published ? (
-                    <Button onClick={() => projectFeaturedToggle(row)}>
-                      {row.original.isFeatured ? "Unfeature" : "Feature"}
-                    </Button>
-                  ) : (
-                    "Unpublished"
-                  )}
-                </td>
               </tr>
             );
           })}

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -57,6 +57,7 @@ const OrganizationAdminProjectsTable = ({ templates, organizationSlug }: Project
     }
   }, [projects, templates]);
 
+  const sort = useMemo<SortingRule<ProjectRow>>(() => ({ id: "updatedDt", desc: true }), []);
   // eslint-disable-next-line
   let columns = useMemo<Array<Column<ProjectRow>>>(
     () => [
@@ -122,8 +123,11 @@ const OrganizationAdminProjectsTable = ({ templates, organizationSlug }: Project
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable<ProjectRow>(
     {
       columns,
-      // @ts-ignore
-      data
+      data,
+      autoResetSortBy: false,
+      initialState: {
+        sortBy: [sort]
+      }
     },
     useSortBy
   );


### PR DESCRIPTION
## Overview

Fixes the sorting on the organization admin table to:
 - Pre-sort by updated date, with most recent at the top (like the home screen)
 - Preserves the sort order when updating the data

Also cleans up the type usage around `react-table`
 - I cleaned up the `ProjectRow` type and moved use of it into the table component
 - I got rid of the of some of the `@ts-ignore` comments by adding `as const` and switching from the "nested.object.keys" syntax to a helper function

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![output](https://user-images.githubusercontent.com/4432106/116125096-17861a80-a693-11eb-9367-7b89622a5790.gif)


## Testing Instructions

- `scripts/server`
- Play around with the org admin table - dates should sort correctly, and 

Closes #678 
