### PR TITLE
Voting data ingest

### DIFF
--- a/src/client/components/FeaturedProjectCard.tsx
+++ b/src/client/components/FeaturedProjectCard.tsx
@@ -53,7 +53,7 @@ const FeaturedProjectCard = ({ project }: { readonly project: ProjectNest }) => 
 
   // TODO #179 - the districts property can't be defined in the shared/entities.d.ts right now
   // @ts-ignore
-  const districts: DistrictGeoJSON | undefined = project.districts;
+  const districts: DistrictsGeoJSON | undefined = project.districts;
 
   useEffect(() => {
     if (mapRef.current === null) {

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,7 +1,12 @@
 /** @jsx jsx */
 import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
-import { areAnyGeoUnitsSelected, geoLevelLabel, isBaseGeoLevelAlwaysVisible } from "../functions";
+import {
+  areAnyGeoUnitsSelected,
+  geoLevelLabel,
+  isBaseGeoLevelAlwaysVisible,
+  capitalizeFirstLetter
+} from "../functions";
 import MapSelectionOptionsFlyout from "./MapSelectionOptionsFlyout";
 
 import Icon from "./Icon";
@@ -140,8 +145,6 @@ const GeoLevelButton = ({
     </Box>
   );
 };
-
-const capitalizeFirstLetter = (s: string) => s.substring(0, 1).toUpperCase() + s.substring(1);
 
 const MapHeader = ({
   label,

--- a/src/client/components/VotingTooltip.tsx
+++ b/src/client/components/VotingTooltip.tsx
@@ -1,0 +1,90 @@
+/** @jsx jsx */
+import mapValues from "lodash/mapValues";
+import { Box, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
+
+import { getPartyColor, capitalizeFirstLetter } from "../functions";
+
+const style: ThemeUIStyleObject = {
+  label: {
+    textAlign: "left",
+    py: 0,
+    px: 2,
+    textTransform: "capitalize"
+  },
+  number: {
+    flex: "auto",
+    textAlign: "right",
+    fontVariant: "tabular-nums",
+    py: 0,
+    px: 1,
+    fontWeight: "light"
+  }
+};
+
+const Row = ({
+  party,
+  votes,
+  percent,
+  color
+}: {
+  readonly party: string;
+  readonly votes?: number;
+  readonly percent?: number;
+  readonly color: string;
+}) => (
+  <Styled.tr
+    sx={{
+      color: "muted",
+      border: "none"
+    }}
+  >
+    <Styled.td>
+      <Box
+        style={{
+          backgroundColor: color
+        }}
+        sx={{
+          height: "15px",
+          width: "15px"
+        }}
+      />
+    </Styled.td>
+    <Styled.td sx={style.label}>
+      <b>{capitalizeFirstLetter(party)}</b>
+    </Styled.td>
+    <Styled.td sx={style.number}>{votes?.toLocaleString(undefined)}</Styled.td>
+    <Styled.td sx={style.number}>
+      {percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0"}
+      {"%"}
+    </Styled.td>
+  </Styled.tr>
+);
+
+const VotingTooltip = ({
+  voting,
+  votingIds
+}: {
+  readonly voting: { readonly [id: string]: number };
+  readonly votingIds: readonly string[];
+}) => {
+  const total = Object.values(voting).reduce((a, b) => a + b, 0);
+  const percentages = mapValues(voting, (votes: number) => (total ? votes / total : 0) * 100);
+  const rows = votingIds.map(party => (
+    <Row
+      key={party}
+      party={party}
+      votes={voting[party]}
+      percent={percentages[party]}
+      color={getPartyColor(party)}
+    />
+  ));
+  return (
+    <Box sx={{ width: "100%", minHeight: "100%" }}>
+      <Styled.table sx={{ margin: "0", width: "100%" }}>
+        <tbody>{rows}</tbody>
+      </Styled.table>
+    </Box>
+  );
+};
+
+export default VotingTooltip;

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -34,6 +34,12 @@ export function allGeoUnitIds(geoUnits: GeoUnits) {
   return Object.values(geoUnits).flatMap(geoUnitForLevel => Array.from(geoUnitForLevel.keys()));
 }
 
+export const capitalizeFirstLetter = (s: string) =>
+  s.substring(0, 1).toUpperCase() + s.substring(1);
+
+export const getPartyColor = (party: string) =>
+  party === "republican" ? "#BF4E6A" : party === "democrat" ? "#4E56BF" : "#F7AD00";
+
 /*
  * Assign nested geounit to district.
  *

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -1,4 +1,4 @@
-import { FeatureCollection, MultiPolygon } from "geojson";
+import { Feature, FeatureCollection, MultiPolygon } from "geojson";
 import * as H from "history";
 import {
   IProject,

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -75,9 +75,10 @@ export class TopologyService {
           this.logger.error(`geoLevelHierarchy missing from static metadata for ${s3URI}`);
         }
         const topology = JSON.parse(topojsonBody) as Topology;
-        const [demographics, geoLevels] = await Promise.all([
+        const [demographics, geoLevels, voting] = await Promise.all([
           this.fetchStaticFiles(s3URI, staticMetadata.demographics),
-          this.fetchStaticFiles(s3URI, staticMetadata.geoLevels)
+          this.fetchStaticFiles(s3URI, staticMetadata.geoLevels),
+          this.fetchStaticFiles(s3URI, staticMetadata.voting || [])
         ]);
 
         this.logger.debug(`downloaded data for s3URI ${s3URI}`);
@@ -86,6 +87,7 @@ export class TopologyService {
           { groups: geoLevelHierarchy.slice().reverse() },
           staticMetadata,
           demographics,
+          voting,
           geoLevels
         );
       } else {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -106,3 +106,5 @@ export const FIPS: { readonly [fips: string]: string } = {
 
 // Maximum allowable upload size, in bytes
 export const MaxUploadFileSize = 25_000_000;
+
+export const REGION_LABELS = ["election"] as const;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -1,4 +1,4 @@
-import { ProjectVisibility } from "./constants";
+import { ProjectVisibility, REGION_LABELS } from "./constants";
 
 export type UserId = string;
 
@@ -121,6 +121,7 @@ export interface GeoLevelInfo {
 }
 
 export type GeoLevelHierarchy = readonly GeoLevelInfo[];
+export type RegionLabels = Record<typeof REGION_LABELS[number], string>;
 
 export interface IStaticMetadata {
   readonly demographics: readonly IStaticFile[];
@@ -128,6 +129,7 @@ export interface IStaticMetadata {
   readonly voting?: readonly IStaticFile[];
   readonly bbox: readonly [number, number, number, number];
   readonly geoLevelHierarchy: GeoLevelHierarchy;
+  readonly labels?: RegionLabels;
 }
 
 export interface Login {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -98,6 +98,7 @@ export type DistrictProperties = {
   readonly contiguity: "contiguous" | "non-contiguous" | "";
   readonly compactness: number;
   readonly demographics: DemographicCounts;
+  readonly voting?: DemographicCounts;
   /* eslint-disable */
   // NOTE: These properties are set for styling purposes
   color?: string;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -125,6 +125,7 @@ export type GeoLevelHierarchy = readonly GeoLevelInfo[];
 export interface IStaticMetadata {
   readonly demographics: readonly IStaticFile[];
   readonly geoLevels: readonly IStaticFile[];
+  readonly voting?: readonly IStaticFile[];
   readonly bbox: readonly [number, number, number, number];
   readonly geoLevelHierarchy: GeoLevelHierarchy;
 }

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -1,4 +1,4 @@
-import { UintArray, DemographicCounts, IStaticMetadata } from "../shared/entities";
+import { UintArray, DemographicCounts, IStaticMetadata, IStaticFile } from "../shared/entities";
 
 // Helper for finding all indices in an array buffer matching a value.
 // Note: mutation is used, because the union type of array buffers proved
@@ -38,14 +38,38 @@ export function getDemographics(
   staticMetadata: IStaticMetadata,
   staticDemographics: readonly UintArray[]
 ): DemographicCounts {
-  // Aggregate demographic data for the IDs
-  return staticMetadata.demographics.reduce((data, demographic, ind) => {
+  return getAggregatedCounts(
+    baseIndices,
+    staticMetadata,
+    staticDemographics,
+    staticMetadata.demographics
+  );
+}
+
+export function getVoting(
+  baseIndices: readonly number[] | ReadonlySet<number>,
+  staticMetadata: IStaticMetadata,
+  staticVoting: readonly UintArray[]
+): DemographicCounts {
+  return staticMetadata.voting
+    ? getAggregatedCounts(baseIndices, staticMetadata, staticVoting, staticMetadata.voting)
+    : {};
+}
+
+export function getAggregatedCounts(
+  baseIndices: readonly number[] | ReadonlySet<number>,
+  staticMetadata: IStaticMetadata,
+  staticFiles: readonly UintArray[],
+  fileProperties: readonly IStaticFile[]
+): DemographicCounts {
+  // Aggregate numeric data for the IDs
+  return fileProperties.reduce((data, props, ind) => {
     let count: number = 0; // eslint-disable-line
     baseIndices.forEach((v: number) => {
-      if (!isNaN(staticDemographics[ind][v])) {
-        count += staticDemographics[ind][v];
+      if (!isNaN(staticFiles[ind][v])) {
+        count += staticFiles[ind][v];
       }
     });
-    return { ...data, [demographic.id]: count };
+    return { ...data, [props.id]: count };
   }, {} as DemographicCounts);
 }


### PR DESCRIPTION
## Overview

First pass at adding voting data to the `process-geojson` script, along with it's first use on the map sidebar with a new column/tooltip.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/117313806-37b49700-ae54-11eb-9834-df8d6d5dad87.png)

![image](https://user-images.githubusercontent.com/4432106/117313859-4307c280-ae54-11eb-9762-818b6db9970a.png)


### Notes

 - This structure works for now, but I imagine relatively soon we'll need to handle _multiple elections_ of information - which will probably require shifting to something more structured, at least in how we handle labels.
 
   The current strategy where the `id` _is_ the label with the 1st char capitalized is showing some growing pains - I had to make `other` be `other party` to avoid a clash with the `other` demographic.

## Testing Instructions

- Test the processing / publishing of Topojson for `VA.geojson` (file located on the fileshare at `\\fileshare.internal.azavea.com\projects\Azavea_DistrictBuilder\clients\Sloan-DistrictBuilder2\data\state-batches\1\PL94-171-with-election-results`)
- Create a new map using the processed region
  - Exports should work & include voting info fields
  - Pol. column / tooltip should appear on the sidebar
  - The new region should be _backwards compatible_ with the `develop` branch (i.e. you will not see any voting related data, but the map still works)
  
Closes #691 
Closes #692
