### PR TITLE
Log non-HTTP errors to Rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change eslint config to detect misuse of NestJS services [#700](https://github.com/PublicMapping/districtbuilder/pull/700)
+- Log non-HTTP errors to Rollbar [#725](https://github.com/PublicMapping/districtbuilder/pull/725)
 
 ### Fixed
 

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -30,7 +30,7 @@ export class RollbarExceptionFilter extends BaseExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost): void {
     if (
       (exception instanceof HttpException && !isWhitelisted(exception)) ||
-      exception instanceof Error
+      (exception instanceof Error && !(exception instanceof HttpException))
     ) {
       const ctx = host.switchToHttp();
       const request = ctx.getRequest<Request>();

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -28,7 +28,10 @@ export class RollbarExceptionFilter extends BaseExceptionFilter {
   }
 
   catch(exception: unknown, host: ArgumentsHost): void {
-    if (exception instanceof HttpException && !isWhitelisted(exception)) {
+    if (
+      (exception instanceof HttpException && !isWhitelisted(exception)) ||
+      exception instanceof Error
+    ) {
       const ctx = host.switchToHttp();
       const request = ctx.getRequest<Request>();
 


### PR DESCRIPTION
## Overview

Our logic was a little flawed in that we required errors to be
`HttpException`s to be logged to Rollbar. However, we also want to know
about other types of unhandled exceptions.

This is slightly tricky in terms of types since in JavaScript, bizarrely, you can
actually throw _any_ type (does not need to be an `Error` or extend
`Error`). However, that seems to be enough of an edge case that we don't
have to worry about it.

In the specific case of the leaving-an-organization bug, that generated
a `QueryFailedError` which is why it was not sent to Rollbar.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions
I didn't super fully test this manually since it seems to be a very straightforward change. If you know of a way to get staging to throw an unhandled, non-whitelisted error, that would be a good test. To test in development, you could simply modify some route to throw an error of some kind and then add some logging within the if block, though you may have to fiddle with the service to make the error be caught (not sure).

Another way to test on staging would be intentionally revert one of the recent bug fixes and deploy to staging but that didn't seem to be worth the trouble (though I can do that if we think it's worthwhile).

Closes #712 
