### PR TITLE
Include unassigned district when switching using keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix switching into/out of evaluate mode [#775](https://github.com/PublicMapping/districtbuilder/pull/775)
 - Fix showing blockgroup selections when viewing the county geolevel [#781](https://github.com/PublicMapping/districtbuilder/pull/781)
 - Don't show limit to county option in read-only mode [#777](https://github.com/PublicMapping/districtbuilder/pull/777)
+- Include unassigned district when switching using keyboard shortcuts [#779](https://github.com/PublicMapping/districtbuilder/pull/779)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -76,13 +76,13 @@ function previousGeoLevel({ geoLevelIndex, isReadOnly }: MapContext) {
 }
 
 function setNextDistrict({ selectedDistrictId, numFeatures }: MapContext) {
-  // Set the next district as currently selected, or first district if currently at end of list
-  const nextDistrictId = selectedDistrictId < numFeatures - 1 ? selectedDistrictId + 1 : 1;
+  // Set the next district as currently selected, or unassigned district if currently at end of list
+  const nextDistrictId = selectedDistrictId < numFeatures - 1 ? selectedDistrictId + 1 : 0;
   store.dispatch(setSelectedDistrictId(nextDistrictId));
 }
 function setPreviousDistrict({ selectedDistrictId, numFeatures }: MapContext) {
   // Set the previous district as currently selected, or last district if currently at start of list
-  const previousDistrictId = selectedDistrictId > 1 ? selectedDistrictId - 1 : numFeatures - 1;
+  const previousDistrictId = selectedDistrictId > 0 ? selectedDistrictId - 1 : numFeatures - 1;
   store.dispatch(setSelectedDistrictId(previousDistrictId));
 }
 


### PR DESCRIPTION
## Overview

Allow switching to the unassigned district when using keyboard shortcuts.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Use `e` and `d` to switch between districts. Ensure you can switch to every district and the unassigned district

Closes #771 
