### PR TITLE
Fix Organization bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor style cleanup for organizations page and dropdown [#709](https://github.com/PublicMapping/districtbuilder/pull/709)
 - Make password validation visible in modal [#706](https://github.com/PublicMapping/districtbuilder/pull/706)
 - Sorting on organization admin table [#711](https://github.com/PublicMapping/districtbuilder/pull/711)
+- Fix joining/leaving organization with an inactive project template [#721](https://github.com/PublicMapping/districtbuilder/pull/721)
+- Show maps for inactive project templates [#721](https://github.com/PublicMapping/districtbuilder/pull/721)
 
 ## [1.4.0] - 2021-04-12
 

--- a/src/server/src/organizations/controllers/organizations.controller.ts
+++ b/src/server/src/organizations/controllers/organizations.controller.ts
@@ -15,8 +15,16 @@ import { OrganizationsService } from "../services/organizations.service";
 export class OrganizationsController {
   constructor(public service: OrganizationsService, private readonly usersService: UsersService) {}
 
-  async getOrg(organizationSlug: OrganizationSlug): Promise<Organization> {
+  async getOrgAndTemplates(organizationSlug: OrganizationSlug): Promise<Organization> {
     const org = await this.service.getOrgAndProjectTemplates(organizationSlug);
+    if (!org) {
+      throw new NotFoundException(`Organization ${organizationSlug} not found`);
+    }
+    return org;
+  }
+
+  async getOrg(organizationSlug: OrganizationSlug): Promise<Organization> {
+    const org = await this.service.findOne({ slug: organizationSlug });
     if (!org) {
       throw new NotFoundException(`Organization ${organizationSlug} not found`);
     }
@@ -37,7 +45,7 @@ export class OrganizationsController {
   @UseGuards(OptionalJwtAuthGuard)
   @Get(":slug/")
   async getOne(@Param("slug") slug: OrganizationSlug): Promise<Organization> {
-    return this.getOrg(slug);
+    return this.getOrgAndTemplates(slug);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -20,7 +20,6 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .innerJoinAndSelect("projectTemplate.projects", "projects")
       .innerJoinAndSelect("projects.user", "user")
       .where("organization.slug = :slug", { slug: slug })
-      .andWhere("projectTemplate.isActive = TRUE")
       .select([
         "projectTemplate.name",
         "projectTemplate.numberOfDistricts",
@@ -48,7 +47,6 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .leftJoinAndSelect("projectTemplate.projects", "projects", "projects.isFeatured = TRUE")
       .innerJoinAndSelect("projects.user", "user")
       .where("organization.slug = :slug", { slug: slug })
-      .andWhere("projectTemplate.isActive = TRUE")
       .select([
         "projectTemplate.name",
         "projectTemplate.numberOfDistricts",


### PR DESCRIPTION
## Overview

Fixes two bugs 
- you couldn't leave an organization with an inactive project template, which bizarrely had a root cause of missing some fields from the custom SQL select we were using
- shows maps for project templates which are not active

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Note the featured map despite no active project templates, and also we can actually leave the organization:
![output](https://user-images.githubusercontent.com/4432106/116482098-747bff00-a852-11eb-96af-f42a77abab3f.gif)

## Testing Instructions

- Set up an organization with at least one template
- Create a map for that template, and publish it
- Using `scripts/dbshell` set `is_active` to `FALSE` on the project template assoicated with your map
- It should still appear on the organization admin screen.
- If you feature your map, it should still appear on the organization home screen
- Even with an inactive project template, you should be able to leave the organization

Closes #714 
Closes #715 
