### PR TITLE
Fix calculation of average compactness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
 - Disable some keyboard shortcuts in reads-only mode [#768](https://github.com/PublicMapping/districtbuilder/pull/768)
 
-- Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 
 ### Changed
 
+- Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
+
 ### Fixed
 
-- Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 - Fix switching into/out of evaluate mode [#775](https://github.com/PublicMapping/districtbuilder/pull/775)
 - Fix showing blockgroup selections when viewing the county geolevel [#781](https://github.com/PublicMapping/districtbuilder/pull/781)
 - Don't show limit to county option in read-only mode [#777](https://github.com/PublicMapping/districtbuilder/pull/777)
 - Include unassigned district when switching using keyboard shortcuts [#779](https://github.com/PublicMapping/districtbuilder/pull/779)
+- Fix calculation of average compactness [#778](https://github.com/PublicMapping/districtbuilder/pull/778)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -48,10 +48,11 @@ const ProjectEvaluateSidebar = ({
   const popThreshold = 0.05;
   useEffect(() => {
     if (geojson && !avgCompactness) {
-      const totalCompactness = geojson.features.reduce(function(accumulator, feature) {
+      const features = geojson.features.slice(1).filter(f => f.properties.compactness !== 0);
+      const totalCompactness = features.reduce(function(accumulator, feature) {
         return accumulator + feature.properties.compactness;
       }, 0);
-      setAvgCompactness(totalCompactness / (geojson.features.length - 1));
+      setAvgCompactness(features.length !== 0 ? totalCompactness / features.length : undefined);
     }
   }, [geojson, avgCompactness]);
 

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -65,7 +65,7 @@ const ProjectEvaluateView = ({
       case "fraction":
         return `${metric.value} / ${metric.total || 18}`;
       case "percent":
-        return `${Math.floor(metric.value * 100)}%`;
+        return metric.value !== undefined ? `${Math.floor(metric.value * 100)}%` : "";
       case "count":
         return `${metric.value}`;
       default:

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -88,7 +88,7 @@ const EqualPopulationMetricDetail = ({
   return (
     <Box>
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
-        {metric.value.toString() || " "} of the {metric.total} districts are within{" "}
+        {metric.value?.toString() || " "} of the {metric.total} districts are within{" "}
         {"popThreshold" in metric &&
           metric.popThreshold &&
           ` ${Math.floor(metric.popThreshold * 100)}%`}{" "}

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -33,7 +33,7 @@ export interface BaseEvaluateMetric {
 
 export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
   readonly type: "fraction" | "percent" | "count";
-  readonly value: number;
+  readonly value?: number;
   readonly total?: number;
   readonly avgPopulation?: number;
   readonly popThreshold?: number;


### PR DESCRIPTION
## Overview

Excludes empty or non-contiguous districts when calculating average compactness

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/119202306-7fdfd600-ba5e-11eb-814c-6a724f6d4576.png)

## Testing Instructions

- Go to the compactness detail on evaluate mode. Empty & non-contiguous districts should not be included in the calculation

Closes #772 
