### PR TITLE
Disable keyboard shortcuts in read only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
+- Disable some keyboard shortcuts in reads-only mode [#768](https://github.com/PublicMapping/districtbuilder/pull/768)
+
 - Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 
 ### Changed

--- a/src/client/components/map/KeyboardShortcutsModal.tsx
+++ b/src/client/components/map/KeyboardShortcutsModal.tsx
@@ -52,7 +52,13 @@ const style: ThemeUIStyleObject = {
   }
 };
 
-const CopyMapModal = ({ showModal }: { readonly showModal: boolean }) => {
+const KeyboardShortcutsModal = ({
+  showModal,
+  isReadOnly
+}: {
+  readonly showModal: boolean;
+  readonly isReadOnly: boolean;
+}) => {
   const hideModal = () => void store.dispatch(showKeyboardShortcutsModal(false));
   const os = navigator.appVersion.indexOf("Mac") !== -1 ? "Mac" : "pc";
   const meta = os === "Mac" ? "⌘" : "CTRL";
@@ -76,35 +82,39 @@ const CopyMapModal = ({ showModal }: { readonly showModal: boolean }) => {
             <Box>
               <table sx={style.table}>
                 <tbody>
-                  {KEYBOARD_SHORTCUTS.map((shortcut, index) => {
-                    const key = (
-                      <span sx={style.keyCode}>{shortcut.label || shortcut.key.toUpperCase()}</span>
-                    );
-                    return (
-                      <tr sx={style.keyRow} key={index}>
-                        <td>
-                          <Box sx={style.keyItem}>
-                            {shortcut.meta ? (
-                              shortcut.shift ? (
-                                <span>
-                                  <span sx={style.keyCode}>{meta}</span>+
-                                  <span sx={style.keyCode}>SHIFT</span>+{key}
-                                </span>
+                  {KEYBOARD_SHORTCUTS.filter(shortcut => !isReadOnly || shortcut.allowReadOnly).map(
+                    (shortcut, index) => {
+                      const key = (
+                        <span sx={style.keyCode}>
+                          {shortcut.label || shortcut.key.toUpperCase()}
+                        </span>
+                      );
+                      return (
+                        <tr sx={style.keyRow} key={index}>
+                          <td>
+                            <Box sx={style.keyItem}>
+                              {shortcut.meta ? (
+                                shortcut.shift ? (
+                                  <span>
+                                    <span sx={style.keyCode}>{meta}</span>+
+                                    <span sx={style.keyCode}>SHIFT</span>+{key}
+                                  </span>
+                                ) : (
+                                  <span>
+                                    <span sx={style.keyCode}>{meta}</span>+{key}
+                                  </span>
+                                )
                               ) : (
-                                <span>
-                                  <span sx={style.keyCode}>{meta}</span>+{key}
-                                </span>
-                              )
-                            ) : (
-                              key
-                            )}
+                                key
+                              )}
 
-                            <span sx={style.keyFunction}>{shortcut.text}</span>
-                          </Box>
-                        </td>
-                      </tr>
-                    );
-                  })}
+                              <span sx={style.keyFunction}>{shortcut.text}</span>
+                            </Box>
+                          </td>
+                        </tr>
+                      );
+                    }
+                  )}
                 </tbody>
               </table>
             </Box>
@@ -130,4 +140,4 @@ function mapStateToProps(state: State) {
   };
 }
 
-export default connect(mapStateToProps)(CopyMapModal);
+export default connect(mapStateToProps)(KeyboardShortcutsModal);

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -271,7 +271,7 @@ const DistrictsMap = ({
           !!shortcut.meta === key[meta] &&
           !!shortcut.shift === key.shiftKey
       );
-      if (shortcut) {
+      if (shortcut && (!isReadOnly || shortcut?.allowReadOnly)) {
         shortcut.action({
           selectionTool,
           geoLevelIndex,

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -37,6 +37,7 @@ interface KeyboardShortcut {
   readonly text: string;
   readonly label?: string;
   readonly meta?: true;
+  readonly allowReadOnly?: boolean;
   readonly shift?: true | "optional";
   // eslint-disable-next-line
   readonly action: (context: MapContext) => void;
@@ -98,22 +99,26 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   {
     key: "e",
     text: "Previous district",
-    action: setPreviousDistrict
+    action: setPreviousDistrict,
+    allowReadOnly: true
   },
   {
     key: "d",
     text: "Next district",
-    action: setNextDistrict
+    action: setNextDistrict,
+    allowReadOnly: true
   },
   {
     key: "s",
     text: "Use bigger geolevels",
-    action: previousGeoLevel
+    action: previousGeoLevel,
+    allowReadOnly: true
   },
   {
     key: "f",
     text: "Use smaller geolevels",
-    action: nextGeoLevel
+    action: nextGeoLevel,
+    allowReadOnly: true
   },
   {
     key: "w",
@@ -142,7 +147,8 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   {
     key: "1",
     text: "Toggle population labels",
-    action: togglePopulationLabel
+    action: togglePopulationLabel,
+    allowReadOnly: true
   },
   {
     key: "q",
@@ -199,6 +205,7 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
     key: "?",
     text: "Show this help menu",
     shift: true,
+    allowReadOnly: true,
     action: () => {
       store.dispatch(showKeyboardShortcutsModal(true));
     }

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -213,7 +213,7 @@ const ProjectScreen = ({
                 />
               )}
               <CopyMapModal project={project} />
-              <KeyboardShortcutsModal />
+              <KeyboardShortcutsModal isReadOnly={isReadOnly} />
               <Flex id="tour-start" sx={style.tourStart}></Flex>
             </React.Fragment>
           ) : null}


### PR DESCRIPTION
## Overview

- Disables keyboard shortcuts related to editing in read-only mode
- Updates the display of the keyboard shortcut modal in read-only mode to only display the enabled shortcuts

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/119162251-278de180-ba28-11eb-9702-ab8e8359298d.png)


## Testing Instructions

- Open a read only map and attempt to use one of the disabled keyboard shortcuts


Closes #761 
