### PR TITLE
Display evaluate mode button for read only maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Display evaluate mode toggle button in read-only mode [#786](https://github.com/PublicMapping/districtbuilder/pull/786)
+
 
 ### Fixed
 

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -56,6 +56,32 @@ interface StateProps {
   readonly undoHistory: UndoHistory;
 }
 
+const EvaluateButton = ({ evaluateMode }: { readonly evaluateMode: boolean }) => (
+  <Box sx={{ position: "relative" }}>
+    <Button
+      sx={{
+        ...{
+          variant: "buttons.primary",
+          fontWeight: "light",
+          maxHeight: "34px",
+          borderBottom: evaluateMode ? "solid 3px" : "none",
+          borderBottomColor: "blue.2"
+        },
+        ...menuButtonStyle.menuButton
+      }}
+      onClick={() => store.dispatch(toggleEvaluate(!evaluateMode))}
+    >
+      <span
+        sx={{
+          mb: evaluateMode ? "-3px" : "0"
+        }}
+      >
+        Evaluate
+      </span>
+    </Button>
+  </Box>
+);
+
 const ProjectHeader = ({
   findMenuOpen,
   evaluateMode,
@@ -129,34 +155,13 @@ const ProjectHeader = ({
               </Box>
             </Button>
           </Box>
-          <Box sx={{ position: "relative" }}>
-            <Button
-              sx={{
-                ...{
-                  variant: "buttons.primary",
-                  fontWeight: "light",
-                  maxHeight: "34px",
-                  borderBottom: evaluateMode ? "solid 3px" : "none",
-                  borderBottomColor: "blue.2"
-                },
-                ...menuButtonStyle.menuButton
-              }}
-              onClick={() => store.dispatch(toggleEvaluate(!evaluateMode))}
-            >
-              <span
-                sx={{
-                  mb: evaluateMode ? "-3px" : "0"
-                }}
-              >
-                Evaluate
-              </span>
-            </Button>
-          </Box>
+          <EvaluateButton evaluateMode={evaluateMode} />
         </React.Fragment>
       ) : (
         <React.Fragment>
           <CopyMapButton invert={true} />
           {project && <ExportMenu invert={true} project={project} />}
+          <EvaluateButton evaluateMode={evaluateMode} />
         </React.Fragment>
       )}
     </Flex>


### PR DESCRIPTION
## Overview

- Displays the evaluate mode button for read only maps just like for a user's maps


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/119406904-75694a80-bcb1-11eb-8b89-86b4f0a1fbf5.png)


## Testing Instructions

- Go to a read only map; expect Evaluate button to visible in header

Closes #785 
