### PR TITLE
Style cleanup: fix padding and change race demographic colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 ### Changed
 
+- Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 
 ### Fixed
 
-
+- Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 
 ## [1.6.0] - 2021-05-24
 
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
 - Disable some keyboard shortcuts in reads-only mode [#768](https://github.com/PublicMapping/districtbuilder/pull/768)
-
 
 ### Changed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -103,6 +103,7 @@ const style: ThemeUIStyleObject = {
     color: "gray.8",
     fontSize: 1,
     p: 2,
+    pt: 0,
     textAlign: "left",
     verticalAlign: "bottom",
     position: "relative"

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -434,11 +434,11 @@ export const negativeChangeColor = "#c54d5d";
 export const selectedDistrictColor = "#f2f6f9";
 
 export const demographicsColors = {
-  white: "#FC8D62",
-  black: "#66C2A5",
-  asian: "#E78AC3",
-  hispanic: "#8DA0CB",
-  nativeAmerican: "#A6D854",
-  pacificIslander: "#FFD92F",
-  other: "#999999"
+  white: "#8DD3C6",
+  black: "#80B1D3",
+  asian: "#FDB462",
+  hispanic: "#BEBADA",
+  nativeAmerican: "#FB8071",
+  pacificIslander: "#B3DE69",
+  other: "#B3DE69"
 };


### PR DESCRIPTION
## Overview

Fixes sidebar padding (#791) and revises race demographic colors.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-05-26 at 4 47 45 PM](https://user-images.githubusercontent.com/1809908/119728989-1d158280-be42-11eb-98c1-e4216b48fd1c.png)

![Screen Shot 2021-05-26 at 4 48 03 PM](https://user-images.githubusercontent.com/1809908/119729046-2bfc3500-be42-11eb-9ff6-7556936fbe1b.png)

### Notes

For the race demographic colors, I found that the new colors were too bold, and the red “white” population color looked too similar to the “non-contiguous” alert icon and the Republican red political red. I reverted back to colors that are slightly more subtle, and removed the conflicting red.

## Testing Instructions

- Confirm that the sidebar looks like the screenshots attached to this issue

Closes #791
