### PR TITLE
Add Vagrant Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ src/cli/lib
 # Manage build
 src/manage/lib
 
+# Ansible
+deployment/ansible/roles/azavea.*
+
 # Terraform
 .terraform
 .terraform/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ deployment/ansible/roles/azavea.*
 *.tfstate.backup
 *.tfvars
 .idea/
+
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display target population symbols in sidebar [#720](https://github.com/PublicMapping/districtbuilder/issues/720)
 - List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796)
 - Add map export to organization admin screen [#805](https://github.com/PublicMapping/districtbuilder/pull/805)
+- Add support for Vagrant Development Environment [#729](https://github.com/PublicMapping/districtbuilder/pull/729)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ DistrictBuilder is web-based, open source software for collaborative redistricti
 
 - [Requirements](#requirements)
 - [Development](#development)
+  - [Host Environments](#host-environments)
+    - [Linux](#linux)
+    - [macOS](#macos)
   - [Hot Reloading 🔥](#hot-reloading-)
   - [Remote Server Proxy](#remote-server-proxy)
   - [Project Organization](#project-organization)
@@ -28,21 +31,56 @@ DistrictBuilder is web-based, open source software for collaborative redistricti
 Ensure that you have an AWS credential profile for `district-builder` configured on your host system.
 The server backend will need this in order to access S3 assets.
 
-Run `scripts/setup` to prepare the development environment:
+### Host Environments
+
+The Docker containers used in development work very well on Linux, but require an additional layer of translation when running on non-Linux hosts. In particular, there are significant file-watching costs, which result in high CPU usage on macOS. On macOS, it is more efficient to run the containers within a Linux VM created with Vagrant.
+
+#### Linux
+
+On Linux, run `scripts/setup` to prepare the development environment:
 
 ```bash
 $ ./scripts/setup
 ```
+
+All other scripts can be run natively from the host, e.g.
+
+```bash
+$ ./scripts/update
+```
+
+#### macOS
+
+On macOS, use the `--vagrant` flag to create a Vagrant VM instead:
+
+```bash
+$ ./scripts/setup --vagrant
+```
+
+All other scripts must be run from the Vagrant VM, e.g.
+
+```bash
+$ vagrant ssh
+vagrant@vagrant:/vagrant$ ./scripts/update
+```
+
+or
+
+```bash
+$ vagrant ssh -c 'cd /vagrant && ./scripts/update'
+```
+
+For brevity, this document will use Linux examples throughout. You should run the scripts from the appropriate environment.
+
+_Note:_ It is recommended to configure your editor to auto-format your code via Prettier on save.
+
+### Hot Reloading 🔥
 
 Next, run `scripts/server` to start the application:
 
 ```bash
  $ ./scripts/server
 ```
-
-_Note:_ It is recommended to configure your editor to auto-format your code via Prettier on save.
-
-### Hot Reloading 🔥
 
 While `server` is running, the [Create React App](https://github.com/facebook/create-react-app/) frontend will automatically [reload](https://github.com/facebook/create-react-app/#whats-included) when changes are made. Additionally, the [NestJS](https://nestjs.com/) backend will [restart](https://docs.nestjs.com/cli/usages#nest-start) when changes are made.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 2.2"
+
+ANSIBLE_VERSION = "2.9.*"
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "bento/ubuntu-20.04"
+
+  config.vm.synced_folder "./", "/vagrant"
+  config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 4096
+    vb.cpus = 4
+  end
+
+  # Nest JS
+  config.vm.network :forwarded_port, guest: 3005, host: 3005
+
+  # React
+  config.vm.network :forwarded_port, guest: 3003, host: 3003
+
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.compatibility_mode = "2.0"
+    ansible.extra_vars = { ansible_python_interpreter: "/usr/bin/python3" }
+    ansible.install_mode = "pip_args_only"
+    ansible.pip_install_cmd = "sudo apt-get install -y python3-distutils && curl https://bootstrap.pypa.io/pip/get-pip.py | sudo python3"
+    ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
+    ansible.playbook = "deployment/ansible/district-builder.yml"
+    ansible.galaxy_role_file = "deployment/ansible/roles.yml"
+    ansible.galaxy_roles_path = "deployment/ansible/roles"
+  end
+
+  config.vm.provision "shell" do |s|
+    s.inline = <<-SHELL
+    if ! grep -q "cd /vagrant" "/home/vagrant/.bashrc"; then
+      echo "cd /vagrant" >> "/home/vagrant/.bashrc"
+    fi
+
+    export AWS_PROFILE=district-builder
+
+    cd /vagrant
+    su vagrant ./scripts/update
+    SHELL
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
   config.vm.provider :virtualbox do |vb|
-    vb.memory = 4096
+    vb.memory = 6144
     vb.cpus = 4
   end
 

--- a/deployment/ansible/district-builder.yml
+++ b/deployment/ansible/district-builder.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  become: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes cache_valid_time=3600
+
+  roles:
+    - { role: "district-builder.devtools" }
+    - { role: "district-builder.docker" }
+    - { role: "district-builder.environment" }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,0 +1,10 @@
+---
+pip_version: "20.3.*"
+
+aws_cli_version: "1.18.*"
+aws_profile: "district-builder"
+
+docker_version: "5:19.*"
+docker_compose_version: "1.26.*"
+docker_users:
+  - "vagrant"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,8 +1,8 @@
 - src: azavea.pip
-  version: 2.0.0
+  version: 2.0.1
 
 - src: azavea.docker
-  version: 5.0.0
+  version: 6.0.0
 
 - src: azavea.aws-cli
   version: 0.1.0

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,0 +1,8 @@
+- src: azavea.pip
+  version: 2.0.0
+
+- src: azavea.docker
+  version: 5.0.0
+
+- src: azavea.aws-cli
+  version: 0.1.0

--- a/deployment/ansible/roles/district-builder.devtools/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.devtools/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+  - name: Install httpie
+    pip: name="httpie"

--- a/deployment/ansible/roles/district-builder.docker/meta/main.yml
+++ b/deployment/ansible/roles/district-builder.docker/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: azavea.pip }
+  - { role: azavea.docker }

--- a/deployment/ansible/roles/district-builder.docker/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.docker/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Docker Compose
+  pip: name=docker-compose version="{{ docker_compose_version }}"
+
+- name: Add Ansible user to Docker group
+  user: name="{{ item }}"
+        groups=docker
+        append=yes
+  with_items: "{{ docker_users }}"

--- a/deployment/ansible/roles/district-builder.docker/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.docker/tasks/main.yml
@@ -7,3 +7,10 @@
         groups=docker
         append=yes
   with_items: "{{ docker_users }}"
+
+- name: Increase file watching limit for Node
+  sysctl: name=fs.inotify.max_user_watches
+          value=524288
+          sysctl_set=yes
+          state=present
+          reload=yes

--- a/deployment/ansible/roles/district-builder.environment/meta/main.yml
+++ b/deployment/ansible/roles/district-builder.environment/meta/main.yml
@@ -1,0 +1,3 @@
+---
+  dependencies:
+    - { role: azavea.aws-cli }

--- a/deployment/ansible/roles/district-builder.environment/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.environment/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Set AWS_PROFILE
+  lineinfile:
+    path: "/etc/environment"
+    regexp: "^AWS_PROFILE="
+    line: "AWS_PROFILE={{ aws_profile }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - ./src/server:/home/node/app/server
       - ./src/shared:/home/node/app/shared
+      - /var/cache/district-builder-server-node-modules:/home/node/app/server/node_modules
       - $HOME/.cache/district-builder:/usr/local/share/.cache/yarn
       - $HOME/.aws:/root/.aws:ro
     working_dir: /home/node/app/server
@@ -51,6 +52,7 @@ services:
     volumes:
       - ./:/home/node/app
       - ./src/server/dist/server/src/static:/home/node/app/build
+      - /var/cache/district-builder-client-node-modules:/home/node/app/node_modules
       - $HOME/.cache/district-builder:/usr/local/share/.cache/yarn
     working_dir: /home/node/app
     command: yarn start
@@ -72,6 +74,8 @@ services:
       - ./src/server:/home/node/app/server
       - ./src/shared:/home/node/app/shared
       - ./src/manage:/home/node/app/manage
+      - /var/cache/district-builder-server-node-modules:/home/node/app/server/node_modules
+      - /var/cache/district-builder-manage-node-modules:/home/node/app/manage/node_modules
       - $HOME/.cache/district-builder:/usr/local/share/.cache/yarn
       - $HOME/.aws:/root/.aws:ro
     working_dir: /home/node/app/manage

--- a/scripts/setup
+++ b/scripts/setup
@@ -8,14 +8,20 @@ fi
 
 function usage() {
     echo -n \
-        "Usage: $(basename "$0")
-Setup the project's development environment.
+        "Usage: $(basename "$0") [--vagrant]
+Setup the project's Docker-based development environment.
+This is recommended for Linux hosts.
+
+Optionally use --vagrant to setup a Vagrant-based environment.
+This is recommended for macOS hosts.
 "
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
+    elif [ "${1:-}" = "--vagrant" ]; then
+        vagrant up --provision
     else
         ./scripts/update
     fi


### PR DESCRIPTION
## Overview

This project is really slow to work with on Mac OS due to issues with running Docker on Mac (see #43).

This PR adds a Vagrant environment that can be used on non-Linux hosts to provide a Linux-like environment in which Docker runs natively and much faster.

On `develop`, running the `update` script can take ~20 minutes. Inside Vagrant, it takes ~4.5 minutes.

### Checklist

- [x] Update README with appropriate instructions for non-Linux environments
- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

* Checkout this branch and `vagrant up`
* SSH in to the Vagrant VM `vagrant ssh`
* Run `./scripts/update`
  - [x] Ensure it runs faster than before 
* Run `./scripts/server`
  - [x] Ensure the server runs correctly http://localhost:3003/
* Make a small change in some front-end file
  - [x] Ensure it is picked up and hot-reload / TypeScript checking works as expected
* Make an account, then load dev data `./scripts/load-dev-data`
  - [x] Ensure the import succeeds
* Do other development-y things
  - [x] Ensure the app works in general and all existing development workflows work
