### PR TITLE
Add configurable population deviation to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add configurable population deviation [#762](https://github.com/PublicMapping/districtbuilder/pull/762)
+
 
 ### Changed
 
 - Display evaluate mode toggle button in read-only mode [#786](https://github.com/PublicMapping/districtbuilder/pull/786)
+- Disable keyboard shortcuts in evaluate mode [#784](https://github.com/PublicMapping/districtbuilder/pull/784)
 
 
 ### Fixed
@@ -26,14 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
-- Disable some keyboard shortcuts in reads-only mode [#768](https://github.com/PublicMapping/districtbuilder/pull/768)
 
 
 ### Changed
 
 - Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 - Cleanup text in evaluate mode [#776](https://github.com/PublicMapping/districtbuilder/pull/776)
-- Disable keyboard shortcuts in evaluate mode [#784](https://github.com/PublicMapping/districtbuilder/pull/784)
+
 
 ### Fixed
 
@@ -56,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display warnings and row-level flags for district import [#708](https://github.com/PublicMapping/districtbuilder/pull/708)
 - Add keyboard shortcuts for map functions [#718](https://github.com/PublicMapping/districtbuilder/pull/718)
 - Added voting info to sidebar [#730](https://github.com/PublicMapping/districtbuilder/pull/730)
-- Add configurable population deviation [#762](https://github.com/PublicMapping/districtbuilder/pull/762)
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display warnings and row-level flags for district import [#708](https://github.com/PublicMapping/districtbuilder/pull/708)
 - Add keyboard shortcuts for map functions [#718](https://github.com/PublicMapping/districtbuilder/pull/718)
 - Added voting info to sidebar [#730](https://github.com/PublicMapping/districtbuilder/pull/730)
+- Add configurable population deviation [#762](https://github.com/PublicMapping/districtbuilder/pull/762)
 
 ### Changed
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -129,7 +129,8 @@ export async function createProject({
   chamber,
   regionConfig,
   districtsDefinition,
-  projectTemplate
+  projectTemplate,
+  populationDeviation
 }: CreateProjectData): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
@@ -139,6 +140,7 @@ export async function createProject({
         regionConfig,
         districtsDefinition,
         chamber,
+        populationDeviation,
         projectTemplate
       })
       .then(response => resolve(response.data))

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -45,6 +45,7 @@ export default function Field<D, R>({
 interface InputFieldProps<D, R> extends FieldProps<D, R> {
   readonly label: string | React.ReactElement;
   readonly description?: string | React.ReactElement;
+  readonly defaultValue?: number | string;
   readonly inputProps: RefAttributes<HTMLInputElement> & InputProps;
 }
 
@@ -52,6 +53,7 @@ export function InputField<D, R>({
   field,
   label,
   description,
+  defaultValue,
   resource,
   inputProps
 }: InputFieldProps<D, R>): React.ReactElement {
@@ -70,6 +72,7 @@ export function InputField<D, R>({
           <Input
             {...inputProps}
             id={field.toString()}
+            defaultValue={defaultValue || undefined}
             aria-describedby={description ? `description-${field.toString()}` : undefined}
             sx={{ borderColor: hasErrors ? "warning" : undefined }}
           />

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -45,7 +45,7 @@ const ProjectEvaluateSidebar = ({
   const [avgCompactness, setAvgCompactness] = useState<number | undefined>(undefined);
   const [avgPopulation, setAvgPopulation] = useState<number | undefined>(undefined);
   const [geoLevel, setGeoLevel] = useState<string | undefined>(undefined);
-  const popThreshold = 0.05;
+  const popThreshold = project && project.populationDeviation / 100.0;
   useEffect(() => {
     if (geojson && !avgCompactness) {
       const features = geojson.features.slice(1).filter(f => f.properties.compactness !== 0);
@@ -84,6 +84,7 @@ const ProjectEvaluateSidebar = ({
       status:
         (avgPopulation &&
           geojson &&
+          popThreshold &&
           geojson?.features.filter(f => {
             return (
               f.id !== 0 &&
@@ -96,15 +97,18 @@ const ProjectEvaluateSidebar = ({
       description: "have equal population",
       shortText:
         "The U.S. constitution requires that each district have about the same population for a map to be considered valid.",
-      longText: `Districts are required to be "Equal Population" for a map to be considered valid. Districts are "Equal Population" when their population falls within the target threshold. The target population is the total population divided by the number of districts and the threshold is a set percentage deviation (${Math.floor(
-        popThreshold * 100
-      )}%) above or below that target.`,
+      longText:
+        (popThreshold &&
+          `Districts are required to be "Equal Population" for a map to be considered valid. Districts are "Equal Population" when their population falls within the target threshold. The target population is the total population divided by the number of districts and the threshold is a set percentage deviation (${Math.floor(
+            popThreshold * 100
+          )}%) above or below that target.`) ||
+        "",
       avgPopulation: avgPopulation || undefined,
       popThreshold: popThreshold,
       type: "fraction",
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
       value:
-        avgPopulation && geojson
+        avgPopulation && geojson && popThreshold
           ? geojson?.features.filter(f => {
               return (
                 f.id !== 0 &&

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -84,7 +84,7 @@ const ProjectEvaluateSidebar = ({
       status:
         (avgPopulation &&
           geojson &&
-          popThreshold &&
+          popThreshold !== undefined &&
           geojson?.features.filter(f => {
             return (
               f.id !== 0 &&
@@ -98,7 +98,7 @@ const ProjectEvaluateSidebar = ({
       shortText:
         "The U.S. constitution requires that each district have about the same population for a map to be considered valid.",
       longText:
-        (popThreshold &&
+        (popThreshold !== undefined &&
           `Districts are required to be "Equal Population" for a map to be considered valid. Districts are "Equal Population" when their population falls within the target threshold. The target population is the total population divided by the number of districts and the threshold is a set percentage deviation (${Math.floor(
             popThreshold * 100
           )}%) above or below that target.`) ||
@@ -108,7 +108,7 @@ const ProjectEvaluateSidebar = ({
       type: "fraction",
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
       value:
-        avgPopulation && geojson && popThreshold
+        avgPopulation && geojson && popThreshold !== undefined
           ? geojson?.features.filter(f => {
               return (
                 f.id !== 0 &&

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -67,7 +67,7 @@ const EqualPopulationMetricDetail = ({
 }) => {
   function computeRowFill(row: DistrictProperties) {
     const val = row.percentDeviation;
-    const choroplethStops = getChoroplethStops(metric.key);
+    const choroplethStops = getChoroplethStops(metric.key, metric.popThreshold);
     // eslint-disable-next-line
     for (let i = 0; i < choroplethStops.length; i++) {
       const r = choroplethStops[i];

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -90,7 +90,7 @@ const EqualPopulationMetricDetail = ({
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
         {metric.value?.toString() || " "} of {metric.total} districts are within{" "}
         {"popThreshold" in metric &&
-          metric.popThreshold &&
+          metric.popThreshold !== undefined &&
           ` ${Math.floor(metric.popThreshold * 100)}%`}{" "}
         of the target ({metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()})
       </Heading>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -333,7 +333,8 @@ const DistrictsMap = ({
         maxZoom,
         map,
         geojson,
-        evaluateMetric && "avgPopulation" in evaluateMetric ? evaluateMetric : undefined
+        evaluateMetric && "avgPopulation" in evaluateMetric ? evaluateMetric : undefined,
+        project && project.populationDeviation ? project.populationDeviation : undefined
       );
 
       setMap(map);
@@ -921,17 +922,26 @@ const DistrictsMap = ({
           <Flex sx={{ alignItems: "center" }}>
             <Text sx={style.legendTitle}>Equal Population</Text>
             <Box sx={{ display: "inline-block" }}>
-              {getChoroplethStops(evaluateMetric.key).map((step, i) => (
-                <Flex sx={style.legendItem} key={i}>
-                  <Box
-                    sx={{
-                      ...style.legendColorSwatch,
-                      backgroundColor: `${step[1]}`
-                    }}
-                  ></Box>
-                  <Text sx={style.legendLabel}>{getChoroplethLabels(evaluateMetric.key)[i]}</Text>
-                </Flex>
-              ))}
+              {getChoroplethStops(evaluateMetric.key, project.populationDeviation).map(
+                (step, i) => (
+                  <Flex sx={style.legendItem} key={i}>
+                    <Box
+                      sx={{
+                        ...style.legendColorSwatch,
+                        backgroundColor: `${step[1]}`
+                      }}
+                    ></Box>
+                    <Text sx={style.legendLabel}>
+                      {project
+                        ? getChoroplethLabels(
+                            evaluateMetric.key,
+                            project.populationDeviation / 100.0
+                          )[i]
+                        : ""}
+                    </Text>
+                  </Flex>
+                )
+              )}
             </Box>
           </Flex>
         </Box>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -334,7 +334,7 @@ const DistrictsMap = ({
         map,
         geojson,
         evaluateMetric && "avgPopulation" in evaluateMetric ? evaluateMetric : undefined,
-        project && project.populationDeviation ? project.populationDeviation : undefined
+        project?.populationDeviation
       );
 
       setMap(map);

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -69,7 +69,7 @@ export const filteredLabelLayers = [
   "poi-label"
 ];
 
-export function getChoroplethStops(metricKey: string, threshold?: number) {
+export function getChoroplethStops(metricKey: string, popThreshold?: number) {
   const compactnessSteps = [
     [0.3, "#edf8fb"],
     [0.4, "#b2e2e2"],
@@ -77,16 +77,22 @@ export function getChoroplethStops(metricKey: string, threshold?: number) {
     [0.6, "#2ca25f"],
     [1.0, "#006d2c"]
   ];
-  const popThreshold = threshold || 0.05;
-  const equalPopulationSteps = [
-    [-1.0, "#D1E5F0"],
-    [-1 * (popThreshold + 0.02), "#66A9CF"],
-    [-1 * (popThreshold + 0.01), "#2166AC"],
-    [-1 * popThreshold, "#01665E"],
-    [popThreshold, "#EFBE60"],
-    [popThreshold + 0.01, "#F5D092"],
-    [popThreshold + 0.02, "#F7E1C3"]
-  ];
+
+  const equalPopulationSteps =
+    popThreshold !== undefined
+      ? [
+          [-1.0, "#D1E5F0"],
+          [-1 * (popThreshold + 0.02), "#66A9CF"],
+          [-1 * (popThreshold + 0.01), "#2166AC"],
+          [-1 * popThreshold, "#01665E"],
+          [popThreshold, "#EFBE60"],
+          [popThreshold + 0.01, "#F5D092"],
+          [popThreshold + 0.02, "#F7E1C3"]
+        ]
+      : [
+          [-1.0, "#D1E5F0"],
+          [1.0, "#F7E1C3"]
+        ];
   switch (metricKey) {
     case "compactness":
       return compactnessSteps;
@@ -97,9 +103,12 @@ export function getChoroplethStops(metricKey: string, threshold?: number) {
   }
 }
 
-export function getChoroplethLabels(metricKey: string) {
+export function getChoroplethLabels(metricKey: string, populationDeviation?: number) {
   const compactnessLabels = ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
-  const steps = getChoroplethStops(metricKey);
+  const steps =
+    populationDeviation !== undefined
+      ? getChoroplethStops(metricKey, populationDeviation)
+      : getChoroplethStops(metricKey);
   switch (metricKey) {
     case "compactness":
       return compactnessLabels;
@@ -173,7 +182,8 @@ export function generateMapLayers(
   /* eslint-disable */
   map: any,
   geojson: any,
-  metric?: EvaluateMetricWithValue
+  metric?: EvaluateMetricWithValue,
+  populationDeviation?: number
   /* eslint-enable */
 ) {
   map.addSource(DISTRICTS_SOURCE_ID, {
@@ -241,7 +251,9 @@ export function generateMapLayers(
         "fill-color": {
           property: "percentDeviation",
           type: "interval",
-          stops: getChoroplethStops("equalPopulation")
+          stops: populationDeviation
+            ? getChoroplethStops("equalPopulation", populationDeviation / 100.0)
+            : getChoroplethStops("equalPopulation")
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -105,10 +105,7 @@ export function getChoroplethStops(metricKey: string, popThreshold?: number) {
 
 export function getChoroplethLabels(metricKey: string, populationDeviation?: number) {
   const compactnessLabels = ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
-  const steps =
-    populationDeviation !== undefined
-      ? getChoroplethStops(metricKey, populationDeviation)
-      : getChoroplethStops(metricKey);
+  const steps = getChoroplethStops(metricKey, populationDeviation);
   switch (metricKey) {
     case "compactness":
       return compactnessLabels;
@@ -237,7 +234,7 @@ export function generateMapLayers(
         "fill-opacity": 0.9
       }
     },
-    LABELS_PLACEHOLDER_LAYER_ID
+    DISTRICTS_PLACEHOLDER_LAYER_ID
   );
 
   map.addLayer(
@@ -259,7 +256,7 @@ export function generateMapLayers(
         "fill-opacity": 0.9
       }
     },
-    LABELS_PLACEHOLDER_LAYER_ID
+    DISTRICTS_PLACEHOLDER_LAYER_ID
   );
 
   map.addLayer(

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -163,8 +163,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       width: "100%",
       pt: 4,
       borderTop: "1px solid",
-      borderColor: "gray.2",
-      display: "flex"
+      borderColor: "gray.2"
     },
     legend: {
       paddingInlineStart: "0",

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Redirect } from "react-router-dom";
 import { userFetch } from "../actions/user";
+import { DEFAULT_POPULATION_DEVIATION } from "../../shared/constants";
 import {
   Box,
   Button,
@@ -47,6 +48,7 @@ interface ProjectForm {
   readonly chamber: IChamber | null;
   readonly regionConfig: IRegionConfig | null;
   readonly numberOfDistricts: number | null;
+  readonly populationDeviation: number | null;
   readonly isCustom: boolean;
 }
 
@@ -55,6 +57,7 @@ interface ValidForm {
   readonly regionConfig: IRegionConfig;
   readonly chamber?: IChamber;
   readonly numberOfDistricts: number;
+  readonly populationDeviation: number;
   readonly isCustom: boolean;
   readonly valid: true;
 }
@@ -76,6 +79,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       regionConfig: null,
       chamber: null,
       numberOfDistricts: null,
+      populationDeviation: DEFAULT_POPULATION_DEVIATION,
       isCustom: false
     }
   });
@@ -159,7 +163,8 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       width: "100%",
       pt: 4,
       borderTop: "1px solid",
-      borderColor: "gray.2"
+      borderColor: "gray.2",
+      display: "flex"
     },
     legend: {
       paddingInlineStart: "0",
@@ -303,6 +308,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                   createProject({
                     ...validatedForm,
                     chamber: validatedForm.chamber || undefined,
+                    populationDeviation: validatedForm.populationDeviation,
                     numberOfDistricts: validatedForm.numberOfDistricts
                   })
                     .then((project: IProject) =>
@@ -384,103 +390,141 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                 </SelectField>
               </Card>
               {data.regionConfig ? (
-                <Card sx={{ variant: "card.flat" }}>
-                  <fieldset sx={style.fieldset}>
+                <React.Fragment>
+                  <Card sx={{ variant: "card.flat" }}>
+                    <fieldset sx={style.fieldset}>
+                      <Flex sx={{ flexWrap: "wrap" }}>
+                        <legend
+                          sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}
+                        >
+                          Districts
+                        </legend>
+                        <Box
+                          id="description-districts"
+                          as="span"
+                          sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
+                        >
+                          How many districts do you want to map? Choose a federal or state
+                          legislative chamber or define your own.
+                        </Box>
+                        {data.regionConfig &&
+                          [...data.regionConfig.chambers]
+                            .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
+                            .map(chamber => (
+                              <Label
+                                key={chamber.id}
+                                sx={{
+                                  display: "inline-flex",
+                                  "@media screen and (min-width: 750px)": {
+                                    flex: "0 0 48%",
+                                    "&:nth-of-type(even)": {
+                                      mr: "2%"
+                                    }
+                                  }
+                                }}
+                              >
+                                <Radio
+                                  name="project-district"
+                                  value={chamber.id}
+                                  onChange={onDistrictChanged}
+                                  aria-describedby="description-districts"
+                                />
+                                <Flex
+                                  as="span"
+                                  sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                                >
+                                  <div sx={style.radioHeading}>{chamber.name}</div>
+                                  <div sx={style.radioSubHeading}>
+                                    {chamber.numberOfDistricts} districts
+                                  </div>
+                                </Flex>
+                              </Label>
+                            ))
+                            .concat(
+                              <div
+                                sx={{
+                                  flex: "0 0 50%",
+                                  "@media screen and (max-width: 770px)": {
+                                    flex: "0 0 100%"
+                                  }
+                                }}
+                                key="custom"
+                              >
+                                <Label>
+                                  <Radio
+                                    name="project-district"
+                                    value=""
+                                    onChange={onDistrictChanged}
+                                  />
+                                  <Flex as="span" sx={{ flexDirection: "column" }}>
+                                    <div sx={style.radioHeading}>Custom</div>
+                                    <div sx={style.radioSubHeading}>
+                                      Define a custom number of districts
+                                    </div>
+                                  </Flex>
+                                </Label>
+                              </div>
+                            )}
+                        {data.isCustom ? (
+                          <Box sx={style.customInputContainer}>
+                            <InputField
+                              field="numberOfDistricts"
+                              label="Number of districts"
+                              resource={createProjectResource}
+                              inputProps={{
+                                onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                                  const value = parseInt(e.currentTarget.value, 10);
+                                  const numberOfDistricts = isNaN(value) ? null : value;
+                                  setCreateProjectResource({
+                                    data: {
+                                      ...data,
+                                      numberOfDistricts
+                                    }
+                                  });
+                                }
+                              }}
+                            />
+                          </Box>
+                        ) : null}
+                      </Flex>
+                    </fieldset>
+                  </Card>
+                  <Card sx={{ variant: "card.flat" }}>
                     <Flex sx={{ flexWrap: "wrap" }}>
                       <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
-                        Districts
+                        Population deviation tolerance
                       </legend>
                       <Box
                         id="description-districts"
                         as="span"
                         sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
                       >
-                        How many districts do you want to map? Choose a federal or state legislative
-                        chamber or define your own.
+                        Depending on whether you are making a map for learning purposes or are
+                        trying to make the exercise as realistic as possible
                       </Box>
-                      {data.regionConfig &&
-                        [...data.regionConfig.chambers]
-                          .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
-                          .map(chamber => (
-                            <Label
-                              key={chamber.id}
-                              sx={{
-                                display: "inline-flex",
-                                "@media screen and (min-width: 750px)": {
-                                  flex: "0 0 48%",
-                                  "&:nth-of-type(even)": {
-                                    mr: "2%"
-                                  }
+                      <Box sx={style.customInputContainer}>
+                        <InputField
+                          field="populationDeviation"
+                          label="Population deviation tolerance (%)"
+                          defaultValue={DEFAULT_POPULATION_DEVIATION}
+                          resource={createProjectResource}
+                          inputProps={{
+                            onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                              const value = parseFloat(e.currentTarget.value);
+                              const populationDeviation = isNaN(value) ? null : value;
+                              setCreateProjectResource({
+                                data: {
+                                  ...data,
+                                  populationDeviation
                                 }
-                              }}
-                            >
-                              <Radio
-                                name="project-district"
-                                value={chamber.id}
-                                onChange={onDistrictChanged}
-                                aria-describedby="description-districts"
-                              />
-                              <Flex
-                                as="span"
-                                sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
-                              >
-                                <div sx={style.radioHeading}>{chamber.name}</div>
-                                <div sx={style.radioSubHeading}>
-                                  {chamber.numberOfDistricts} districts
-                                </div>
-                              </Flex>
-                            </Label>
-                          ))
-                          .concat(
-                            <div
-                              sx={{
-                                flex: "0 0 50%",
-                                "@media screen and (max-width: 770px)": {
-                                  flex: "0 0 100%"
-                                }
-                              }}
-                              key="custom"
-                            >
-                              <Label>
-                                <Radio
-                                  name="project-district"
-                                  value=""
-                                  onChange={onDistrictChanged}
-                                />
-                                <Flex as="span" sx={{ flexDirection: "column" }}>
-                                  <div sx={style.radioHeading}>Custom</div>
-                                  <div sx={style.radioSubHeading}>
-                                    Define a custom number of districts
-                                  </div>
-                                </Flex>
-                              </Label>
-                            </div>
-                          )}
-                      {data.isCustom ? (
-                        <Box sx={style.customInputContainer}>
-                          <InputField
-                            field="numberOfDistricts"
-                            label="Number of districts"
-                            resource={createProjectResource}
-                            inputProps={{
-                              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                                const value = parseInt(e.currentTarget.value, 10);
-                                const numberOfDistricts = isNaN(value) ? null : value;
-                                setCreateProjectResource({
-                                  data: {
-                                    ...data,
-                                    numberOfDistricts,
-                                    isCustom: true
-                                  }
-                                });
-                              }
-                            }}
-                          />
-                        </Box>
-                      ) : null}
+                              });
+                            }
+                          }}
+                        />
+                      </Box>
                     </Flex>
-                  </fieldset>
-                </Card>
+                  </Card>
+                </React.Fragment>
               ) : (
                 undefined
               )}

--- a/src/server/migrations/1621459864489-add-configurable-population-deviation.ts
+++ b/src/server/migrations/1621459864489-add-configurable-population-deviation.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addConfigurablePopulationDeviation1621459864489 implements MigrationInterface {
+    name = 'addConfigurablePopulationDeviation1621459864489'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "population_deviation" double precision NOT NULL DEFAULT 5`);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD "population_deviation" double precision NOT NULL DEFAULT 5`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project_template" DROP COLUMN "population_deviation"`);
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "population_deviation"`);
+    }
+
+}

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -5,6 +5,7 @@ import { Chamber } from "../../chambers/entities/chamber.entity";
 import { Organization } from "../../organizations/entities/organization.entity";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Project } from "../../projects/entities/project.entity";
+import { DEFAULT_POPULATION_DEVIATION } from "../../../../shared/constants";
 
 @Entity()
 export class ProjectTemplate implements IProjectTemplateWithProjects {
@@ -51,6 +52,13 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
 
   @Column({ type: "character varying" })
   details: string;
+
+  @Column({
+    type: "double precision",
+    name: "population_deviation",
+    default: () => `${DEFAULT_POPULATION_DEVIATION}`
+  })
+  populationDeviation: number;
 
   @Column({ name: "is_active", type: "boolean", default: true })
   isActive: boolean;

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -1,4 +1,13 @@
-import { ArrayNotEmpty, IsArray, IsInt, IsNotEmpty, IsOptional, IsPositive } from "class-validator";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsNumber,
+  Max
+} from "class-validator";
 
 import { CreateProjectData, DistrictsDefinition } from "../../../../shared/entities";
 import { ChamberIdDto } from "../../chambers/entities/chamber-id.dto";
@@ -17,6 +26,10 @@ export class CreateProjectDto implements CreateProjectData {
   @ArrayNotEmpty()
   @IsOptional()
   readonly districtsDefinition: DistrictsDefinition;
+  @IsOptional()
+  @IsNumber()
+  @Max(100, { message: "Population deviation must be between 0% and 100%" })
+  readonly populationDeviation: number;
   @IsOptional()
   readonly chamber: ChamberIdDto;
   @IsOptional()

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -6,7 +6,8 @@ import {
   IsOptional,
   IsPositive,
   IsNumber,
-  Max
+  Max,
+  Min
 } from "class-validator";
 
 import { CreateProjectData, DistrictsDefinition } from "../../../../shared/entities";
@@ -29,6 +30,7 @@ export class CreateProjectDto implements CreateProjectData {
   @IsOptional()
   @IsNumber()
   @Max(100, { message: "Population deviation must be between 0% and 100%" })
+  @Min(0, { message: "Population deviation must be between 0% and 100%" })
   readonly populationDeviation: number;
   @IsOptional()
   readonly chamber: ChamberIdDto;

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -7,6 +7,7 @@ import { RegionConfig } from "../../region-configs/entities/region-config.entity
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
 import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
+import { DEFAULT_POPULATION_DEVIATION } from "../../../../shared/constants";
 
 // TODO #179: Move to shared/entities
 export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
@@ -81,6 +82,13 @@ export class Project implements IProject {
 
   @Column({ type: "boolean", default: false })
   isFeatured: boolean;
+
+  @Column({
+    type: "double precision",
+    name: "population_deviation",
+    default: () => `${DEFAULT_POPULATION_DEVIATION}`
+  })
+  populationDeviation: number;
 
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {

--- a/src/server/src/projects/entities/update-project.dto.ts
+++ b/src/server/src/projects/entities/update-project.dto.ts
@@ -1,4 +1,14 @@
-import { ArrayNotEmpty, IsArray, IsBoolean, IsEnum, IsNotEmpty, IsOptional } from "class-validator";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  Max
+} from "class-validator";
 
 import { ProjectVisibility } from "../../../../shared/constants";
 import { DistrictsDefinition, UpdateProjectData } from "../../../../shared/entities";
@@ -18,6 +28,11 @@ export class UpdateProjectDto implements UpdateProjectData {
   @IsBoolean()
   @IsOptional()
   readonly advancedEditingEnabled: boolean;
+  @IsOptional()
+  @IsPositive({ message: "Population deviation must be positive" })
+  @IsNumber()
+  @Max(100, { message: "Population deviation must be between 0% and 100%" })
+  readonly populationDeviation: number;
   @IsEnum(ProjectVisibility)
   @IsOptional()
   readonly visibility: ProjectVisibility;

--- a/src/server/src/projects/entities/update-project.dto.ts
+++ b/src/server/src/projects/entities/update-project.dto.ts
@@ -6,8 +6,8 @@ import {
   IsNotEmpty,
   IsNumber,
   IsOptional,
-  IsPositive,
-  Max
+  Max,
+  Min
 } from "class-validator";
 
 import { ProjectVisibility } from "../../../../shared/constants";
@@ -29,9 +29,9 @@ export class UpdateProjectDto implements UpdateProjectData {
   @IsOptional()
   readonly advancedEditingEnabled: boolean;
   @IsOptional()
-  @IsPositive({ message: "Population deviation must be positive" })
   @IsNumber()
   @Max(100, { message: "Population deviation must be between 0% and 100%" })
+  @Min(0, { message: "Population deviation must be between 0% and 100%" })
   readonly populationDeviation: number;
   @IsEnum(ProjectVisibility)
   @IsOptional()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -44,6 +44,8 @@ export enum ProjectVisibility {
   Published = "PUBLISHED"
 }
 
+export const DEFAULT_POPULATION_DEVIATION = 5;
+
 export const FIPS: { readonly [fips: string]: string } = {
   "10": "DE",
   "11": "DC",

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -177,6 +177,7 @@ interface ProjectTemplateFields {
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
   readonly chamber?: IChamber;
+  readonly populationDeviation: number;
   readonly districtsDefinition: DistrictsDefinition;
 }
 
@@ -214,6 +215,7 @@ export interface CreateProjectData {
   readonly regionConfig: Pick<IRegionConfig, "id">;
   readonly chamber?: Pick<IChamber, "id">;
   readonly districtsDefinition?: DistrictsDefinition;
+  readonly populationDeviation?: number;
   readonly projectTemplate?: Pick<IProjectTemplate, "id">;
 }
 


### PR DESCRIPTION
## Overview

- Add `populationDeviation` field to Project defaulting to 5 for existing projects
- Add field to CreateProjectScreen for `populationDeviation`
- Leverage `populationDeviation` field for Evaluate Mode equal population view
- Update map symbology and legend for Evaluate Mode equal population view

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/118554814-ecda2f80-b72f-11eb-8591-5496ae9864bc.png)
![image](https://user-images.githubusercontent.com/66973361/118556551-02505900-b732-11eb-916f-6b27b7e258c4.png)




### Notes

- My gut feeling said to use decimal (0.05) instead of percentage (5) for _storing_ the data - but this would make things a little trickier to get the frontend to work as specified in the design and was explicitly specified in the issue so I went with the latter.
- I couldn't get the % to line up properly in `CreateProjectForm` - seems like there is probably an easy solution here @jfrankl 
- ~Do we need to update the symbology / legend in the map here as well?~ Forgot that I already planned for this in #685 :)

## Testing Instructions

- `./scripts/update`
- Create a new project, and set the `populationDeviation` to be something other than 0.05
- Add some area to a district to get it close to the specified `populationDeviation` threshold
- Open evaluate mode - expect Equal Population metric to be 

Closes #599 
