### PR TITLE
Hide limit to county flyout menu in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 - Fix switching into/out of evaluate mode [#775](https://github.com/PublicMapping/districtbuilder/pull/775)
 - Fix showing blockgroup selections when viewing the county geolevel [#781](https://github.com/PublicMapping/districtbuilder/pull/781)
+- Don't show limit to county option in read-only mode [#777](https://github.com/PublicMapping/districtbuilder/pull/777)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import React from "react";
 import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
 import { geoLevelLabel, capitalizeFirstLetter, canSwitchGeoLevels } from "../functions";
@@ -168,42 +169,45 @@ const MapHeader = ({
     <Flex sx={style.header}>
       <Flex>
         {!isReadOnly && (
-          <Flex sx={{ ...style.buttonGroup, mr: 2 }}>
-            <Tooltip content="Point-and-click selection">
-              <Button
-                sx={{ ...style.selectionButton }}
-                className={buttonClassName(selectionTool === SelectionTool.Default)}
-                onClick={() => store.dispatch(setSelectionTool(SelectionTool.Default))}
-              >
-                <Icon name="hand-pointer" />
-              </Button>
-            </Tooltip>
-            <Tooltip content="Rectangle selection">
-              <Button
-                sx={{ ...style.selectionButton }}
-                className={buttonClassName(selectionTool === SelectionTool.Rectangle)}
-                onClick={() => store.dispatch(setSelectionTool(SelectionTool.Rectangle))}
-              >
-                <Icon name="draw-square" />
-              </Button>
-            </Tooltip>
-            <Tooltip content="Paint brush selection">
-              <Button
-                sx={{ ...style.selectionButton }}
-                className={buttonClassName(selectionTool === SelectionTool.PaintBrush)}
-                onClick={() => store.dispatch(setSelectionTool(SelectionTool.PaintBrush))}
-              >
-                <Icon name="paint-brush" />
-              </Button>
-            </Tooltip>
-          </Flex>
+          <React.Fragment>
+            <Flex sx={{ ...style.buttonGroup, mr: 2 }}>
+              <Tooltip content="Point-and-click selection">
+                <Button
+                  sx={{ ...style.selectionButton }}
+                  className={buttonClassName(selectionTool === SelectionTool.Default)}
+                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.Default))}
+                >
+                  <Icon name="hand-pointer" />
+                </Button>
+              </Tooltip>
+              <Tooltip content="Rectangle selection">
+                <Button
+                  sx={{ ...style.selectionButton }}
+                  className={buttonClassName(selectionTool === SelectionTool.Rectangle)}
+                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.Rectangle))}
+                >
+                  <Icon name="draw-square" />
+                </Button>
+              </Tooltip>
+              <Tooltip content="Paint brush selection">
+                <Button
+                  sx={{ ...style.selectionButton }}
+                  className={buttonClassName(selectionTool === SelectionTool.PaintBrush)}
+                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.PaintBrush))}
+                >
+                  <Icon name="paint-brush" />
+                </Button>
+              </Tooltip>
+            </Flex>
+
+            <Box sx={{ position: "relative", mr: 3, pt: "6px" }}>
+              <MapSelectionOptionsFlyout
+                limitSelectionToCounty={limitSelectionToCounty}
+                topGeoLevelName={topGeoLevelName}
+              />
+            </Box>
+          </React.Fragment>
         )}
-        <Box sx={{ position: "relative", mr: 3, pt: "6px" }}>
-          <MapSelectionOptionsFlyout
-            limitSelectionToCounty={limitSelectionToCounty}
-            topGeoLevelName={topGeoLevelName}
-          />
-        </Box>
         <Flex className="geolevel-button-group">{geoLevelOptions}</Flex>
       </Flex>
       <Box sx={{ lineHeight: "1" }}>


### PR DESCRIPTION
## Overview

This option should not be shown in read-only mode

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

No ⚙ icon:
![image](https://user-images.githubusercontent.com/4432106/119201699-6e49fe80-ba5d-11eb-8f06-814b3dbcc960.png)

## Testing Instructions

- Go to the project screen for a published map while not logged in. You shouldn't see the gear icon to open the menu where you can limit your selection to county

Closes #760 