### PR TITLE
Export organization maps to csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add configurable population deviation [#762](https://github.com/PublicMapping/districtbuilder/pull/762)
 - Display target population symbols in sidebar [#720](https://github.com/PublicMapping/districtbuilder/issues/720)
 - List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796)
+- Add map export to organization admin screen [#805](https://github.com/PublicMapping/districtbuilder/pull/805)
 
 ### Changed
 

--- a/src/client/actions/organizationProjects.ts
+++ b/src/client/actions/organizationProjects.ts
@@ -38,3 +38,8 @@ export const toggleProjectFeaturedSuccess = createAction("Toggle project feature
 export const toggleProjectFeaturedFailure = createAction("Toggle project featured failure")<
   ResourceFailure
 >();
+
+export const exportProjects = createAction("Export organization projects CSV")<OrganizationSlug>();
+export const exportProjectsFailure = createAction("Export organization projects CSV failure")<
+  string
+>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -335,6 +335,19 @@ export async function fetchOrganizationFeaturedProjects(
   });
 }
 
+export async function exportOrganizationProjectsCsv(slug: OrganizationSlug): Promise<void> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .get(`/api/project_templates/${slug}/export/maps-csv`)
+      .then(response => {
+        return resolve(
+          saveAs(new Blob([response.data], { type: "text/csv;charset=utf-8" }), `${slug}.csv`)
+        );
+      })
+      .catch(error => reject(error.message));
+  });
+}
+
 export async function saveProjectFeatured(project: ProjectNest): Promise<IOrganization> {
   return new Promise((resolve, reject) => {
     const projectPost = {

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -3,6 +3,7 @@ import mapValues from "lodash/mapValues";
 import { Box, jsx, Styled, ThemeUIStyleObject, Divider } from "theme-ui";
 
 import { demographicsColors } from "../constants/colors";
+import { getDemographicLabel } from "../../shared/functions";
 
 const style: ThemeUIStyleObject = {
   label: {
@@ -21,16 +22,12 @@ const style: ThemeUIStyleObject = {
   }
 };
 
-function parseRowLabel(label: string) {
-  return label.split(/(?=[A-Z])/).join(" ");
-}
-
 const Row = ({
-  label,
+  id,
   percent,
   color
 }: {
-  readonly label: string;
+  readonly id: string;
   readonly percent?: number;
   readonly color: string;
 }) => (
@@ -40,7 +37,7 @@ const Row = ({
       border: "none"
     }}
   >
-    <Styled.td sx={style.label}>{parseRowLabel(label)}</Styled.td>
+    <Styled.td sx={style.label}>{getDemographicLabel(id)}</Styled.td>
     <Styled.td sx={{ minWidth: "50px", py: 0 }}>
       <Box
         style={{
@@ -84,7 +81,7 @@ const DemographicsTooltip = ({
   const rows = races
     .filter(race => percentages[race] !== undefined)
     .map((id: typeof races[number]) => (
-      <Row key={id} label={id} percent={percentages[id]} color={demographicsColors[id]} />
+      <Row key={id} id={id} percent={percentages[id]} color={demographicsColors[id]} />
     ));
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>

--- a/src/client/reducers/organizationProjects.ts
+++ b/src/client/reducers/organizationProjects.ts
@@ -7,9 +7,10 @@ import { IProjectTemplateWithProjects } from "../../shared/entities";
 import {
   fetchOrganizationFeaturedProjects,
   fetchOrganizationProjects,
-  saveProjectFeatured
+  saveProjectFeatured,
+  exportOrganizationProjectsCsv
 } from "../api";
-import { showResourceFailedToast } from "../functions";
+import { showResourceFailedToast, showActionFailedToast } from "../functions";
 import { Resource } from "../resource";
 import {
   organizationProjectsFetch,
@@ -20,7 +21,9 @@ import {
   organizationFeaturedProjectsFetchFailure,
   toggleProjectFeatured,
   toggleProjectFeaturedSuccess,
-  toggleProjectFeaturedFailure
+  toggleProjectFeaturedFailure,
+  exportProjectsFailure,
+  exportProjects
 } from "../actions/organizationProjects";
 
 export interface OrganizationProjectsState {
@@ -124,6 +127,16 @@ const organizationProjectsReducer: LoopReducer<OrganizationProjectsState, Action
         },
         Cmd.run(showResourceFailedToast)
       );
+    case getType(exportProjects):
+      return loop(
+        state,
+        Cmd.run(exportOrganizationProjectsCsv, {
+          failActionCreator: exportProjectsFailure,
+          args: [action.payload] as Parameters<typeof exportOrganizationProjectsCsv>
+        })
+      );
+    case getType(exportProjectsFailure):
+      return loop(state, Cmd.run(showActionFailedToast));
     default:
       return state;
   }

--- a/src/client/screens/OrganizationAdminScreen.tsx
+++ b/src/client/screens/OrganizationAdminScreen.tsx
@@ -2,9 +2,9 @@
 import { useEffect } from "react";
 import { connect } from "react-redux";
 import { useParams, Link } from "react-router-dom";
-import { Box, Flex, Heading, jsx } from "theme-ui";
+import { Box, Flex, Heading, jsx, Button } from "theme-ui";
 import { organizationFetch } from "../actions/organization";
-import { organizationProjectsFetch } from "../actions/organizationProjects";
+import { organizationProjectsFetch, exportProjects } from "../actions/organizationProjects";
 import { State } from "../reducers";
 import { OrganizationState } from "../reducers/organization";
 import { UserState } from "../reducers/user";
@@ -30,7 +30,9 @@ const style = {
     boxShadow: "small",
     p: 5,
     "> *": {
-      m: 5
+      width: "100%",
+      m: 5,
+      pr: 5
     }
   },
   projectList: {
@@ -116,6 +118,12 @@ const OrganizationAdminScreen = ({ organization, user, organizationProjects }: S
                   <Link to={`/o/${organizationSlug}`}>{organization.resource.name}</Link>
                 </Heading>
                 <Heading>Maps</Heading>
+                <Button
+                  onClick={() => store.dispatch(exportProjects(organizationSlug))}
+                  sx={{ float: "right" }}
+                >
+                  Export maps
+                </Button>
                 <Box>
                   Published maps that were created by members of your organization. You can select
                   up to 12 maps to feature on your organization profile page.

--- a/src/server/src/project-templates/controllers/project-templates.controller.ts
+++ b/src/server/src/project-templates/controllers/project-templates.controller.ts
@@ -11,8 +11,9 @@ import {
   HostParam,
   InternalServerErrorException
 } from "@nestjs/common";
+import stringify from "csv-stringify/lib/sync";
 
-import { OrganizationSlug, IStaticMetadata } from "../../../../shared/entities";
+import { OrganizationSlug } from "../../../../shared/entities";
 
 import { JwtAuthGuard, OptionalJwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { Organization } from "../../organizations/entities/organization.entity";
@@ -23,8 +24,6 @@ import { ProjectTemplatesService } from "../services/project-templates.service";
 import { TopologyService } from "../../districts/services/topology.service";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
 import { getDemographicLabel } from "../../../../shared/functions";
-import _ from "lodash";
-import stringify from "csv-stringify/lib/sync";
 
 function getIds(
   topoLayers: { [s3uri: string]: GeoUnitTopology },
@@ -104,10 +103,12 @@ export class ProjectTemplatesController {
     }
     const projectRows = await this.service.findAdminOrgProjectsWithDistrictProperties(slug);
     const regionURIs = new Set(projectRows.map(row => row.regionS3URI));
-    let topoLayers: { [s3uri: string]: GeoUnitTopology } = {};
+    const topoLayers: { [s3uri: string]: GeoUnitTopology } = {};
+    // eslint-disable-next-line
     for (const [s3uri, layerPromise] of Object.entries(this.topologyService.layers() || {})) {
       const layer = await layerPromise;
       if (layer && regionURIs.has(s3uri)) {
+        // eslint-disable-next-line
         topoLayers[s3uri] = layer;
       }
     }

--- a/src/server/src/project-templates/project-templates.module.ts
+++ b/src/server/src/project-templates/project-templates.module.ts
@@ -6,9 +6,15 @@ import { OrganizationsModule } from "../organizations/organizations.module";
 import { ProjectTemplatesController } from "./controllers/project-templates.controller";
 import { ProjectTemplatesService } from "./services/project-templates.service";
 import { ProjectTemplate } from "./entities/project-template.entity";
+import { DistrictsModule } from "../districts/districts.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ProjectTemplate]), RegionConfigsModule, OrganizationsModule],
+  imports: [
+    TypeOrmModule.forFeature([ProjectTemplate]),
+    DistrictsModule,
+    RegionConfigsModule,
+    OrganizationsModule
+  ],
   controllers: [ProjectTemplatesController],
   providers: [ProjectTemplatesService],
   exports: [ProjectTemplatesService]

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -46,6 +46,7 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .leftJoin("projects.chamber", "chamber")
       .where("organization.slug = :slug", { slug })
       .andWhere("projects.visibility <> :private", { private: ProjectVisibility.Private })
+      .andWhere("projects.archived <> TRUE")
       .select("user.id", "userId")
       .addSelect("user.name", "userName")
       .addSelect("user.email", "userEmail")
@@ -76,6 +77,7 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .innerJoinAndSelect("projects.user", "user")
       .where("organization.slug = :slug", { slug })
       .andWhere("projects.visibility <> :private", { private: ProjectVisibility.Private })
+      .andWhere("projects.archived <> TRUE")
       .select([
         "projectTemplate.name",
         "projectTemplate.numberOfDistricts",

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -185,6 +185,7 @@ export type ProjectId = string;
 
 export type IProject = ProjectTemplateFields & {
   readonly id: ProjectId;
+  readonly createdDt: Date;
   readonly updatedDt: Date;
   readonly user: Pick<IUser, PublicUserProperties>;
   readonly projectTemplate?: IProjectTemplate;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -73,3 +73,7 @@ export function getAggregatedCounts(
     return { ...data, [props.id]: count };
   }, {} as DemographicCounts);
 }
+
+export function getDemographicLabel(id: string) {
+  return id.split(/(?=[A-Z])/).join(" ");
+}


### PR DESCRIPTION
## Overview

Adds a district-level CSV export to the organization admin screen.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_o_azavea_admin (1)](https://user-images.githubusercontent.com/4432106/120700141-47d58b80-c47f-11eb-8d0b-3604e164c8c0.png)

[azavea.csv](https://github.com/PublicMapping/districtbuilder/files/6593855/azavea.1.csv)


## Testing Instructions

- `scripts/server`
  - Go to the organization admin screen (and ensure there are projects listed there)
  - Click the "Export maps" button and ensure the contents of the CSV are correct

Closes #794 
