### PR TITLE
Add voting info to map tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
+- Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
+
 
 ### Changed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -44,7 +44,7 @@ import DistrictOptionsFlyout from "./DistrictOptionsFlyout";
 import Icon from "./Icon";
 import ProjectSidebarHeader from "./ProjectSidebarHeader";
 import Tooltip from "./Tooltip";
-import VotingTooltip from "./VotingTooltip";
+import VotingSidebarTooltip from "./VotingSidebarTooltip";
 
 interface LoadingProps {
   readonly isLoading: boolean;
@@ -423,7 +423,7 @@ const SidebarRow = memo(
               placement="top-start"
               content={
                 votesTotal !== 0 ? (
-                  <VotingTooltip voting={voting} votingIds={votingIds} />
+                  <VotingSidebarTooltip voting={voting} votingIds={votingIds} />
                 ) : (
                   <em>
                     <strong>Empty district.</strong> Add people to this district to view the vote
@@ -536,7 +536,7 @@ const SidebarRows = ({
       // Don't overwrite current results with outdated ones
       !outdated &&
         setSelectedDemographics({
-          total: selectedTotals,
+          total: selectedTotals.demographics,
           savedDistrict: districtTotals
         });
     }

--- a/src/client/components/VotingMapTooltip.tsx
+++ b/src/client/components/VotingMapTooltip.tsx
@@ -1,0 +1,80 @@
+/** @jsx jsx */
+import { mapValues, sum } from "lodash";
+import { Box, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
+
+import { getPartyColor, capitalizeFirstLetter } from "../functions";
+
+const style: ThemeUIStyleObject = {
+  label: {
+    textAlign: "left",
+    py: 0,
+    pr: 2,
+    textTransform: "capitalize"
+  },
+  number: {
+    flex: "auto",
+    textAlign: "right",
+    fontVariant: "tabular-nums",
+    py: 0,
+    fontWeight: "light"
+  }
+};
+
+const Row = ({
+  label,
+  percent,
+  color
+}: {
+  readonly label: string;
+  readonly percent?: number;
+  readonly color: string;
+}) => (
+  <Styled.tr
+    sx={{
+      color: "muted",
+      border: "none"
+    }}
+  >
+    <Styled.td sx={style.label}>{capitalizeFirstLetter(label)}</Styled.td>
+    <Styled.td sx={{ minWidth: "50px", py: 0 }}>
+      <Box
+        style={{
+          width: `${percent}%`
+        }}
+        sx={{
+          height: "10px",
+          backgroundColor: color,
+          borderRadius: "1px"
+        }}
+      />
+    </Styled.td>
+    <Styled.td sx={style.number}>
+      {percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0"}
+      {"%"}
+    </Styled.td>
+  </Styled.tr>
+);
+
+const VotingMapTooltip = ({
+  voting,
+  votingIds
+}: {
+  readonly voting: { readonly [id: string]: number };
+  readonly votingIds: readonly string[];
+}) => {
+  const total = sum(Object.values(voting));
+  const percentages = mapValues(voting, (votes: number) => (total ? votes / total : 0) * 100);
+  const rows = votingIds.map(party => (
+    <Row key={party} label={party} percent={percentages[party]} color={getPartyColor(party)} />
+  ));
+
+  return (
+    <Box sx={{ width: "100%", minHeight: "100%" }}>
+      <Styled.table sx={{ margin: "0", width: "100%" }}>
+        <tbody>{rows}</tbody>
+      </Styled.table>
+    </Box>
+  );
+};
+
+export default VotingMapTooltip;

--- a/src/client/components/VotingSidebarTooltip.tsx
+++ b/src/client/components/VotingSidebarTooltip.tsx
@@ -1,0 +1,90 @@
+/** @jsx jsx */
+import { mapValues, sum } from "lodash";
+import { Box, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
+
+import { getPartyColor, capitalizeFirstLetter } from "../functions";
+
+const style: ThemeUIStyleObject = {
+  label: {
+    textAlign: "left",
+    py: 0,
+    px: 2,
+    textTransform: "capitalize"
+  },
+  number: {
+    flex: "auto",
+    textAlign: "right",
+    fontVariant: "tabular-nums",
+    py: 0,
+    px: 1,
+    fontWeight: "light"
+  }
+};
+
+const Row = ({
+  party,
+  votes,
+  percent,
+  color
+}: {
+  readonly party: string;
+  readonly votes?: number;
+  readonly percent?: number;
+  readonly color: string;
+}) => (
+  <Styled.tr
+    sx={{
+      color: "muted",
+      border: "none"
+    }}
+  >
+    <Styled.td>
+      <Box
+        style={{
+          backgroundColor: color
+        }}
+        sx={{
+          height: "15px",
+          width: "15px"
+        }}
+      />
+    </Styled.td>
+    <Styled.td sx={style.label}>
+      <b>{capitalizeFirstLetter(party)}</b>
+    </Styled.td>
+    <Styled.td sx={style.number}>{votes?.toLocaleString(undefined)}</Styled.td>
+    <Styled.td sx={style.number}>
+      {percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0"}
+      {"%"}
+    </Styled.td>
+  </Styled.tr>
+);
+
+const VotingSidebarTooltip = ({
+  voting,
+  votingIds
+}: {
+  readonly voting: { readonly [id: string]: number };
+  readonly votingIds: readonly string[];
+}) => {
+  const total = sum(Object.values(voting));
+  const percentages = mapValues(voting, (votes: number) => (total ? votes / total : 0) * 100);
+  const rows = votingIds.map(party => (
+    <Row
+      key={party}
+      party={party}
+      votes={voting[party]}
+      percent={percentages[party]}
+      color={getPartyColor(party)}
+    />
+  ));
+  return (
+    <Box sx={{ width: "100%", minHeight: "100%" }}>
+      <Styled.table sx={{ margin: "0", width: "100%" }}>
+        <tbody>{rows}</tbody>
+      </Styled.table>
+    </Box>
+  );
+};
+
+export default VotingSidebarTooltip;

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import throttle from "lodash/throttle";
 import MapboxGL from "mapbox-gl";
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useMemo } from "react";
 import { connect } from "react-redux";
 import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 
@@ -11,6 +11,7 @@ import { getTotalSelectedDemographics } from "../../worker-functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
 import DemographicsTooltip from "../DemographicsTooltip";
+import VotingMapTooltip from "../VotingMapTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 import { getLabel } from "./labels";
 
@@ -23,7 +24,7 @@ const style: ThemeUIStyleObject = {
     height: "auto",
     borderRadius: "small",
     boxShadow: "small",
-    width: "170px",
+    width: "180px",
     overflow: "hidden",
     pointerEvents: "none",
     p: 2,
@@ -36,6 +37,7 @@ const style: ThemeUIStyleObject = {
 
 interface Data {
   readonly demographics: DemographicCounts;
+  readonly voting?: DemographicCounts;
   readonly heading: React.ReactElement | string;
 }
 
@@ -68,6 +70,12 @@ const MapTooltip = ({
   const invertedGeoLevelIndex = staticMetadata
     ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
     : undefined;
+
+  const votingIds = useMemo(
+    () =>
+      staticMetadata && staticMetadata.voting ? staticMetadata.voting.map(props => props.id) : [],
+    [staticMetadata]
+  );
 
   useEffect(() => {
     const throttledSetFeature = throttle(
@@ -139,13 +147,15 @@ const MapTooltip = ({
         const selectedGeounits = areAnyGeoUnitsSelected(highlightedGeounits)
           ? highlightedGeounits
           : feature && featuresToGeoUnits([feature], staticMetadata.geoLevelHierarchy);
-        const demographics =
+        const staticCounts =
           selectedGeounits &&
           (await getTotalSelectedDemographics(
             staticMetadata,
             project.regionConfig.s3URI,
             selectedGeounits
           ));
+        const demographics = staticCounts?.demographics;
+        const voting = staticCounts?.voting;
 
         const featureLabel = () => (
           <span sx={{ textTransform: "capitalize" }}>{getLabel(geoLevelId, feature)}</span>
@@ -167,7 +177,11 @@ const MapTooltip = ({
 
         // Only set data if it is for the most recent version requested, to
         // avoid overwriting fresh data with stale data
-        !outdated && throttledDataSetter(setData, demographics && { demographics, heading });
+        !outdated &&
+          throttledDataSetter(
+            setData,
+            demographics && (voting ? { demographics, voting, heading } : { demographics, heading })
+          );
       }
     }
     void getData();
@@ -219,6 +233,12 @@ const MapTooltip = ({
         <Divider sx={{ my: 1, borderColor: "gray.6" }} />
         <Box sx={{ width: "100%" }}>
           <DemographicsTooltip demographics={data.demographics} />
+          {data.voting && (
+            <React.Fragment>
+              <Divider sx={{ my: 1, borderColor: "gray.6" }} />
+              <VotingMapTooltip voting={data.voting} votingIds={votingIds} />
+            </React.Fragment>
+          )}
         </Box>
       </Box>
     );

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -88,9 +88,11 @@ export async function fetchWorkerStaticData(
 ): Promise<WorkerProjectData> {
   return Promise.all([
     fetchGeoUnitHierarchy(path),
-    fetchStaticFiles(path, staticMetadata.demographics)
-  ]).then(([geoUnitHierarchy, staticDemographics]) => ({
+    fetchStaticFiles(path, staticMetadata.demographics),
+    staticMetadata.voting && fetchStaticFiles(path, staticMetadata.voting)
+  ]).then(([geoUnitHierarchy, staticDemographics, staticVotingData]) => ({
     geoUnitHierarchy,
-    staticDemographics
+    staticDemographics,
+    staticVotingData
   }));
 }

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -5,7 +5,8 @@ import {
   IStaticMetadata,
   UintArrays,
   GeoUnitHierarchy,
-  DistrictProperties
+  DistrictProperties,
+  DemographicCounts
 } from "../shared/entities";
 
 export type DistrictGeoJSON = Feature<MultiPolygon, DistrictProperties>;
@@ -24,7 +25,14 @@ export interface StaticProjectData {
 
 export interface WorkerProjectData {
   readonly staticDemographics: UintArrays;
+  readonly staticVotingData?: UintArrays;
   readonly geoUnitHierarchy: GeoUnitHierarchy;
+}
+
+export interface StaticCounts {
+  // nest demographics and voting data together
+  readonly demographics: DemographicCounts;
+  readonly voting?: DemographicCounts;
 }
 
 export type ProjectData = DynamicProjectData & StaticProjectData;

--- a/src/client/worker-functions.ts
+++ b/src/client/worker-functions.ts
@@ -2,6 +2,7 @@ import stringify from "json-stable-stringify";
 import memoize from "memoizee";
 
 import { DemographicCounts, GeoUnits, IProject, IStaticMetadata, S3URI } from "../shared/entities";
+import { StaticCounts } from "../client/types";
 /* eslint import/no-webpack-loader-syntax: off */
 import createWorker from "workerize-loader!./worker";
 import * as WorkerType from "./worker";
@@ -26,7 +27,7 @@ export const getTotalSelectedDemographics = memoize(
     staticMetadata: IStaticMetadata,
     regionURI: S3URI,
     selectedGeounits: GeoUnits
-  ): Promise<DemographicCounts> => {
+  ): Promise<StaticCounts> => {
     return worker.getTotalSelectedDemographics(staticMetadata, regionURI, selectedGeounits);
   },
   {


### PR DESCRIPTION
## Overview

- Adds new component `VotingMapTooltip` and displays within map tooltip in the same styling as existing demographics
- Migrates existing `VotingTooltip`to `VotingSidebarTooltip`
- Updates worker functions to load voting data simultaneously as demographics

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/118042908-aad17800-b342-11eb-8029-b086f71f4f73.png)

### Notes

I'm not entirely sure how DRY this implementation is, since these two tooltips have more or less the same function and there is a bit of processing repeated.


## Testing Instructions

- Open a project with voting data ingested
- Hover over geounits in the map - expect voting data to be displayed underneath demographics

Closes #693 
