### PR TITLE
Show minority majority districts in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display warnings and row-level flags for district import [#708](https://github.com/PublicMapping/districtbuilder/pull/708)
 - Add keyboard shortcuts for map functions [#718](https://github.com/PublicMapping/districtbuilder/pull/718)
 - Added voting info to sidebar [#730](https://github.com/PublicMapping/districtbuilder/pull/730)
+- Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 
 ### Changed
 

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import mapValues from "lodash/mapValues";
-import { Box, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
+import { Box, jsx, Styled, ThemeUIStyleObject, Divider } from "theme-ui";
 
 import { demographicsColors } from "../constants/colors";
 
@@ -56,9 +56,11 @@ const Row = ({
 );
 
 const DemographicsTooltip = ({
-  demographics
+  demographics,
+  isMinorityMajority
 }: {
   readonly demographics: { readonly [id: string]: number };
+  readonly isMinorityMajority?: boolean;
 }) => {
   const percentages = mapValues(
     demographics,
@@ -74,6 +76,12 @@ const DemographicsTooltip = ({
       <Styled.table sx={{ margin: "0", width: "100%" }}>
         <tbody>{rows}</tbody>
       </Styled.table>
+      {isMinorityMajority && (
+        <Box>
+          <Divider sx={{ my: 1, borderColor: "gray.6" }} />
+          <Box>* Minority majority district</Box>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -107,6 +107,14 @@ const style: ThemeUIStyleObject = {
     verticalAlign: "bottom",
     position: "relative"
   },
+  chart: {
+    display: "inline-block"
+  },
+  minorityMajorityFlag: {
+    display: "inline-block",
+    position: "relative",
+    top: "10px"
+  },
   districtColor: {
     width: "10px",
     height: "10px",
@@ -307,6 +315,7 @@ const SidebarRow = memo(
     const intermediatePopulation = demographics.population + selectedDifference;
     const intermediateDeviation = deviation + selectedDifference;
     const populationDisplay = intermediatePopulation.toLocaleString();
+    const isMinorityMajority = demographics.white / demographics.population < 0.5;
     const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
       intermediateDeviation
     ).toLocaleString()}`;
@@ -388,7 +397,10 @@ const SidebarRow = memo(
             placement="top-start"
             content={
               demographics.population > 0 ? (
-                <DemographicsTooltip demographics={demographics} />
+                <DemographicsTooltip
+                  demographics={demographics}
+                  isMinorityMajority={isMinorityMajority}
+                />
               ) : (
                 <em>
                   <strong>Empty district.</strong> Add people to this district to view the race
@@ -397,8 +409,11 @@ const SidebarRow = memo(
               )
             }
           >
-            <span>
-              <DemographicsChart demographics={demographics} />
+            <span sx={{ display: "inline-block" }}>
+              <span sx={style.chart}>
+                <DemographicsChart demographics={demographics} />
+              </span>
+              {isMinorityMajority && <span sx={style.minorityMajorityFlag}>*</span>}
             </span>
           </Tooltip>
         </Styled.td>


### PR DESCRIPTION
## Overview

- Adds an asterisk next to the demographics chart in sidebar for minority-majority districts
- Adds a footer to tooltip denoting a district as minority majority

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/118724083-2d9f7a80-b7fc-11eb-93fa-5b2104968b7e.png)
![image](https://user-images.githubusercontent.com/66973361/118724113-36904c00-b7fc-11eb-8960-7f814050c360.png)


### Notes

@jfrankl This could use a bit of styling finesse here:

1. Making the asterisk displayed a little cleaner
2. Adding the icon to the tooltip footer

## Testing Instructions

- Create a minority-majority district (e.g., the city of Philadelphia)
- Expect: an asterisk is displayed next to the district, and the tooltip that is displayed when hovering over the demographics chart includes an annotation in the footer


Closes #426 
