### PR TITLE
Update race column to handle different race categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
-
+- Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 
 ### Changed
 
 ### Fixed
- - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
+
+- Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/DemographicsChart.tsx
+++ b/src/client/components/DemographicsChart.tsx
@@ -30,7 +30,13 @@ const DemographicsChart = ({
       <Bar width={percentages.black} color={demographicsColors.black} />
       <Bar width={percentages.asian} color={demographicsColors.asian} />
       <Bar width={percentages.hispanic} color={demographicsColors.hispanic} />
-      <Bar width={percentages.other} color={demographicsColors.other} />
+      {"other" in percentages && <Bar width={percentages.other} color={demographicsColors.other} />}
+      {"nativeAmerican" in percentages && (
+        <Bar width={percentages.nativeAmerican} color={demographicsColors.nativeAmerican} />
+      )}
+      {"pacificIslander" in percentages && (
+        <Bar width={percentages.pacificIslander} color={demographicsColors.pacificIslander} />
+      )}
     </Flex>
   );
 };

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -67,10 +67,20 @@ const DemographicsTooltip = ({
     (population: number) =>
       (demographics.population ? population / demographics.population : 0) * 100
   );
-  const races = ["white", "black", "asian", "hispanic", "other"] as const;
-  const rows = races.map((id: typeof races[number]) => (
-    <Row key={id} label={id} percent={percentages[id]} color={demographicsColors[id]} />
-  ));
+  const races = [
+    "white",
+    "black",
+    "asian",
+    "hispanic",
+    "nativeAmerican",
+    "pacificIslander",
+    "other"
+  ] as const;
+  const rows = races
+    .filter(race => percentages[race])
+    .map((id: typeof races[number]) => (
+      <Row key={id} label={id} percent={percentages[id]} color={demographicsColors[id]} />
+    ));
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>
       <Styled.table sx={{ margin: "0", width: "100%" }}>

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -9,6 +9,7 @@ const style: ThemeUIStyleObject = {
     textAlign: "left",
     py: 0,
     pr: 2,
+    whiteSpace: "nowrap",
     textTransform: "capitalize"
   },
   number: {
@@ -19,6 +20,10 @@ const style: ThemeUIStyleObject = {
     fontWeight: "light"
   }
 };
+
+function parseRowLabel(label: string) {
+  return label.split(/(?=[A-Z])/).join(" ");
+}
 
 const Row = ({
   label,
@@ -35,7 +40,7 @@ const Row = ({
       border: "none"
     }}
   >
-    <Styled.td sx={style.label}>{label}</Styled.td>
+    <Styled.td sx={style.label}>{parseRowLabel(label)}</Styled.td>
     <Styled.td sx={{ minWidth: "50px", py: 0 }}>
       <Box
         style={{
@@ -77,7 +82,7 @@ const DemographicsTooltip = ({
     "other"
   ] as const;
   const rows = races
-    .filter(race => percentages[race])
+    .filter(race => percentages[race] !== undefined)
     .map((id: typeof races[number]) => (
       <Row key={id} label={id} percent={percentages[id]} color={demographicsColors[id]} />
     ));

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -24,7 +24,7 @@ const style: ThemeUIStyleObject = {
     height: "auto",
     borderRadius: "small",
     boxShadow: "small",
-    width: "180px",
+    width: "200px",
     overflow: "hidden",
     pointerEvents: "none",
     p: 2,

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -434,11 +434,11 @@ export const negativeChangeColor = "#c54d5d";
 export const selectedDistrictColor = "#f2f6f9";
 
 export const demographicsColors = {
-  white: "#F5B472",
-  black: "#6AC59B",
-  asian: "#F194C4",
-  hispanic: "#C8BFF2",
-  nativeAmerican: "#9969F2",
-  pacificIslander: "#89A53A",
+  white: "#FC8D62",
+  black: "#66C2A5",
+  asian: "#E78AC3",
+  hispanic: "#8DA0CB",
+  nativeAmerican: "#A6D854",
+  pacificIslander: "#FFD92F",
   other: "#999999"
 };

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -438,5 +438,7 @@ export const demographicsColors = {
   black: "#6AC59B",
   asian: "#F194C4",
   hispanic: "#C8BFF2",
+  nativeAmerican: "#9969F2",
+  pacificIslander: "#89A53A",
   other: "#999999"
 };


### PR DESCRIPTION
## Overview

- Adds fields for `nativeAmerican` and `pacificIslander` to demographics chart
- Allows for the existing split (with `Other`) to still be read and displayed


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/119042675-299f6400-b986-11eb-84a8-c4df57cdc2f1.png)
![image](https://user-images.githubusercontent.com/66973361/119042698-31f79f00-b986-11eb-8425-f6cd23f84ad4.png)


### Notes

I've noticed a few instances where `pacificIslander` is displayed as 0% - does it make sense to display this instead as "< 1%"?

## Testing Instructions

- Process the attached geojson for Delaware: `./scripts/manage process-geojson data/input/de.geojson -o data/output/Delaware -n 12,4,4 -x 12,12,12 -d "population,white,black,asian,hispanic,native:nativeAmerican,pacific:pacificIslander"`
- Add it to the database: `./scripts/manage publish-region data/output/Delaware US DE Delaware`
- Create a new project for Delaware and view it; expect tooltip to be displayed as screenshot above
- Create a new project for PA; expect tooltip to be displayed as it was previously

Closes #764 
