### PR TITLE
Fix handling of switching into block editing when using keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -41,6 +41,7 @@ export const setSelectionTool = createAction("Set selection tool")<SelectionTool
 export const setGeoLevelIndex = createAction("Set geoLevel index")<{
   readonly index: number;
   readonly isReadOnly: boolean;
+  readonly skipModal?: boolean;
 }>();
 
 export const setMapLabel = createAction("Set map label")<string | undefined>();

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -38,7 +38,7 @@ export const clearHighlightedGeounits = createAction("Clear highlighted geounit 
 
 export const setSelectionTool = createAction("Set selection tool")<SelectionTool>();
 
-export const setGeoLevelIndex = createAction("Set geoLevel index")<number>();
+export const setGeoLevelIndex = createAction("Set geoLevel index")<readonly [number, boolean]>();
 
 export const setMapLabel = createAction("Set map label")<string | undefined>();
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -38,7 +38,10 @@ export const clearHighlightedGeounits = createAction("Clear highlighted geounit 
 
 export const setSelectionTool = createAction("Set selection tool")<SelectionTool>();
 
-export const setGeoLevelIndex = createAction("Set geoLevel index")<readonly [number, boolean]>();
+export const setGeoLevelIndex = createAction("Set geoLevel index")<{
+  readonly index: number;
+  readonly isReadOnly: boolean;
+}>();
 
 export const setMapLabel = createAction("Set map label")<string | undefined>();
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -109,7 +109,7 @@ const GeoLevelButton = ({
             key={index}
             sx={{ ...style.selectionButton, ...{ mr: "1px" } }}
             className={buttonClassName(geoLevelIndex === index)}
-            onClick={() => store.dispatch(setGeoLevelIndex([index, isReadOnly]))}
+            onClick={() => store.dispatch(setGeoLevelIndex({ index, isReadOnly }))}
             disabled={isButtonDisabled}
           >
             {label}

--- a/src/client/components/map/AdvancedEditingModal.tsx
+++ b/src/client/components/map/AdvancedEditingModal.tsx
@@ -106,7 +106,9 @@ const AdvancedEditingModal = ({
               setIsPending(true);
               patchProject(id, { advancedEditingEnabled: true })
                 .then(() => {
-                  store.dispatch(setGeoLevelIndex([geoLevels.length - 1, false]));
+                  store.dispatch(
+                    setGeoLevelIndex({ index: geoLevels.length - 1, isReadOnly: false })
+                  );
                   store.dispatch(projectFetch(id));
                   hideModal();
                 })

--- a/src/client/components/map/AdvancedEditingModal.tsx
+++ b/src/client/components/map/AdvancedEditingModal.tsx
@@ -106,7 +106,7 @@ const AdvancedEditingModal = ({
               setIsPending(true);
               patchProject(id, { advancedEditingEnabled: true })
                 .then(() => {
-                  store.dispatch(setGeoLevelIndex(geoLevels.length - 1));
+                  store.dispatch(setGeoLevelIndex([geoLevels.length - 1, false]));
                   store.dispatch(projectFetch(id));
                   hideModal();
                 })

--- a/src/client/components/map/AdvancedEditingModal.tsx
+++ b/src/client/components/map/AdvancedEditingModal.tsx
@@ -107,7 +107,11 @@ const AdvancedEditingModal = ({
               patchProject(id, { advancedEditingEnabled: true })
                 .then(() => {
                   store.dispatch(
-                    setGeoLevelIndex({ index: geoLevels.length - 1, isReadOnly: false })
+                    setGeoLevelIndex({
+                      index: geoLevels.length - 1,
+                      isReadOnly: false,
+                      skipModal: true
+                    })
                   );
                   store.dispatch(projectFetch(id));
                   hideModal();

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -264,6 +264,7 @@ const DistrictsMap = ({
         shortcut.action({
           selectionTool,
           geoLevelIndex,
+          isReadOnly,
           selectedDistrictId,
           label,
           numFeatures: geojson.features.length,
@@ -277,6 +278,7 @@ const DistrictsMap = ({
     [
       selectionTool,
       geoLevelIndex,
+      isReadOnly,
       selectedDistrictId,
       label,
       geojson.features.length,

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -66,12 +66,12 @@ function previousSelectionTool({ selectionTool }: MapContext) {
 function nextGeoLevel({ geoLevelIndex, numGeolevels, isReadOnly }: MapContext) {
   // Go to next geolevel if not already on smallest level
   const nextGeoLevelIndex = geoLevelIndex < numGeolevels - 1 ? geoLevelIndex + 1 : geoLevelIndex;
-  store.dispatch(setGeoLevelIndex([nextGeoLevelIndex, isReadOnly]));
+  store.dispatch(setGeoLevelIndex({ index: nextGeoLevelIndex, isReadOnly }));
 }
 function previousGeoLevel({ geoLevelIndex, isReadOnly }: MapContext) {
   // Go to previous geolevel if not already at largest level
   const previousGeoLevelIndex = geoLevelIndex > 0 ? geoLevelIndex - 1 : geoLevelIndex;
-  store.dispatch(setGeoLevelIndex([previousGeoLevelIndex, isReadOnly]));
+  store.dispatch(setGeoLevelIndex({ index: previousGeoLevelIndex, isReadOnly }));
 }
 
 function setNextDistrict({ selectedDistrictId, numFeatures }: MapContext) {

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { DistrictId, GeoUnits } from "../../../shared/entities";
+import { DistrictId } from "../../../shared/entities";
 
 import {
   setGeoLevelIndex,

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { DistrictId } from "../../../shared/entities";
+import { DistrictId, GeoUnits } from "../../../shared/entities";
 
 import {
   setGeoLevelIndex,
@@ -21,6 +21,7 @@ import { showMapActionToast } from "../../functions";
 interface MapContext {
   readonly selectionTool: SelectionTool;
   readonly geoLevelIndex: number;
+  readonly isReadOnly: boolean;
   readonly selectedDistrictId: DistrictId;
   readonly label?: string;
   readonly numFeatures: number;
@@ -62,15 +63,15 @@ function previousSelectionTool({ selectionTool }: MapContext) {
   store.dispatch(setSelectionTool(SelectionToolOrder[previousSelectionTool]));
 }
 
-function nextGeoLevel({ geoLevelIndex, numGeolevels }: MapContext) {
+function nextGeoLevel({ geoLevelIndex, numGeolevels, isReadOnly }: MapContext) {
   // Go to next geolevel if not already on smallest level
   const nextGeoLevelIndex = geoLevelIndex < numGeolevels - 1 ? geoLevelIndex + 1 : geoLevelIndex;
-  store.dispatch(setGeoLevelIndex(nextGeoLevelIndex));
+  store.dispatch(setGeoLevelIndex([nextGeoLevelIndex, isReadOnly]));
 }
-function previousGeoLevel({ geoLevelIndex }: MapContext) {
+function previousGeoLevel({ geoLevelIndex, isReadOnly }: MapContext) {
   // Go to previous geolevel if not already at largest level
   const previousGeoLevelIndex = geoLevelIndex > 0 ? geoLevelIndex - 1 : geoLevelIndex;
-  store.dispatch(setGeoLevelIndex(previousGeoLevelIndex));
+  store.dispatch(setGeoLevelIndex([previousGeoLevelIndex, isReadOnly]));
 }
 
 function setNextDistrict({ selectedDistrictId, numFeatures }: MapContext) {

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -20,6 +20,26 @@ export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
   return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
 }
 
+export function canSwitchGeoLevels(
+  currentIndex: number,
+  newIndex: number,
+  geoLevelHierarchy: GeoLevelHierarchy,
+  selectedGeounits: GeoUnits
+): boolean {
+  const areGeoUnitsSelected = areAnyGeoUnitsSelected(selectedGeounits);
+  const isBaseLevelAlwaysVisible = isBaseGeoLevelAlwaysVisible(geoLevelHierarchy);
+  const isBaseGeoLevelSelected = newIndex === geoLevelHierarchy.length - 1;
+  const isCurrentLevelBaseGeoLevel = currentIndex === geoLevelHierarchy.length - 1;
+  return !(
+    !isBaseLevelAlwaysVisible &&
+    areGeoUnitsSelected &&
+    // block level selected, so disable all higher geolevels
+    ((isBaseGeoLevelSelected && !isCurrentLevelBaseGeoLevel) ||
+      // non-block level selected, so disable block level
+      (!isBaseGeoLevelSelected && isCurrentLevelBaseGeoLevel))
+  );
+}
+
 // Determines if we are in a scenario where all geolevels have the same minimum zoom,
 // and thus, the base geolevel doesn't require special handling
 export function isBaseGeoLevelAlwaysVisible(geoLevelHierarchy: GeoLevelHierarchy) {

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -54,11 +54,7 @@ import {
   UndoableState,
   updateCurrentState
 } from "./undoRedo";
-import {
-  isBaseGeoLevelAlwaysVisible,
-  areAnyGeoUnitsSelected,
-  canSwitchGeoLevels
-} from "../functions";
+import { canSwitchGeoLevels } from "../functions";
 
 function setGeoUnitsForLevel(
   currentGeoUnits: GeoUnitsForLevel,

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -54,7 +54,7 @@ import {
   UndoableState,
   updateCurrentState
 } from "./undoRedo";
-import { canSwitchGeoLevels } from "../functions";
+import { canSwitchGeoLevels, isBaseGeoLevelAlwaysVisible } from "../functions";
 
 function setGeoUnitsForLevel(
   currentGeoUnits: GeoUnitsForLevel,
@@ -261,14 +261,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
         selectionTool: action.payload
       };
     case getType(setGeoLevelIndex): {
-      if (
-        !state.showAdvancedEditingModal &&
-        "resource" in state.staticData &&
-        "resource" in state.projectData
-      ) {
-        const { index, isReadOnly } = action.payload;
+      if ("resource" in state.staticData && "resource" in state.projectData) {
+        const { index, isReadOnly, skipModal } = action.payload;
         const { geoLevelHierarchy } = state.staticData.resource.staticMetadata;
         const { advancedEditingEnabled } = state.projectData.resource.project;
+        const isBaseLevelAlwaysVisible = isBaseGeoLevelAlwaysVisible(geoLevelHierarchy);
         const canSwitch = canSwitchGeoLevels(
           state.undoHistory.present.state.geoLevelIndex,
           index,
@@ -278,11 +275,15 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
 
         return !canSwitch
           ? loop(state, Cmd.none)
-          : isReadOnly || advancedEditingEnabled
-          ? updateCurrentState(state, {
+          : !advancedEditingEnabled &&
+            !skipModal &&
+            !isReadOnly &&
+            !isBaseLevelAlwaysVisible &&
+            index === geoLevelHierarchy.length - 1
+          ? loop(state, Cmd.action(showAdvancedEditingModal(true)))
+          : updateCurrentState(state, {
               geoLevelIndex: index
-            })
-          : loop(state, Cmd.action(showAdvancedEditingModal(true)));
+            });
       }
       return state;
     }

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -270,7 +270,7 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
         "resource" in state.staticData &&
         "resource" in state.projectData
       ) {
-        const [index, isReadOnly] = action.payload;
+        const { index, isReadOnly } = action.payload;
         const { geoLevelHierarchy } = state.staticData.resource.staticMetadata;
         const { advancedEditingEnabled } = state.projectData.resource.project;
         const canSwitch = canSwitchGeoLevels(


### PR DESCRIPTION
## Overview

I moved most of the business logic into a helper function, which is called both by `MapHeader.tsx` as it used to be, as well as by the redux ~action~ reducer, which allows the keyboard event handler to continue to be very simple.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

Switching between geolevels using S / F should behave _exactly_ as it does when clicking the buttons in the header

Scenarios to check:
 - A read-only map (I used an incognito window)
 - A map where you haven't done block editing before, as well as one where you have
 - How it behaves when there are pending changes

Closes #747 
