### PR TITLE
Cleanup text in evaluate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
+- Cleanup text in evaluate mode [#776](https://github.com/PublicMapping/districtbuilder/pull/776)
 
 ### Fixed
 

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -87,9 +87,7 @@ const ProjectEvaluateSidebar = ({
           geojson?.features.filter(f => {
             return (
               f.id !== 0 &&
-              // @ts-ignore
               f.properties.percentDeviation &&
-              // @ts-ignore
               Math.abs(f.properties.percentDeviation) <= popThreshold
             );
           }).length ===
@@ -110,9 +108,7 @@ const ProjectEvaluateSidebar = ({
           ? geojson?.features.filter(f => {
               return (
                 f.id !== 0 &&
-                // @ts-ignore
                 f.properties.percentDeviation &&
-                // @ts-ignore
                 Math.abs(f.properties.percentDeviation) <= popThreshold
               );
             }).length

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -81,12 +81,26 @@ const ProjectEvaluateSidebar = ({
     {
       key: "equalPopulation",
       name: "Equal Population",
-      status: false,
+      status:
+        (avgPopulation &&
+          geojson &&
+          geojson?.features.filter(f => {
+            return (
+              f.id !== 0 &&
+              // @ts-ignore
+              f.properties.percentDeviation &&
+              // @ts-ignore
+              Math.abs(f.properties.percentDeviation) <= popThreshold
+            );
+          }).length ===
+            geojson?.features.length - 1) ||
+        false,
       description: "have equal population",
-      shortText: "Lorem ipsum",
-      longText: `This map has a goal of getting within ${Math.floor(
+      shortText:
+        "The U.S. constitution requires that each district have about the same population for a map to be considered valid.",
+      longText: `Districts are required to be "Equal Population" for a map to be considered valid. Districts are "Equal Population" when their population falls within the target threshold. The target population is the total population divided by the number of districts and the threshold is a set percentage deviation (${Math.floor(
         popThreshold * 100
-      )}% of ${avgPopulation?.toLocaleString()}`,
+      )}%) above or below that target.`,
       avgPopulation: avgPopulation || undefined,
       popThreshold: popThreshold,
       type: "fraction",
@@ -111,9 +125,9 @@ const ProjectEvaluateSidebar = ({
         geojson?.features.filter(f => f.properties.contiguity === "non-contiguous").length === 0,
       description: "are contiguous",
       longText:
-        "A district must be in a single, unbroken shape. Two areas touching at the corners are typically not considered contiguous. An exception would be the inclusion of islands in a coastal district.",
+        "Each district should be contiguous, meaning it must be a single, unbroken shape. Some exceptions are allowed, such as the inclusion of islands in a coastal district. Two areas connected only by a single point (touching just their corners) are not considered contiguous.",
       shortText:
-        "All parts of a district must be in physical contact with some other part of the district",
+        "All parts of a district must be in physical contact with some other part of the district, to the extent possible.",
       type: "fraction",
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
       value:
@@ -122,40 +136,44 @@ const ProjectEvaluateSidebar = ({
     }
   ];
   const optionalMetrics: readonly EvaluateMetric[] = [
-    {
-      key: "competitiveness",
-      name: "Competitiveness",
-      description: "are competitive"
-    },
+    // TODO: Add competitiveness display (??)
+    // {
+    //   key: "competitiveness",
+    //   name: "Competitiveness",
+    //   description: "are competitive"
+    // },
     {
       key: "compactness",
       name: "Compactness",
       type: "percent",
       longText:
-        "A district that is more spread out has a lower compactness. Low compactness can be an indicators of gerrymandering when lorem ipsum lorem ipsum. Above XX% is considered good. Calculated using the Polsby-Popper method.",
+        "A district that efficiently groups constituents together has higher compactness. Low compactness or districts that branch out to different areas can be indicators of gerrymandering. Compactness is calculated using the Polsby-Popper method. Higher numbers are better.",
       shortText:
-        "A district that is more spread out has a lower compactness. Low compactness can be an indicators of gerrymandering",
+        "A district that is more spread out has a lower compactness. Low compactness can be an indicator of gerrymandering.",
       description: "are compact",
       value: avgCompactness
     },
-    {
-      key: "minorityMajority",
-      name: "Minority-Majority",
-      type: "fraction",
-      description: "are minority-majority",
-      shortText:
-        "A district in which the majority of the constituents are racial or ethnic minorities",
-      longText:
-        "A district in which the majority of the constituents are racial or ethnic minorities",
-      value: 1
-    },
+    // TODO: Minority-Majority updates (#750)
+    // {
+    //   key: "minorityMajority",
+    //   name: "Minority-Majority",
+    //   type: "fraction",
+    //   description: "are minority-majority",
+    //   shortText:
+    //     "A district in which the majority of the constituents are racial or ethnic minorities",
+    //   longText:
+    //     "A district in which the majority of the constituents are racial or ethnic minorities",
+    //   value: 1
+    // },
     {
       key: "countySplits",
       name: `${geoLevel ? geoLevelLabelSingular(geoLevel) : ""} splits`,
       type: "count",
       description: "are split",
-      shortText: "Lorem ipsum",
-      longText: "Lorem ipsum",
+      shortText:
+        "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
+      longText:
+        "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,
       splitCounties: project?.districtsDefinition.map(c => {

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -88,7 +88,7 @@ const EqualPopulationMetricDetail = ({
   return (
     <Box>
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
-        {metric.value.toString() || " "} of {metric.total} districts are within{" "}
+        {metric.value?.toString() || " "} of {metric.total} districts are within{" "}
         {"popThreshold" in metric &&
           metric.popThreshold &&
           ` ${Math.floor(metric.popThreshold * 100)}%`}{" "}

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -88,12 +88,11 @@ const EqualPopulationMetricDetail = ({
   return (
     <Box>
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
-        {metric.value?.toString() || " "} of the {metric.total} districts are within{" "}
+        {metric.value.toString() || " "} of {metric.total} districts are within{" "}
         {"popThreshold" in metric &&
           metric.popThreshold &&
           ` ${Math.floor(metric.popThreshold * 100)}%`}{" "}
-        of the target population (
-        {metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()})
+        of the target ({metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()})
       </Heading>
       <Styled.table sx={style.table}>
         <thead>

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -92,7 +92,8 @@ const EqualPopulationMetricDetail = ({
         {"popThreshold" in metric &&
           metric.popThreshold &&
           ` ${Math.floor(metric.popThreshold * 100)}%`}{" "}
-        of {metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()}
+        of the target population (
+        {metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()})
       </Heading>
       <Styled.table sx={style.table}>
         <thead>


### PR DESCRIPTION
## Overview

- Make text updates as specified in #767 
- Update flag on equal population


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/119199350-e3670500-ba58-11eb-877f-4a379edb63bf.png)


### Notes

One copy Q for the Equal Population page - does it make sense to specify the threshold for the project in the header text? My inclination is yes, but just wanted to confirm @tgilcrest 

![image](https://user-images.githubusercontent.com/66973361/119199475-1c06de80-ba59-11eb-9bf4-a7800046b833.png)


## Testing Instructions

- Review all pages in Evaluate Mode to confirm that the text matches what is expected

Closes #767 
