### PR TITLE
Always display currently selected geounits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 - Fix handling of switching into block editing when using keyboard shortcut [#758](https://github.com/PublicMapping/districtbuilder/pull/758)
 - Fix switching into/out of evaluate mode [#775](https://github.com/PublicMapping/districtbuilder/pull/775)
+- Fix showing blockgroup selections when viewing the county geolevel [#781](https://github.com/PublicMapping/districtbuilder/pull/781)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -145,8 +145,8 @@ function enableEditmode(map: MapboxGL.Map, staticMetadata: IStaticMetadata, geoL
   const invertedGeoLevelIndex = staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1;
   staticMetadata.geoLevelHierarchy.forEach((geoLevel, idx) => {
     const geoLevelVisibility = idx >= invertedGeoLevelIndex ? "visible" : "none";
-    map.setLayoutProperty(levelToSelectionLayerId(geoLevel.id), "visibility", geoLevelVisibility);
     map.setLayoutProperty(levelToLineLayerId(geoLevel.id), "visibility", geoLevelVisibility);
+    map.setLayoutProperty(levelToSelectionLayerId(geoLevel.id), "visibility", "visible");
     map.setLayoutProperty(levelToLabelLayerId(geoLevel.id), "visibility", "visible");
   });
 }


### PR DESCRIPTION


Fixes #780

## Overview

We were incorrectly hiding selected geounits based on the current geolevel.

 _Currently selected_ geounits should always be shown regardless of the currently geolevel, so that when working at the county layer you can see pending block group changes, and vice versa.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

## Testing Instructions

- On the project screen,  select a county, switch to the blockgroup layer, and then switch back. You should continue to see your selections.

Closes #780
