### PR TITLE
Fix sidebar and EqualPopulation metric for population deviation of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't show limit to county option in read-only mode [#777](https://github.com/PublicMapping/districtbuilder/pull/777)
 - Include unassigned district when switching using keyboard shortcuts [#779](https://github.com/PublicMapping/districtbuilder/pull/779)
 - Fix calculation of average compactness [#778](https://github.com/PublicMapping/districtbuilder/pull/778)
+- Fix computation of equal population flags for population deviation of zero [#806](https://github.com/PublicMapping/districtbuilder/pull/806)
 
 ## [1.5.0] - 2021-05-13
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -150,8 +150,8 @@ const ProjectSidebar = ({
   geoUnitHierarchy,
   lockedDistricts,
   hoveredDistrictId,
+  avgDistrictPopulationIsInteger,
   saving,
-  avgPopulation,
   isReadOnly
 }: {
   readonly project?: IProject;
@@ -163,8 +163,8 @@ const ProjectSidebar = ({
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly lockedDistricts: LockedDistricts;
   readonly hoveredDistrictId: number | null;
+  readonly avgDistrictPopulationIsInteger: boolean;
   readonly saving: SavingState;
-  readonly avgPopulation?: number;
   readonly isReadOnly: boolean;
 } & LoadingProps) => {
   return (
@@ -228,6 +228,7 @@ const ProjectSidebar = ({
                 selectedDistrictId={selectedDistrictId}
                 hoveredDistrictId={hoveredDistrictId}
                 selectedGeounits={selectedGeounits}
+                avgPopulationIsInteger={avgDistrictPopulationIsInteger}
                 highlightedGeounits={highlightedGeounits}
                 lockedDistricts={lockedDistricts}
                 saving={saving}
@@ -298,6 +299,7 @@ const SidebarRow = memo(
     districtId,
     isDistrictLocked,
     isDistrictHovered,
+    avgPopulationIsInteger,
     isReadOnly,
     popDeviationThreshold
   }: {
@@ -310,6 +312,7 @@ const SidebarRow = memo(
     readonly districtId: number;
     readonly isDistrictLocked?: boolean;
     readonly isDistrictHovered: boolean;
+    readonly avgPopulationIsInteger: boolean;
     readonly isReadOnly: boolean;
     readonly popDeviationThreshold: number;
   }) => {
@@ -321,12 +324,7 @@ const SidebarRow = memo(
         : negativeChangeColor
       : "inherit";
     const intermediatePopulation = demographics.population + selectedDifference;
-    const intermediateDeviation =
-      deviation + selectedDifference > 0
-        ? Math.floor(deviation + selectedDifference)
-        : deviation + selectedDifference > -1
-        ? Math.abs(Math.ceil(deviation + selectedDifference))
-        : Math.ceil(deviation + selectedDifference);
+    const intermediateDeviation = Math.ceil(deviation + selectedDifference);
     const populationDisplay = intermediatePopulation.toLocaleString();
     const isMinorityMajority = demographics.white / demographics.population < 0.5;
     const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
@@ -408,7 +406,9 @@ const SidebarRow = memo(
           <span sx={style.deviationIcon}>
             {(districtId === 0 && Math.abs(Math.floor(intermediateDeviation)) === 0) ||
             (districtId !== 0 &&
-              Math.floor(Math.abs(intermediateDeviation)) <= popDeviationThreshold) ? (
+              Math.floor(Math.abs(intermediateDeviation)) <= popDeviationThreshold) ||
+            (Math.floor(Math.abs(intermediateDeviation)) <= popDeviationThreshold + 1 &&
+              !avgPopulationIsInteger) ? (
               <Icon name="circle-check-solid" color="#388a64" />
             ) : intermediateDeviation < 0 ? (
               <Icon name="arrow-circle-down-solid" color="gray.4" />
@@ -506,6 +506,7 @@ interface SidebarRowsProps {
   readonly hoveredDistrictId: number | null;
   readonly selectedGeounits: GeoUnits;
   readonly highlightedGeounits: GeoUnits;
+  readonly avgPopulationIsInteger: boolean;
   readonly lockedDistricts: LockedDistricts;
   readonly saving: SavingState;
   readonly isReadOnly: boolean;
@@ -519,6 +520,7 @@ const SidebarRows = ({
   hoveredDistrictId,
   selectedGeounits,
   highlightedGeounits,
+  avgPopulationIsInteger,
   lockedDistricts,
   isReadOnly
 }: SidebarRowsProps) => {
@@ -612,6 +614,7 @@ const SidebarRows = ({
             isDistrictLocked={lockedDistricts[districtId - 1]}
             isDistrictHovered={districtId === hoveredDistrictId}
             districtId={districtId}
+            avgPopulationIsInteger={avgPopulationIsInteger}
             isReadOnly={isReadOnly}
             popDeviationThreshold={averagePopulation * (project.populationDeviation / 100)}
             votingIds={votingIds}

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -321,7 +321,12 @@ const SidebarRow = memo(
         : negativeChangeColor
       : "inherit";
     const intermediatePopulation = demographics.population + selectedDifference;
-    const intermediateDeviation = deviation + selectedDifference;
+    const intermediateDeviation =
+      deviation + selectedDifference > 0
+        ? Math.floor(deviation + selectedDifference)
+        : deviation + selectedDifference > -1
+        ? Math.abs(Math.ceil(deviation + selectedDifference))
+        : Math.ceil(deviation + selectedDifference);
     const populationDisplay = intermediatePopulation.toLocaleString();
     const isMinorityMajority = demographics.white / demographics.population < 0.5;
     const deviationDisplay = `${intermediateDeviation > 0 ? "+" : ""}${Math.round(
@@ -401,8 +406,9 @@ const SidebarRow = memo(
         <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
           <span>{deviationDisplay}</span>
           <span sx={style.deviationIcon}>
-            {(districtId === 0 && Math.abs(intermediateDeviation) === 0) ||
-            (districtId !== 0 && Math.abs(intermediateDeviation) <= popDeviationThreshold) ? (
+            {(districtId === 0 && Math.abs(Math.floor(intermediateDeviation)) === 0) ||
+            (districtId !== 0 &&
+              Math.floor(Math.abs(intermediateDeviation)) <= popDeviationThreshold) ? (
               <Icon name="circle-check-solid" color="#388a64" />
             ) : intermediateDeviation < 0 ? (
               <Icon name="arrow-circle-down-solid" color="gray.4" />

--- a/src/client/components/Tour.tsx
+++ b/src/client/components/Tour.tsx
@@ -27,7 +27,7 @@ class Tour extends Component<Props, State> {
     super(props);
 
     const numberOfDistricts = props.project.numberOfDistricts;
-    const population = Number(Math.round(getTargetPopulation(props.geojson))).toLocaleString();
+    const population = Math.round(getTargetPopulation(props.geojson)).toLocaleString();
     const regionConfig = props.project.regionConfig.name;
     const geoLevelsSingular = props.staticMetadata.geoLevelHierarchy
       .map(geolevel => geolevel.id)

--- a/src/client/components/Tour.tsx
+++ b/src/client/components/Tour.tsx
@@ -27,9 +27,7 @@ class Tour extends Component<Props, State> {
     super(props);
 
     const numberOfDistricts = props.project.numberOfDistricts;
-    const population = Number(
-      Math.round(getTargetPopulation(props.geojson, props.project))
-    ).toLocaleString();
+    const population = Number(Math.round(getTargetPopulation(props.geojson))).toLocaleString();
     const regionConfig = props.project.regionConfig.name;
     const geoLevelsSingular = props.staticMetadata.geoLevelHierarchy
       .map(geolevel => geolevel.id)

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -33,12 +33,14 @@ const ProjectEvaluateSidebar = ({
   geojson,
   metric,
   project,
+  avgDistrictPopulationIsInteger,
   regionProperties,
   staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
   readonly metric: EvaluateMetric | undefined;
   readonly project?: IProject;
+  readonly avgDistrictPopulationIsInteger: boolean;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
@@ -69,6 +71,25 @@ const ProjectEvaluateSidebar = ({
     }
   }, [staticMetadata]);
 
+  console.log(
+    geojson &&
+      popThreshold !== undefined &&
+      geojson?.features.filter(f => {
+        console.log(f.properties);
+        return (
+          f.id !== 0 &&
+          f.properties.percentDeviation !== undefined &&
+          f.properties.populationDeviation !== undefined &&
+          (Math.abs(f.properties.percentDeviation) <= popThreshold ||
+            // @ts-ignore
+            Math.abs(f.properties.populationDeviation) < 1 ||
+            (Math.floor(Math.abs(f.properties.populationDeviation)) === 1 &&
+              !avgDistrictPopulationIsInteger))
+        );
+      })
+  );
+  console.log(geojson?.features.filter(f => f.properties.demographics.population > 0));
+
   useEffect(() => {
     if (project && project.regionConfig.regionCode && geoLevel) {
       store.dispatch(
@@ -82,19 +103,21 @@ const ProjectEvaluateSidebar = ({
       key: "equalPopulation",
       name: "Equal Population",
       status:
-        (avgPopulation &&
-          geojson &&
+        (geojson &&
           popThreshold !== undefined &&
           geojson?.features.filter(f => {
+            console.log(f.properties);
             return (
-              (f.id !== 0 &&
-                f.properties.percentDeviation !== undefined &&
-                f.properties.populationDeviation !== undefined &&
-                Math.abs(f.properties.percentDeviation) <= popThreshold) ||
-              // @ts-ignore
-              Math.abs(f.properties.populationDeviation) < 1
+              f.id !== 0 &&
+              f.properties.percentDeviation !== undefined &&
+              f.properties.populationDeviation !== undefined &&
+              (Math.abs(f.properties.percentDeviation) <= popThreshold ||
+                // @ts-ignore
+                Math.abs(f.properties.populationDeviation) < 1 ||
+                (Math.floor(Math.abs(f.properties.populationDeviation)) === 1 &&
+                  !avgDistrictPopulationIsInteger))
             );
-          }).length ===
+          }).length >=
             geojson?.features.filter(f => f.properties.demographics.population > 0).length - 1) ||
         false,
       description: "have equal population",

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -86,10 +86,14 @@ const ProjectEvaluateSidebar = ({
           geojson &&
           popThreshold !== undefined &&
           geojson?.features.filter(f => {
+            console.log(f);
             return (
-              f.id !== 0 &&
-              f.properties.percentDeviation &&
-              Math.abs(f.properties.percentDeviation) <= popThreshold
+              (f.id !== 0 &&
+                f.properties.percentDeviation !== undefined &&
+                f.properties.populationDeviation !== undefined &&
+                Math.abs(f.properties.percentDeviation) <= popThreshold) ||
+              // @ts-ignore
+              Math.abs(f.properties.populationDeviation) < 1
             );
           }).length ===
             geojson?.features.filter(f => f.properties.demographics.population > 0).length - 1) ||
@@ -111,9 +115,12 @@ const ProjectEvaluateSidebar = ({
         avgPopulation && geojson && popThreshold !== undefined
           ? geojson?.features.filter(f => {
               return (
-                f.id !== 0 &&
-                f.properties.percentDeviation &&
-                Math.abs(f.properties.percentDeviation) <= popThreshold
+                (f.id !== 0 &&
+                  f.properties.percentDeviation !== undefined &&
+                  f.properties.populationDeviation !== undefined &&
+                  Math.abs(f.properties.percentDeviation) <= popThreshold) ||
+                // @ts-ignore
+                Math.abs(f.properties.populationDeviation) < 1
               );
             }).length
           : 0

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -86,7 +86,6 @@ const ProjectEvaluateSidebar = ({
           geojson &&
           popThreshold !== undefined &&
           geojson?.features.filter(f => {
-            console.log(f);
             return (
               (f.id !== 0 &&
                 f.properties.percentDeviation !== undefined &&

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -33,14 +33,12 @@ const ProjectEvaluateSidebar = ({
   geojson,
   metric,
   project,
-  avgDistrictPopulationIsInteger,
   regionProperties,
   staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
   readonly metric: EvaluateMetric | undefined;
   readonly project?: IProject;
-  readonly avgDistrictPopulationIsInteger: boolean;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
@@ -71,25 +69,6 @@ const ProjectEvaluateSidebar = ({
     }
   }, [staticMetadata]);
 
-  console.log(
-    geojson &&
-      popThreshold !== undefined &&
-      geojson?.features.filter(f => {
-        console.log(f.properties);
-        return (
-          f.id !== 0 &&
-          f.properties.percentDeviation !== undefined &&
-          f.properties.populationDeviation !== undefined &&
-          (Math.abs(f.properties.percentDeviation) <= popThreshold ||
-            // @ts-ignore
-            Math.abs(f.properties.populationDeviation) < 1 ||
-            (Math.floor(Math.abs(f.properties.populationDeviation)) === 1 &&
-              !avgDistrictPopulationIsInteger))
-        );
-      })
-  );
-  console.log(geojson?.features.filter(f => f.properties.demographics.population > 0));
-
   useEffect(() => {
     if (project && project.regionConfig.regionCode && geoLevel) {
       store.dispatch(
@@ -106,16 +85,13 @@ const ProjectEvaluateSidebar = ({
         (geojson &&
           popThreshold !== undefined &&
           geojson?.features.filter(f => {
-            console.log(f.properties);
             return (
               f.id !== 0 &&
               f.properties.percentDeviation !== undefined &&
               f.properties.populationDeviation !== undefined &&
               (Math.abs(f.properties.percentDeviation) <= popThreshold ||
                 // @ts-ignore
-                Math.abs(f.properties.populationDeviation) < 1 ||
-                (Math.floor(Math.abs(f.properties.populationDeviation)) === 1 &&
-                  !avgDistrictPopulationIsInteger))
+                Math.abs(f.properties.populationDeviation) < 1)
             );
           }).length >=
             geojson?.features.filter(f => f.properties.demographics.population > 0).length - 1) ||

--- a/src/client/components/evaluate/detail/Compactness.tsx
+++ b/src/client/components/evaluate/detail/Compactness.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Box, Flex, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
 import { EvaluateMetricWithValue, DistrictProperties } from "../../../../shared/entities";
-import { getChoroplethStops } from "../../map/index";
+import { getCompactnessStops } from "../../map/index";
 import { DistrictsGeoJSON } from "../../../types";
 import { getCompactnessDisplay } from "../../ProjectSidebar";
 
@@ -65,7 +65,7 @@ const CompactnessMetricDetail = ({
 }) => {
   function computeRowFill(row: DistrictProperties) {
     const val = row.compactness;
-    const choroplethStops = getChoroplethStops(metric.key);
+    const choroplethStops = getCompactnessStops();
     // eslint-disable-next-line
     let i = 0;
     // eslint-disable-next-line

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -65,10 +65,15 @@ const EqualPopulationMetricDetail = ({
   readonly metric: EvaluateMetricWithValue;
   readonly geojson?: DistrictsGeoJSON;
 }) => {
+  const avgDistrictPopulationIsInteger =
+    (metric.avgPopulation && metric.avgPopulation % 1 === 0) || false;
   function computeRowFill(row: DistrictProperties) {
     const val = row.percentDeviation;
-    const choroplethStops = getChoroplethStops(metric.key, metric.popThreshold);
-    console.log(val);
+    const choroplethStops = getChoroplethStops(
+      metric.key,
+      metric.popThreshold,
+      avgDistrictPopulationIsInteger
+    );
     // eslint-disable-next-line
     for (let i = 0; i < choroplethStops.length; i++) {
       const r = choroplethStops[i];
@@ -111,7 +116,8 @@ const EqualPopulationMetricDetail = ({
                   <Styled.td sx={{ ...style.td, ...style.colFirst }}>{id}</Styled.td>
 
                   <Styled.td sx={style.td}>
-                    {feature.properties.percentDeviation !== undefined ? (
+                    {feature.properties.percentDeviation !== undefined &&
+                    feature.properties.populationDeviation !== undefined ? (
                       <Flex sx={{ alignItems: "center" }}>
                         <Styled.div
                           sx={{
@@ -124,8 +130,8 @@ const EqualPopulationMetricDetail = ({
                         ></Styled.div>
                         <Box>
                           {feature.properties.percentDeviation > 0
-                            ? Math.floor(feature.properties.percentDeviation * 1000) / 10
-                            : Math.ceil(feature.properties.percentDeviation * 1000) / 10}
+                            ? Math.ceil(feature.properties.percentDeviation * 1000) / 10
+                            : Math.floor(feature.properties.percentDeviation * 1000) / 10}
                           %
                         </Box>
                       </Flex>
@@ -136,11 +142,11 @@ const EqualPopulationMetricDetail = ({
 
                   <Styled.td sx={{ ...style.td, ...style.number, ...style.colLast }}>
                     {feature.properties.populationDeviation !== undefined ? (
-                      Math.round(feature.properties.populationDeviation) !== -0 ? (
-                        Math.round(feature.properties.populationDeviation).toLocaleString()
-                      ) : (
+                      Math.round(feature.properties.populationDeviation) === -0 ? (
                         // Render 0 instead of -0
                         0
+                      ) : (
+                        Math.round(feature.properties.populationDeviation).toLocaleString()
                       )
                     ) : (
                       <Box sx={style.blankValue}>-</Box>

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -142,12 +142,7 @@ const EqualPopulationMetricDetail = ({
 
                   <Styled.td sx={{ ...style.td, ...style.number, ...style.colLast }}>
                     {feature.properties.populationDeviation !== undefined ? (
-                      Math.round(feature.properties.populationDeviation) === -0 ? (
-                        // Render 0 instead of -0
-                        0
-                      ) : (
-                        Math.round(feature.properties.populationDeviation).toLocaleString()
-                      )
+                      Math.round(feature.properties.populationDeviation).toLocaleString()
                     ) : (
                       <Box sx={style.blankValue}>-</Box>
                     )}

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -68,10 +68,11 @@ const EqualPopulationMetricDetail = ({
   function computeRowFill(row: DistrictProperties) {
     const val = row.percentDeviation;
     const choroplethStops = getChoroplethStops(metric.key, metric.popThreshold);
+    console.log(val);
     // eslint-disable-next-line
     for (let i = 0; i < choroplethStops.length; i++) {
       const r = choroplethStops[i];
-      if (val && val >= r[0]) {
+      if (val !== undefined && val >= r[0]) {
         if (i < choroplethStops.length - 1) {
           const r1 = choroplethStops[i + 1];
           if (val < r1[0]) {
@@ -110,7 +111,7 @@ const EqualPopulationMetricDetail = ({
                   <Styled.td sx={{ ...style.td, ...style.colFirst }}>{id}</Styled.td>
 
                   <Styled.td sx={style.td}>
-                    {feature.properties.percentDeviation ? (
+                    {feature.properties.percentDeviation !== undefined ? (
                       <Flex sx={{ alignItems: "center" }}>
                         <Styled.div
                           sx={{
@@ -121,7 +122,12 @@ const EqualPopulationMetricDetail = ({
                             bg: computeRowFill(feature.properties)
                           }}
                         ></Styled.div>
-                        <Box>{Math.floor(feature.properties.percentDeviation * 1000) / 10}%</Box>
+                        <Box>
+                          {feature.properties.percentDeviation > 0
+                            ? Math.floor(feature.properties.percentDeviation * 1000) / 10
+                            : Math.ceil(feature.properties.percentDeviation * 1000) / 10}
+                          %
+                        </Box>
                       </Flex>
                     ) : (
                       <Box sx={style.blankValue}>-</Box>
@@ -129,8 +135,13 @@ const EqualPopulationMetricDetail = ({
                   </Styled.td>
 
                   <Styled.td sx={{ ...style.td, ...style.number, ...style.colLast }}>
-                    {feature.properties.populationDeviation ? (
-                      Math.round(feature.properties.populationDeviation).toLocaleString()
+                    {feature.properties.populationDeviation !== undefined ? (
+                      Math.round(feature.properties.populationDeviation) !== -0 ? (
+                        Math.round(feature.properties.populationDeviation).toLocaleString()
+                      ) : (
+                        // Render 0 instead of -0
+                        0
+                      )
                     ) : (
                       <Box sx={style.blankValue}>-</Box>
                     )}

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -178,6 +178,7 @@ interface Props {
   readonly geoLevelIndex: number;
   readonly lockedDistricts: LockedDistricts;
   readonly evaluateMetric?: EvaluateMetric;
+  readonly avgDistrictPopulationIsInteger: boolean;
   readonly evaluateMode: boolean;
   readonly isReadOnly: boolean;
   readonly limitSelectionToCounty: boolean;
@@ -257,6 +258,7 @@ const DistrictsMap = ({
   limitSelectionToCounty,
   findMenuOpen,
   evaluateMetric,
+  avgDistrictPopulationIsInteger,
   evaluateMode,
   findTool,
   label,
@@ -323,7 +325,6 @@ const DistrictsMap = ({
     const setLevelVisibility = () => {
       store.dispatch(setGeoLevelVisibility(getGeoLevelVisibility(map, staticMetadata)));
     };
-
     const onMapLoad = () => {
       generateMapLayers(
         project.regionConfig.s3URI,
@@ -333,7 +334,7 @@ const DistrictsMap = ({
         maxZoom,
         map,
         geojson,
-        evaluateMetric && "avgPopulation" in evaluateMetric ? evaluateMetric : undefined,
+        avgDistrictPopulationIsInteger,
         project?.populationDeviation
       );
 

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -80,12 +80,18 @@ export function getChoroplethStops(metricKey: string, popThreshold?: number) {
 
   const equalPopulationSteps =
     popThreshold !== undefined
-      ? [
+      ? popThreshold !== 0 ? [
           [-1.0, "#D1E5F0"],
           [-1 * (popThreshold + 0.02), "#66A9CF"],
           [-1 * (popThreshold + 0.01), "#2166AC"],
           [-1 * popThreshold, "#01665E"],
           [popThreshold, "#EFBE60"],
+          [popThreshold + 0.01, "#F5D092"],
+          [popThreshold + 0.02, "#F7E1C3"]
+        ] : [
+          [-1.0, "#D1E5F0"],
+          [-1 * (popThreshold + 0.02), "#66A9CF"],
+          [-1 * (popThreshold + 0.01), "#01665E"],
           [popThreshold + 0.01, "#F5D092"],
           [popThreshold + 0.02, "#F7E1C3"]
         ]
@@ -248,7 +254,7 @@ export function generateMapLayers(
         "fill-color": {
           property: "percentDeviation",
           type: "interval",
-          stops: populationDeviation
+          stops: populationDeviation !== undefined
             ? getChoroplethStops("equalPopulation", populationDeviation / 100.0)
             : getChoroplethStops("equalPopulation")
         },

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -16,7 +16,7 @@ import {
   UintArrays
 } from "../../../shared/entities";
 import { getAllIndices } from "../../../shared/functions";
-import { isBaseGeoLevelAlwaysVisible } from "../../functions";
+import { isBaseGeoLevelAlwaysVisible, getTargetPopulation } from "../../functions";
 import { mapValues } from "lodash";
 
 // Vector tiles with geolevel data for this geography
@@ -68,94 +68,44 @@ export const filteredLabelLayers = [
   "poi-label"
 ];
 
-export function getChoroplethStops(
-  metricKey: string,
-  popThreshold?: number,
-  avgPopulationIsInteger?: boolean
-) {
-  const compactnessSteps = [
+export function getCompactnessStops() {
+  return [
     [0.3, "#edf8fb"],
     [0.4, "#b2e2e2"],
     [0.5, "#66c2a4"],
     [0.6, "#2ca25f"],
     [1.0, "#006d2c"]
   ];
-
-  const equalPopulationSteps =
-    popThreshold !== undefined
-      ? popThreshold !== 0
-        ? [
-            [-1.0, "#D1E5F0"],
-            [-1 * (popThreshold + 0.02), "#66A9CF"],
-            [-1 * (popThreshold + 0.01), "#2166AC"],
-            [-1 * popThreshold, "#01665E"],
-            [popThreshold, "#EFBE60"],
-            [popThreshold + 0.01, "#F5D092"],
-            [popThreshold + 0.02, "#F7E1C3"]
-          ]
-        : avgPopulationIsInteger
-        ? [
-            [-1.0, "#D1E5F0"],
-            [-0.01, "#66A9CF"],
-            [0, "#01665E"],
-            [0.0000001, "#EFBE60"],
-            [0.01, "#F5D092"],
-            [popThreshold + 0.02, "#F7E1C3"]
-          ]
-        : [
-            [-1.0, "#D1E5F0"],
-            [-0.01, "#66A9CF"],
-            [-0.001, "#01665E"],
-            [0.001, "#EFBE60"],
-            [0.01, "#F5D092"],
-            [popThreshold + 0.02, "#F7E1C3"]
-          ]
-      : [
-          [-1.0, "#D1E5F0"],
-          [1.0, "#F7E1C3"]
-        ];
-  switch (metricKey) {
-    case "compactness":
-      return compactnessSteps;
-    case "equalPopulation":
-      return equalPopulationSteps;
-    default:
-      return [];
-  }
 }
 
-export function getChoroplethLabels(metricKey: string, populationDeviation?: number) {
-  const compactnessLabels = ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
-  const steps = getChoroplethStops(metricKey, populationDeviation);
-  switch (metricKey) {
-    case "compactness":
-      return compactnessLabels;
-    case "equalPopulation":
-      return steps.map((step, i) => {
-        const stepVal = Number(step[0]);
-        if (i === 0) {
-          // Lower bound condition
-          return `< ${Math.ceil(Number(steps[1][0]) * 100)}%`;
-        } else if (i === steps.length - 1) {
-          // Upper bound condition
-          return `> ${Math.floor(stepVal * 100)}%`;
-        } else {
-          const nextStep = Number(steps[i + 1][0]);
-          if (stepVal < 0 && nextStep > 0) {
-            // Target condition
-            return `Target (+/- ${Math.floor(nextStep * 100)}%)`;
-          } else {
-            if (stepVal < 0) {
-              return `${Math.ceil(stepVal * 100)}% to ${Math.ceil(nextStep * 100)}%`;
-            } else {
-              return `${Math.floor(stepVal * 100)}% to ${Math.floor(nextStep * 100)}%`;
-            }
-          }
-        }
-      });
-    default:
-      return [];
-  }
+export function getEqualPopulationStops(popThresholdNum: number, avgPopulation: number) {
+  const popThreshold = popThresholdNum / 100;
+  const isAvgFractional = avgPopulation % 1 !== 0;
+  return [
+    [-1.0 * avgPopulation, "#D1E5F0"],
+    [-1 * (popThreshold + 0.02) * avgPopulation, "#66A9CF"],
+    [-1 * (popThreshold + 0.01) * avgPopulation, "#2166AC"],
+    [-1 * popThreshold * avgPopulation - (isAvgFractional ? 1 : 0.1), "#01665E"],
+    [popThreshold === 0 ? (isAvgFractional ? 1 : 0.1) : popThreshold * avgPopulation, "#EFBE60"],
+    [(popThreshold + 0.01) * avgPopulation, "#F5D092"],
+    [(popThreshold + 0.02) * avgPopulation, "#F7E1C3"]
+  ];
+}
+
+export function getCompactnessLabels() {
+  return ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
+}
+
+export function getEqualPopulationLabels(popThreshold: number) {
+  return [
+    [`< ${Math.ceil(-1 * (popThreshold + 2))}%`],
+    [`${-1 * Math.ceil(popThreshold + 2)}% to ${-1 * Math.ceil(popThreshold + 1)}%`],
+    [`${-1 * Math.ceil(popThreshold + 1)}% to ${-1 * Math.ceil(popThreshold)}%`],
+    [popThreshold !== 0 ? `Target (+/- ${Math.floor(popThreshold)}%)` : `Target (0%)`],
+    [`${Math.floor(popThreshold)}% to ${Math.floor(popThreshold + 1)}%`],
+    [`${Math.floor(popThreshold + 1)}% to ${Math.floor(popThreshold + 2)}%`],
+    [`> ${Math.floor(popThreshold + 2)}%`]
+  ];
 }
 
 export function getGeolevelLinePaintStyle(geoLevel: string) {
@@ -200,9 +150,8 @@ export function generateMapLayers(
   /* eslint-disable */
   map: any,
   geojson: any,
-  avgDistrictPopulationIsInteger: boolean,
-  populationDeviation?: number
   /* eslint-enable */
+  populationDeviation: number
 ) {
   map.addSource(DISTRICTS_SOURCE_ID, {
     type: "geojson",
@@ -249,7 +198,7 @@ export function generateMapLayers(
       paint: {
         "fill-color": {
           property: "compactness",
-          stops: getChoroplethStops("compactness")
+          stops: getCompactnessStops()
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9
@@ -257,6 +206,8 @@ export function generateMapLayers(
     },
     DISTRICTS_PLACEHOLDER_LAYER_ID
   );
+
+  const avgPopulation = getTargetPopulation(geojson);
   map.addLayer(
     {
       id: DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID,
@@ -266,16 +217,9 @@ export function generateMapLayers(
       filter: ["match", ["get", "color"], ["transparent"], false, true],
       paint: {
         "fill-color": {
-          property: "percentDeviation",
+          property: "populationDeviation",
           type: "interval",
-          stops:
-            populationDeviation !== undefined
-              ? getChoroplethStops(
-                  "equalPopulation",
-                  populationDeviation / 100.0,
-                  avgDistrictPopulationIsInteger
-                )
-              : getChoroplethStops("equalPopulation")
+          stops: getEqualPopulationStops(populationDeviation, avgPopulation)
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -68,7 +68,11 @@ export const filteredLabelLayers = [
   "poi-label"
 ];
 
-export function getChoroplethStops(metricKey: string, popThreshold?: number, avgPopulationIsInteger?: boolean) {
+export function getChoroplethStops(
+  metricKey: string,
+  popThreshold?: number,
+  avgPopulationIsInteger?: boolean
+) {
   const compactnessSteps = [
     [0.3, "#edf8fb"],
     [0.4, "#b2e2e2"],
@@ -79,29 +83,33 @@ export function getChoroplethStops(metricKey: string, popThreshold?: number, avg
 
   const equalPopulationSteps =
     popThreshold !== undefined
-      ? popThreshold !== 0 ? [
-          [-1.0, "#D1E5F0"],
-          [-1 * (popThreshold + 0.02), "#66A9CF"],
-          [-1 * (popThreshold + 0.01), "#2166AC"],
-          [-1 * popThreshold, "#01665E"],
-          [popThreshold, "#EFBE60"],
-          [popThreshold + 0.01, "#F5D092"],
-          [popThreshold + 0.02, "#F7E1C3"]
-        ] : avgPopulationIsInteger ? [
-          [-1.0, "#D1E5F0"],
-          [-0.01, "#66A9CF"],
-          [0, "#01665E"],
-          [0.0000001, "#EFBE60"],
-          [0.01, "#F5D092"],
-          [popThreshold + 0.02, "#F7E1C3"]
-        ] : [
-          [-1.0, "#D1E5F0"],
-          [-0.01, "#66A9CF"],
-          [-0.001, "#01665E"],
-          [0.001, "#EFBE60"],
-          [0.01, "#F5D092"],
-          [popThreshold + 0.02, "#F7E1C3"]
-        ]
+      ? popThreshold !== 0
+        ? [
+            [-1.0, "#D1E5F0"],
+            [-1 * (popThreshold + 0.02), "#66A9CF"],
+            [-1 * (popThreshold + 0.01), "#2166AC"],
+            [-1 * popThreshold, "#01665E"],
+            [popThreshold, "#EFBE60"],
+            [popThreshold + 0.01, "#F5D092"],
+            [popThreshold + 0.02, "#F7E1C3"]
+          ]
+        : avgPopulationIsInteger
+        ? [
+            [-1.0, "#D1E5F0"],
+            [-0.01, "#66A9CF"],
+            [0, "#01665E"],
+            [0.0000001, "#EFBE60"],
+            [0.01, "#F5D092"],
+            [popThreshold + 0.02, "#F7E1C3"]
+          ]
+        : [
+            [-1.0, "#D1E5F0"],
+            [-0.01, "#66A9CF"],
+            [-0.001, "#01665E"],
+            [0.001, "#EFBE60"],
+            [0.01, "#F5D092"],
+            [popThreshold + 0.02, "#F7E1C3"]
+          ]
       : [
           [-1.0, "#D1E5F0"],
           [1.0, "#F7E1C3"]
@@ -260,9 +268,14 @@ export function generateMapLayers(
         "fill-color": {
           property: "percentDeviation",
           type: "interval",
-          stops: populationDeviation !== undefined
-            ? getChoroplethStops("equalPopulation", populationDeviation / 100.0, avgDistrictPopulationIsInteger)
-            : getChoroplethStops("equalPopulation")
+          stops:
+            populationDeviation !== undefined
+              ? getChoroplethStops(
+                  "equalPopulation",
+                  populationDeviation / 100.0,
+                  avgDistrictPopulationIsInteger
+                )
+              : getChoroplethStops("equalPopulation")
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -13,8 +13,7 @@ import {
   MutableGeoUnits,
   IStaticMetadata,
   LockedDistricts,
-  UintArrays,
-  EvaluateMetricWithValue
+  UintArrays
 } from "../../../shared/entities";
 import { getAllIndices } from "../../../shared/functions";
 import { isBaseGeoLevelAlwaysVisible } from "../../functions";
@@ -69,7 +68,7 @@ export const filteredLabelLayers = [
   "poi-label"
 ];
 
-export function getChoroplethStops(metricKey: string, popThreshold?: number) {
+export function getChoroplethStops(metricKey: string, popThreshold?: number, avgPopulationIsInteger?: boolean) {
   const compactnessSteps = [
     [0.3, "#edf8fb"],
     [0.4, "#b2e2e2"],
@@ -88,11 +87,19 @@ export function getChoroplethStops(metricKey: string, popThreshold?: number) {
           [popThreshold, "#EFBE60"],
           [popThreshold + 0.01, "#F5D092"],
           [popThreshold + 0.02, "#F7E1C3"]
+        ] : avgPopulationIsInteger ? [
+          [-1.0, "#D1E5F0"],
+          [-0.01, "#66A9CF"],
+          [0, "#01665E"],
+          [0.0000001, "#EFBE60"],
+          [0.01, "#F5D092"],
+          [popThreshold + 0.02, "#F7E1C3"]
         ] : [
           [-1.0, "#D1E5F0"],
-          [-1 * (popThreshold + 0.02), "#66A9CF"],
-          [-1 * (popThreshold + 0.01), "#01665E"],
-          [popThreshold + 0.01, "#F5D092"],
+          [-0.01, "#66A9CF"],
+          [-0.001, "#01665E"],
+          [0.001, "#EFBE60"],
+          [0.01, "#F5D092"],
           [popThreshold + 0.02, "#F7E1C3"]
         ]
       : [
@@ -185,7 +192,7 @@ export function generateMapLayers(
   /* eslint-disable */
   map: any,
   geojson: any,
-  metric?: EvaluateMetricWithValue,
+  avgDistrictPopulationIsInteger: boolean,
   populationDeviation?: number
   /* eslint-enable */
 ) {
@@ -242,7 +249,6 @@ export function generateMapLayers(
     },
     DISTRICTS_PLACEHOLDER_LAYER_ID
   );
-
   map.addLayer(
     {
       id: DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID,
@@ -255,7 +261,7 @@ export function generateMapLayers(
           property: "percentDeviation",
           type: "interval",
           stops: populationDeviation !== undefined
-            ? getChoroplethStops("equalPopulation", populationDeviation / 100.0)
+            ? getChoroplethStops("equalPopulation", populationDeviation / 100.0, avgDistrictPopulationIsInteger)
             : getChoroplethStops("equalPopulation")
         },
         "fill-outline-color": "gray",

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -8,8 +8,7 @@ import {
   GeoUnits,
   GeoUnitIndices,
   GeoUnitHierarchy,
-  NestedArray,
-  IProject
+  NestedArray
 } from "../shared/entities";
 import { Resource } from "./resource";
 import { DistrictsGeoJSON } from "./types";
@@ -134,12 +133,13 @@ export function assignGeounitsToDistrict(
 // The target population is based on the average population of all districts,
 // not including the unassigned district, so we use the number of districts,
 // rather than the district feature count (which includes the unassigned district)
-export function getTargetPopulation(geojson: DistrictsGeoJSON, project: IProject) {
+export function getTargetPopulation(geojson: DistrictsGeoJSON) {
   return (
     geojson.features.reduce(
       (population, feature) => population + feature.properties.demographics.population,
       0
-    ) / project.numberOfDistricts
+    ) /
+    (geojson.features.length - 1)
   );
 }
 

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -165,9 +165,6 @@ const ProjectScreen = ({
             geojson={geojson}
             metric={evaluateMetric}
             project={project}
-            avgDistrictPopulationIsInteger={
-              (avgDistrictPopulation && avgDistrictPopulation % 1 === 0) || false
-            }
             regionProperties={regionProperties}
             staticMetadata={staticMetadata}
           />

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -90,11 +90,10 @@ const ProjectScreen = ({
   const isFirstLoadPending = isLoading && (project === undefined || staticMetadata === undefined);
   const presentDrawingState = districtDrawing.undoHistory.present.state;
   useEffect(() => {
-    if (geojson && !avgDistrictPopulation && project) {
-      getTargetPopulation(geojson, project);
-      setAvgDistrictPopulation(getTargetPopulation(geojson, project));
+    if (geojson && !avgDistrictPopulation) {
+      setAvgDistrictPopulation(getTargetPopulation(geojson));
     }
-  }, [geojson, avgDistrictPopulation, project]);
+  }, [geojson, avgDistrictPopulation]);
 
   // Warn the user when attempting to leave the page with selected geounits
   useBeforeunload(event => {
@@ -154,9 +153,6 @@ const ProjectScreen = ({
             geoUnitHierarchy={geoUnitHierarchy}
             lockedDistricts={presentDrawingState.lockedDistricts}
             hoveredDistrictId={districtDrawing.hoveredDistrictId}
-            avgDistrictPopulationIsInteger={
-              (avgDistrictPopulation && avgDistrictPopulation % 1 === 0) || false
-            }
             saving={districtDrawing.saving}
             isReadOnly={isReadOnly}
           />
@@ -209,9 +205,6 @@ const ProjectScreen = ({
                 lockedDistricts={presentDrawingState.lockedDistricts}
                 evaluateMode={evaluateMode}
                 evaluateMetric={evaluateMetric}
-                avgDistrictPopulationIsInteger={
-                  (avgDistrictPopulation && avgDistrictPopulation % 1 === 0) || false
-                }
                 isReadOnly={isReadOnly}
                 limitSelectionToCounty={districtDrawing.limitSelectionToCounty}
                 label={mapLabel}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -165,6 +165,9 @@ const ProjectScreen = ({
             geojson={geojson}
             metric={evaluateMetric}
             project={project}
+            avgDistrictPopulationIsInteger={
+              (avgDistrictPopulation && avgDistrictPopulation % 1 === 0) || false
+            }
             regionProperties={regionProperties}
             staticMetadata={staticMetadata}
           />


### PR DESCRIPTION
## Overview

- Fixes the flag in ProjectSidebar to display correctly with a population deviation of 0
- Fixes choropleth steps for Equal Population metric for a population deviation of 0
- Fixes computation of EqualPopulation metric for evaluate mode for a population deviation of 0
- Distinguishes between the unique cases of a whole integer `avgDistrictPopulation`, and an average population that contains a fraction

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Whole integer avgPopulation

![image](https://user-images.githubusercontent.com/66973361/120707301-27f69580-c488-11eb-8f3d-47c4464d58be.png)

![image](https://user-images.githubusercontent.com/66973361/120707348-35138480-c488-11eb-885d-0985e9f94729.png)



Non-integer avgPopulation

![image](https://user-images.githubusercontent.com/66973361/120709091-6d1bc700-c48a-11eb-8131-973b7016d363.png)

![image](https://user-images.githubusercontent.com/66973361/120709138-7a38b600-c48a-11eb-94f6-bfe6a8110583.png)


## Testing Instructions

- Create a map in PA with an even number of districts (e.g., 4), so the average population contains a fractional remainder
- Add a district that exactly matches the target population, or target population + 1 - expect it to be treated as equal population
- Add a district that is -1 the target population, expect to be treated as invalid

- Create a map in VA with an even number of districts (e.g., 4), so the average population is a whole integer
- Add a district that exactly matches the target population - expect it to be treated as equal population
- Add a district that not exactly equal to the target population, expect to be treated as invalid


Closes #801 
