### PR TITLE
Add organization user CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display target population symbols in sidebar [#720](https://github.com/PublicMapping/districtbuilder/issues/720)
 - List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796)
 - Add map export to organization admin screen [#805](https://github.com/PublicMapping/districtbuilder/pull/805)
+<<<<<<< HEAD
 - Add support for Vagrant Development Environment [#729](https://github.com/PublicMapping/districtbuilder/pull/729)
+=======
+- Add user export to organization admin screen [#812](https://github.com/PublicMapping/districtbuilder/pull/812)
+>>>>>>> Update CHANGELOG
 
 ### Changed
 

--- a/src/client/actions/organization.ts
+++ b/src/client/actions/organization.ts
@@ -7,3 +7,13 @@ export const organizationFetchSuccess = createAction("Organization fetch success
 export const organizationFetchFailure = createAction("Organization fetch failure")<
   ResourceFailure
 >();
+
+export const exportProjects = createAction("Export organization projects CSV")<OrganizationSlug>();
+export const exportProjectsFailure = createAction("Export organization projects CSV failure")<
+  string
+>();
+
+export const exportOrgUsers = createAction("Export organization users CSV")<OrganizationSlug>();
+export const exportOrgUsersFailure = createAction("Export organization users CSV failure")<
+  string
+>();

--- a/src/client/actions/organizationProjects.ts
+++ b/src/client/actions/organizationProjects.ts
@@ -38,8 +38,3 @@ export const toggleProjectFeaturedSuccess = createAction("Toggle project feature
 export const toggleProjectFeaturedFailure = createAction("Toggle project featured failure")<
   ResourceFailure
 >();
-
-export const exportProjects = createAction("Export organization projects CSV")<OrganizationSlug>();
-export const exportProjectsFailure = createAction("Export organization projects CSV failure")<
-  string
->();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -338,10 +338,23 @@ export async function fetchOrganizationFeaturedProjects(
 export async function exportOrganizationProjectsCsv(slug: OrganizationSlug): Promise<void> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .get(`/api/project_templates/${slug}/export/maps-csv`)
+      .get(`/api/project_templates/${slug}/export/maps-csv/`)
       .then(response => {
         return resolve(
-          saveAs(new Blob([response.data], { type: "text/csv;charset=utf-8" }), `${slug}.csv`)
+          saveAs(new Blob([response.data], { type: "text/csv;charset=utf-8" }), `${slug}-maps.csv`)
+        );
+      })
+      .catch(error => reject(error.message));
+  });
+}
+
+export async function exportOrganizationUsersCsv(slug: OrganizationSlug): Promise<void> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .get(`/api/organization/${slug}/export/users-csv/`)
+      .then(response => {
+        return resolve(
+          saveAs(new Blob([response.data], { type: "text/csv;charset=utf-8" }), `${slug}-users.csv`)
         );
       })
       .catch(error => reject(error.message));

--- a/src/client/components/OrganizationExportMenu.tsx
+++ b/src/client/components/OrganizationExportMenu.tsx
@@ -1,0 +1,56 @@
+/** @jsx jsx */
+import { jsx, Box } from "theme-ui";
+import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import Icon from "../components/Icon";
+import { OrganizationSlug } from "../../shared/entities";
+import { style } from "./MenuButton.styles";
+import store from "../store";
+import { exportProjects, exportOrgUsers } from "../actions/organization";
+
+enum UserMenuKeys {
+  ExportMaps = "maps",
+  ExportUsers = "users"
+}
+
+interface Props {
+  readonly slug: OrganizationSlug;
+}
+
+const OrganizationExportMenu = (props: Props) => {
+  return (
+    <Wrapper
+      sx={{ position: "relative", display: "inline-block", ml: 3, pr: 1 }}
+      onSelection={(userMenuKey: string) => {
+        const action = userMenuKey === UserMenuKeys.ExportMaps ? exportProjects : exportOrgUsers;
+        store.dispatch(action(props.slug));
+      }}
+    >
+      <MenuButton
+        sx={{
+          ...{ variant: "buttons.secondary", fontWeight: "light" },
+          ...style.menuButton
+        }}
+        className="export-menu"
+      >
+        <Icon name="export" />
+        Download
+      </MenuButton>
+      <Menu sx={style.menu}>
+        <ul sx={style.menuList}>
+          <li key={UserMenuKeys.ExportMaps}>
+            <MenuItem value={UserMenuKeys.ExportMaps}>
+              <Box sx={style.menuListItem}>Download Maps</Box>
+            </MenuItem>
+          </li>
+          <li key={UserMenuKeys.ExportUsers}>
+            <MenuItem value={UserMenuKeys.ExportUsers}>
+              <Box sx={style.menuListItem}>Download Users</Box>
+            </MenuItem>
+          </li>
+        </ul>
+      </Menu>
+    </Wrapper>
+  );
+};
+
+export default OrganizationExportMenu;

--- a/src/client/reducers/organization.ts
+++ b/src/client/reducers/organization.ts
@@ -5,12 +5,20 @@ import { Action } from "../actions";
 import {
   organizationFetch,
   organizationFetchFailure,
-  organizationFetchSuccess
+  organizationFetchSuccess,
+  exportOrgUsers,
+  exportOrgUsersFailure,
+  exportProjects,
+  exportProjectsFailure
 } from "../actions/organization";
 
 import { IOrganization } from "../../shared/entities";
-import { fetchOrganization } from "../api";
-import { showResourceFailedToast } from "../functions";
+import {
+  fetchOrganization,
+  exportOrganizationUsersCsv,
+  exportOrganizationProjectsCsv
+} from "../api";
+import { showResourceFailedToast, showActionFailedToast } from "../functions";
 import { Resource } from "../resource";
 
 export type OrganizationState = Resource<IOrganization>;
@@ -48,6 +56,26 @@ const organizationReducer: LoopReducer<OrganizationState, Action> = (
           ? Cmd.run(showResourceFailedToast)
           : Cmd.none
       );
+    case getType(exportProjects):
+      return loop(
+        state,
+        Cmd.run(exportOrganizationProjectsCsv, {
+          failActionCreator: exportProjectsFailure,
+          args: [action.payload] as Parameters<typeof exportOrganizationProjectsCsv>
+        })
+      );
+    case getType(exportProjectsFailure):
+      return loop(state, Cmd.run(showActionFailedToast));
+    case getType(exportOrgUsers):
+      return loop(
+        state,
+        Cmd.run(exportOrganizationUsersCsv, {
+          failActionCreator: exportOrgUsersFailure,
+          args: [action.payload] as Parameters<typeof exportOrganizationUsersCsv>
+        })
+      );
+    case getType(exportOrgUsersFailure):
+      return loop(state, Cmd.run(showActionFailedToast));
     default:
       return state;
   }

--- a/src/client/reducers/organizationProjects.ts
+++ b/src/client/reducers/organizationProjects.ts
@@ -7,10 +7,9 @@ import { IProjectTemplateWithProjects } from "../../shared/entities";
 import {
   fetchOrganizationFeaturedProjects,
   fetchOrganizationProjects,
-  saveProjectFeatured,
-  exportOrganizationProjectsCsv
+  saveProjectFeatured
 } from "../api";
-import { showResourceFailedToast, showActionFailedToast } from "../functions";
+import { showResourceFailedToast } from "../functions";
 import { Resource } from "../resource";
 import {
   organizationProjectsFetch,
@@ -21,9 +20,7 @@ import {
   organizationFeaturedProjectsFetchFailure,
   toggleProjectFeatured,
   toggleProjectFeaturedSuccess,
-  toggleProjectFeaturedFailure,
-  exportProjectsFailure,
-  exportProjects
+  toggleProjectFeaturedFailure
 } from "../actions/organizationProjects";
 
 export interface OrganizationProjectsState {
@@ -127,16 +124,6 @@ const organizationProjectsReducer: LoopReducer<OrganizationProjectsState, Action
         },
         Cmd.run(showResourceFailedToast)
       );
-    case getType(exportProjects):
-      return loop(
-        state,
-        Cmd.run(exportOrganizationProjectsCsv, {
-          failActionCreator: exportProjectsFailure,
-          args: [action.payload] as Parameters<typeof exportOrganizationProjectsCsv>
-        })
-      );
-    case getType(exportProjectsFailure):
-      return loop(state, Cmd.run(showActionFailedToast));
     default:
       return state;
   }

--- a/src/client/screens/OrganizationAdminScreen.tsx
+++ b/src/client/screens/OrganizationAdminScreen.tsx
@@ -1,19 +1,22 @@
 /** @jsx jsx */
 import { useEffect } from "react";
 import { connect } from "react-redux";
-import { useParams, Link } from "react-router-dom";
-import { Box, Flex, Heading, jsx, Button } from "theme-ui";
+import { Link, useParams } from "react-router-dom";
+import { Box, Flex, Heading, jsx } from "theme-ui";
+
 import { organizationFetch } from "../actions/organization";
-import { organizationProjectsFetch, exportProjects } from "../actions/organizationProjects";
+import { organizationProjectsFetch } from "../actions/organizationProjects";
+import { userFetch } from "../actions/user";
+import OrganizationAdminProjectsTable from "../components/OrganizationAdminProjectsTable";
+import OrganizationExportMenu from "../components/OrganizationExportMenu";
+import SiteHeader from "../components/SiteHeader";
 import { State } from "../reducers";
 import { OrganizationState } from "../reducers/organization";
+import { OrganizationProjectsState } from "../reducers/organizationProjects";
 import { UserState } from "../reducers/user";
 import store from "../store";
-import SiteHeader from "../components/SiteHeader";
+
 import PageNotFoundScreen from "./PageNotFoundScreen";
-import { OrganizationProjectsState } from "../reducers/organizationProjects";
-import OrganizationAdminProjectsTable from "../components/OrganizationAdminProjectsTable";
-import { userFetch } from "../actions/user";
 
 interface StateProps {
   readonly organization: OrganizationState;
@@ -118,15 +121,10 @@ const OrganizationAdminScreen = ({ organization, user, organizationProjects }: S
                   <Link to={`/o/${organizationSlug}`}>{organization.resource.name}</Link>
                 </Heading>
                 <Heading>Maps</Heading>
-                <Button
-                  onClick={() => store.dispatch(exportProjects(organizationSlug))}
-                  sx={{ float: "right" }}
-                >
-                  Export maps
-                </Button>
                 <Box>
                   Published maps that were created by members of your organization. You can select
                   up to 12 maps to feature on your organization profile page.
+                  <OrganizationExportMenu slug={organizationSlug} />
                 </Box>
               </Box>
             </Flex>

--- a/src/server/src/project-templates/controllers/project-templates.controller.ts
+++ b/src/server/src/project-templates/controllers/project-templates.controller.ts
@@ -88,7 +88,7 @@ export class ProjectTemplatesController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get(":slug/export/maps-csv")
+  @Get(":slug/export/maps-csv/")
   @Header("Content-Type", "text/csv")
   async exportMapsCsv(
     @Param("slug") slug: OrganizationSlug,

--- a/src/server/src/users/services/users.service.ts
+++ b/src/server/src/users/services/users.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
 import { Repository } from "typeorm";
 
-import { Register } from "../../../../shared/entities";
+import { Register, OrganizationSlug } from "../../../../shared/entities";
 import { User } from "../entities/user.entity";
 
 @Injectable()
@@ -21,5 +21,12 @@ export class UsersService extends TypeOrmCrudService<User> {
   save(user: User): Promise<User> {
     // @ts-ignore
     return this.repo.save(user);
+  }
+
+  async getOrgUsers(slug: OrganizationSlug): Promise<ReadonlyArray<User>> {
+    return this.repo
+      .createQueryBuilder("user")
+      .innerJoin("user.organizations", "organization", "slug = :slug", { slug })
+      .getMany();
   }
 }


### PR DESCRIPTION
## Overview

Adds a second CSV export to the organization admin screen, for exporting users

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_o_azavea_admin (2)](https://user-images.githubusercontent.com/4432106/121205348-98653400-c845-11eb-8d5c-681a5d516622.png)

[azavea-users.csv](https://github.com/PublicMapping/districtbuilder/files/6617606/azavea-users.csv)


## Testing Instructions

- Go to the organization admin screen
- Both exports should function as expected

Closes #793 