### PR TITLE
Cleanup useEffect callback to handle switching evaluate modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
+- Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
+- Fix switching into/out of evaluate mode [#775](https://github.com/PublicMapping/districtbuilder/pull/775)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -131,14 +131,6 @@ export function getChoroplethLabels(metricKey: string) {
   }
 }
 
-export function removeEvaluateModeLayers(map: MapboxGL.Map) {
-  map.setLayoutProperty(DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID, "visibility", "none");
-  map.setLayoutProperty(DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID, "visibility", "none");
-  map.setLayoutProperty(TOPMOST_GEOLEVEL_EVALUATE_SPLIT_ID, "visibility", "none");
-  map.setLayoutProperty(TOPMOST_GEOLEVEL_EVALUATE_FILL_SPLIT_ID, "visibility", "none");
-  map.setLayoutProperty(DISTRICTS_CONTIGUITY_CHLOROPLETH_LAYER_ID, "visibility", "none");
-}
-
 export function getGeolevelLinePaintStyle(geoLevel: string) {
   const largeGeolevel = {
     "line-color": "#000",


### PR DESCRIPTION
## Overview

Cleans up the code for enabling/disabling layers for entering/leaving evaluate mode and its various subpages

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![output](https://user-images.githubusercontent.com/4432106/119197534-e3b1d100-ba55-11eb-8ab0-ec180d32e954.gif)


## Testing Instructions

- Ensure that on `develop` you are able to trigger the issues described in #769 and #770. On this PR they should be fixed, and there should be no regressions in Evaluate mode behavior

Fixes #770
Fixes #769
