### PR TITLE
Disable keyboard shortcuts in evaluate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 - Cleanup text in evaluate mode [#776](https://github.com/PublicMapping/districtbuilder/pull/776)
+- Disable keyboard shortcuts in evaluate mode [#784](https://github.com/PublicMapping/districtbuilder/pull/784)
 
 ### Fixed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -52,7 +52,7 @@ export const toggleDistrictLocked = createAction("Toggle district locked")<Distr
 
 export const toggleLimitDrawingToWithinCounty = createAction("Limit drawing to within county")();
 
-export const showKeyboardShortcutsModal = createAction("Show keyboard shortcuts modal")<boolean>();
+export const toggleKeyboardShortcutsModal = createAction("Show keyboard shortcuts modal")();
 
 export const showAdvancedEditingModal = createAction("Show advanced editing warning modal")<
   boolean

--- a/src/client/components/map/KeyboardShortcutsModal.tsx
+++ b/src/client/components/map/KeyboardShortcutsModal.tsx
@@ -4,7 +4,7 @@ import AriaModal from "react-aria-modal";
 import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
 import { connect } from "react-redux";
 
-import { showKeyboardShortcutsModal } from "../../actions/districtDrawing";
+import { toggleKeyboardShortcutsModal } from "../../actions/districtDrawing";
 import { State } from "../../reducers";
 import store from "../../store";
 import { KEYBOARD_SHORTCUTS } from "./keyboardShortcuts";
@@ -54,12 +54,14 @@ const style: ThemeUIStyleObject = {
 
 const KeyboardShortcutsModal = ({
   showModal,
-  isReadOnly
+  isReadOnly,
+  evaluateMode
 }: {
   readonly showModal: boolean;
   readonly isReadOnly: boolean;
+  readonly evaluateMode: boolean;
 }) => {
-  const hideModal = () => void store.dispatch(showKeyboardShortcutsModal(false));
+  const hideModal = () => void store.dispatch(toggleKeyboardShortcutsModal());
   const os = navigator.appVersion.indexOf("Mac") !== -1 ? "Mac" : "pc";
   const meta = os === "Mac" ? "⌘" : "CTRL";
 
@@ -82,39 +84,39 @@ const KeyboardShortcutsModal = ({
             <Box>
               <table sx={style.table}>
                 <tbody>
-                  {KEYBOARD_SHORTCUTS.filter(shortcut => !isReadOnly || shortcut.allowReadOnly).map(
-                    (shortcut, index) => {
-                      const key = (
-                        <span sx={style.keyCode}>
-                          {shortcut.label || shortcut.key.toUpperCase()}
-                        </span>
-                      );
-                      return (
-                        <tr sx={style.keyRow} key={index}>
-                          <td>
-                            <Box sx={style.keyItem}>
-                              {shortcut.meta ? (
-                                shortcut.shift ? (
-                                  <span>
-                                    <span sx={style.keyCode}>{meta}</span>+
-                                    <span sx={style.keyCode}>SHIFT</span>+{key}
-                                  </span>
-                                ) : (
-                                  <span>
-                                    <span sx={style.keyCode}>{meta}</span>+{key}
-                                  </span>
-                                )
+                  {KEYBOARD_SHORTCUTS.filter(
+                    shortcut =>
+                      (!isReadOnly || shortcut.allowReadOnly) &&
+                      (!evaluateMode || shortcut.allowInEvaluateMode)
+                  ).map((shortcut, index) => {
+                    const key = (
+                      <span sx={style.keyCode}>{shortcut.label || shortcut.key.toUpperCase()}</span>
+                    );
+                    return (
+                      <tr sx={style.keyRow} key={index}>
+                        <td>
+                          <Box sx={style.keyItem}>
+                            {shortcut.meta ? (
+                              shortcut.shift ? (
+                                <span>
+                                  <span sx={style.keyCode}>{meta}</span>+
+                                  <span sx={style.keyCode}>SHIFT</span>+{key}
+                                </span>
                               ) : (
-                                key
-                              )}
+                                <span>
+                                  <span sx={style.keyCode}>{meta}</span>+{key}
+                                </span>
+                              )
+                            ) : (
+                              key
+                            )}
 
-                              <span sx={style.keyFunction}>{shortcut.text}</span>
-                            </Box>
-                          </td>
-                        </tr>
-                      );
-                    }
-                  )}
+                            <span sx={style.keyFunction}>{shortcut.text}</span>
+                          </Box>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </Box>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -363,7 +363,11 @@ const DistrictsMap = ({
           !!shortcut.meta === key[meta] &&
           !!shortcut.shift === key.shiftKey
       );
-      if (shortcut && (!isReadOnly || shortcut?.allowReadOnly)) {
+      if (
+        shortcut &&
+        (!isReadOnly || shortcut?.allowReadOnly) &&
+        (!evaluateMode || shortcut?.allowInEvaluateMode)
+      ) {
         shortcut.action({
           selectionTool,
           geoLevelIndex,

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -13,7 +13,7 @@ import {
   undo,
   redo,
   toggleLimitDrawingToWithinCounty,
-  showKeyboardShortcutsModal
+  toggleKeyboardShortcutsModal
 } from "../../actions/districtDrawing";
 import store from "../../store";
 import { showMapActionToast } from "../../functions";
@@ -38,6 +38,7 @@ interface KeyboardShortcut {
   readonly label?: string;
   readonly meta?: true;
   readonly allowReadOnly?: boolean;
+  readonly allowInEvaluateMode?: boolean;
   readonly shift?: true | "optional";
   // eslint-disable-next-line
   readonly action: (context: MapContext) => void;
@@ -160,6 +161,8 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   {
     key: "t",
     text: "Toggle evaluate mode",
+    allowReadOnly: true,
+    allowInEvaluateMode: true,
     action: ({ evaluateMode }: MapContext) => {
       store.dispatch(toggleEvaluate(!evaluateMode));
     }
@@ -206,8 +209,9 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
     text: "Show this help menu",
     shift: true,
     allowReadOnly: true,
+    allowInEvaluateMode: true,
     action: () => {
-      store.dispatch(showKeyboardShortcutsModal(true));
+      store.dispatch(toggleKeyboardShortcutsModal());
     }
   }
   // Feature not implemented yet

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -34,7 +34,7 @@ import {
   selectEvaluationMetric,
   setZoomToDistrictId,
   setMapLabel,
-  showKeyboardShortcutsModal
+  toggleKeyboardShortcutsModal
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
@@ -309,10 +309,10 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
         ...state,
         showAdvancedEditingModal: action.payload
       };
-    case getType(showKeyboardShortcutsModal):
+    case getType(toggleKeyboardShortcutsModal):
       return {
         ...state,
-        showKeyboardShortcutsModal: action.payload
+        showKeyboardShortcutsModal: !state.showKeyboardShortcutsModal
       };
     case getType(showCopyMapModal):
       return {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -213,7 +213,7 @@ const ProjectScreen = ({
                 />
               )}
               <CopyMapModal project={project} />
-              <KeyboardShortcutsModal isReadOnly={isReadOnly} />
+              <KeyboardShortcutsModal isReadOnly={isReadOnly} evaluateMode={evaluateMode} />
               <Flex id="tour-start" sx={style.tourStart}></Flex>
             </React.Fragment>
           ) : null}


### PR DESCRIPTION
## Overview

- Disables all keyboard shortcuts in evaluate mode expect 'Toggle evaluate mode'
- Closes keyboard shortcuts modal with "?"

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/119398069-084fb800-bca5-11eb-9b7c-c9ae1ecc9215.png)



## Testing Instructions

- Open a project and go to evaluate mode
- Confirm that none of the keyboard shortcuts are available in evaluate mode besides `T` to toggle evaluate mode and `?` to toggle the modal

Closes #782 
