### PR TITLE
Change map visibility settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change eslint config to detect misuse of NestJS services [#700](https://github.com/PublicMapping/districtbuilder/pull/700)
 - Log non-HTTP errors to Rollbar [#725](https://github.com/PublicMapping/districtbuilder/pull/725)
+- Changed default project visibility, prevent org admins from seeing private maps [#754](https://github.com/PublicMapping/districtbuilder/pull/754)
 
 ### Fixed
 

--- a/src/server/migrations/1620913550713-change_visibility_default.ts
+++ b/src/server/migrations/1620913550713-change_visibility_default.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class changeVisibilityDefault1620913550713 implements MigrationInterface {
+    name = 'changeVisibilityDefault1620913550713'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`COMMENT ON COLUMN "project"."visibility" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "visibility" SET DEFAULT 'PUBLISHED'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "visibility" SET DEFAULT 'PRIVATE'`);
+        await queryRunner.query(`COMMENT ON COLUMN "project"."visibility" IS NULL`);
+    }
+
+}

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -4,6 +4,7 @@ import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
 import { Repository } from "typeorm";
 
 import { ProjectTemplate } from "../entities/project-template.entity";
+import { ProjectVisibility } from "../../../../shared/constants";
 
 @Injectable()
 export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate> {
@@ -19,7 +20,8 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
       .innerJoinAndSelect("projectTemplate.projects", "projects")
       .innerJoinAndSelect("projects.user", "user")
-      .where("organization.slug = :slug", { slug: slug })
+      .where("organization.slug = :slug", { slug })
+      .andWhere("projects.visibility <> :private", { private: ProjectVisibility.Private })
       .select([
         "projectTemplate.name",
         "projectTemplate.numberOfDistricts",

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -119,8 +119,7 @@ import { Errors } from "../../../../shared/types";
       };
     } else {
       // Unauthenticated access is allowed for individual projects if they are
-      // visible or published, and not archived. Admins can also see projects created from templates
-      // for organizations that they administer.
+      // visible or published, and not archived.
       const publicallyVisible = [
         { visibility: ProjectVisibility.Published },
         { visibility: ProjectVisibility.Visible }
@@ -129,8 +128,6 @@ import { Errors } from "../../../../shared/types";
         ? [
             // User created project
             { user_id: user.id },
-            // User is admin of project template organization
-            { "projectTemplate.organization.admin": user.id },
             // Or it's public
             ...publicallyVisible
           ]

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -73,7 +73,7 @@ export class Project implements IProject {
   })
   lockedDistricts: readonly boolean[];
 
-  @Column({ type: "enum", enum: ProjectVisibility, default: ProjectVisibility.Private })
+  @Column({ type: "enum", enum: ProjectVisibility, default: ProjectVisibility.Published })
   visibility: ProjectVisibility;
 
   @Column({ type: "boolean", default: false })


### PR DESCRIPTION
## Overview

 - Organization admins can no longer see Private maps
 - Maps now have a "Published" visibility by default

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- `scripts/yarn server run build`
- `scripts/migration`
- New projects should default to a "Published" visibility
- Organization admins should no longer be able to go to a project detail or see them on the admin screen, if the project visibility is set to "Private"

Closes #739
