### PR TITLE
Fix off-by-one error in handling locked districts map interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix joining/leaving organization with an inactive project template [#721](https://github.com/PublicMapping/districtbuilder/pull/721)
 - Show maps for inactive project templates [#721](https://github.com/PublicMapping/districtbuilder/pull/721)
 - Only check file extension and not file type for CSV imports [#723](https://github.com/PublicMapping/districtbuilder/pull/723)
+- Fix off-by-one error in district lock handling [#741](https://github.com/PublicMapping/districtbuilder/pull/741)
 
 ## [1.4.0] - 2021-04-12
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -489,12 +489,12 @@ function isGeoUnitLocked(
       )
     : typeof districtsDefinition === "number"
     ? // Check if this specific district is locked
-      lockedDistricts[districtsDefinition]
+      lockedDistricts[districtsDefinition - 1]
     : // Check if any district at this geolevel is locked
       districtsDefinition.some(districtId =>
         typeof districtId === "number"
           ? // Whole district is assigned so it can be looked up directly
-            lockedDistricts[districtId]
+            lockedDistricts[districtId - 1]
           : // District definition has more nesting so it must be followed further
             isGeoUnitLocked(districtId, lockedDistricts, geoUnitIndices)
       );


### PR DESCRIPTION
## Overview

We were properly displaying `lockedDistricts` as 0-indexed, but the click-handler code was still treating it as `1-indexed` as we did before #677.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- On `develop`, locking a district will appear to work, but interactions will as as though the district before it in the list is locked.
- On this branch, the visual lock indication should match behavior

Closes #728 
