### PR TITLE
Fix to stop display of the Pol. column for regions w/o data

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -330,7 +330,11 @@ const SidebarRow = memo(
       store.dispatch(toggleDistrictLocked(districtId - 1));
     };
 
-    const { voting } = district.properties;
+    // The voting dobject can be present but have no data, we treat this case as if it isn't there
+    const voting =
+      Object.keys(district.properties.voting || {}).length > 0
+        ? district.properties.voting
+        : undefined;
     const winningParty =
       voting && Object.keys(voting).reduce((a, b) => (voting[a] > voting[b] ? a : b), "");
     const color = winningParty && getPartyColor(winningParty);


### PR DESCRIPTION
## Overview

Fixes display of the sidebar for the Pol. column for regions w/o voting data

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

VA w/ political data:
![localhost_3003_projects_dbc4de2a-45a0-4c48-9e60-ad1380308f32 (1)](https://user-images.githubusercontent.com/4432106/118139792-b91ca400-b3d5-11eb-9f24-0ab845ffa4e0.png)

PA w/o voting data:
![localhost_3003_projects_dbc4de2a-45a0-4c48-9e60-ad1380308f32](https://user-images.githubusercontent.com/4432106/118139815-bfab1b80-b3d5-11eb-9d0b-7ff96285f1de.png)


## Testing Instructions

- Ensure you have maps for a region w/ voting data (most recent VA) and a region w/o voting data (anything else)
- The sidebar should no longer be broken on non-VA maps

Closes #745 
