### PR TITLE
Fix process-geojson command when --voting flag is not passed

### DIFF
--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -30,9 +30,13 @@ import { geojsonPolygonLabels, tileJoin, tippecanoe } from "../lib/cmd";
 // Takes a comma-separated list of items, optionally as a pair separated by a ':'
 // and returns an array
 function splitPairs(input: string): readonly [string, string][] {
-  return input
-    .split(",")
-    .map(item => (item.includes(":") ? (item.split(":", 2) as [string, string]) : [item, item]));
+  return input.length === 0
+    ? []
+    : input
+        .split(",")
+        .map(item =>
+          item.includes(":") ? (item.split(":", 2) as [string, string]) : [item, item]
+        );
 }
 
 export default class ProcessGeojson extends Command {
@@ -188,12 +192,16 @@ it when necessary (file sizes ~1GB+).
         return;
       }
     }
-    for (const mapping of [geoLevels, voting]) {
-      for (const [prop, _id] of mapping) {
-        if (!(prop in firstFeature.properties)) {
-          this.log(`Geolevel: "${prop}" not present in features, exiting`);
-          return;
-        }
+    for (const [prop, _id] of geoLevels) {
+      if (!(prop in firstFeature.properties)) {
+        this.log(`Geolevel: "${prop}" not present in features, exiting`);
+        return;
+      }
+    }
+    for (const [prop, _id] of voting) {
+      if (!(prop in firstFeature.properties)) {
+        this.log(`Voting data: "${prop}" not present in features, exiting`);
+        return;
       }
     }
 


### PR DESCRIPTION
## Overview

Fix process-geojson command when `--voting` / `-v` flag is not passed.
This flag was intended to be optional and default to no data.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- `scripts/manage process-geojson ...` should work w/o passing the `-v` flag
