### PR TITLE
Clean up 'Community maps' view and 'My maps' views

### DIFF
--- a/src/client/components/FeaturedProjectCard.tsx
+++ b/src/client/components/FeaturedProjectCard.tsx
@@ -105,7 +105,7 @@ const FeaturedProjectCard = ({ project }: { readonly project: ProjectNest }) => 
         <Box ref={mapRef} sx={style.map}></Box>
       </Box>
       {!mapLoaded && (
-        <Box sx={style.mapContainer}>
+        <Box sx={{ ...style.mapContainer, ...{ position: "absolute" } }}>
           <Spinner variant="spinner.small" />
         </Box>
       )}

--- a/src/client/components/OrganizationDropdown.tsx
+++ b/src/client/components/OrganizationDropdown.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui";
 import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
-import Icon from "../components/Icon";
 import { invertStyles, style } from "./MenuButton.styles";
 import { OrganizationNest } from "../../shared/entities";
 import * as H from "history";
@@ -14,7 +13,7 @@ interface Props {
 const OrganizationDropdown = ({ organizations }: Props) => {
   const history = useHistory();
   return (
-    <Wrapper sx={{ position: "relative", pr: 1 }} onSelection={handleSelection(history)}>
+    <Wrapper sx={{ position: "relative" }} onSelection={handleSelection(history)}>
       <MenuButton
         sx={{
           ...{ variant: "buttons.ghost", fontWeight: "light" },
@@ -25,7 +24,6 @@ const OrganizationDropdown = ({ organizations }: Props) => {
         className="organization-menu"
       >
         My Organizations
-        <Icon name="angle-down" />
       </MenuButton>
       <Menu sx={style.menu}>
         <ul sx={style.menuList}>

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -43,7 +43,7 @@ const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
         <li sx={{ display: "inline" }} key={number} id={number.toString()}>
           <Button
             sx={number === currentPage ? style.paginationSelected : style.pagination}
-            onClick={() =>number !== currentPage && setPage(number)}
+            onClick={() => number !== currentPage && setPage(number)}
           >
             {number}
           </Button>

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -12,19 +12,22 @@ interface StateProps {
 
 const style = {
   pagination: {
-    // TODO: Make this not look bad
     cursor: "pointer",
+    display: "inline",
+    mr: 1,
+    backgroundColor: "transparent",
+    color: "text"
+  },
+  paginationSelected: {
+    cursor: "pointer",
+    fontWeight: 700,
     display: "inline",
     mr: 1
   },
-  paginationSelected: {
-    // TODO: Make this not look bad
-    cursor: "pointer",
-    fontWeight: 700,
-    display: "inline"
-  },
   pageList: {
-    display: "inline-block"
+    display: "inline-block",
+    padding: 0,
+    listStyle: "none"
   }
 };
 
@@ -37,12 +40,11 @@ const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
     pageNumbers &&
     pageNumbers.map(number => {
       return (
-        <li
-          key={number}
-          id={number.toString()}
-          sx={number === currentPage ? style.paginationSelected : style.pagination}
-        >
-          <Button disabled={number === currentPage} onClick={() => setPage(number)}>
+        <li sx={{ display: "inline" }} key={number} id={number.toString()}>
+          <Button
+            sx={number === currentPage ? style.paginationSelected : style.pagination}
+            onClick={() => setPage(number)}
+          >
             {number}
           </Button>
         </li>

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -43,7 +43,7 @@ const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
         <li sx={{ display: "inline" }} key={number} id={number.toString()}>
           <Button
             sx={number === currentPage ? style.paginationSelected : style.pagination}
-            onClick={() => setPage(number)}
+            onClick={() =>number !== currentPage && setPage(number)}
           >
             {number}
           </Button>

--- a/src/client/components/SiteHeader.tsx
+++ b/src/client/components/SiteHeader.tsx
@@ -2,7 +2,7 @@
 import { Button as MenuButton, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
 import Avatar from "react-avatar";
 import React, { useState } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link, NavLink, useHistory } from "react-router-dom";
 import * as H from "history";
 import Icon from "../components/Icon";
 import SupportMenu from "../components/SupportMenu";
@@ -90,6 +90,22 @@ const style: ThemeUIStyleObject = {
     m: "0",
     listStyleType: "none"
   },
+  linkItem: {
+    px: "3",
+    py: 1,
+    display: "inline-block",
+    a: {
+      textDecoration: "none",
+      fontWeight: "light",
+      fontFamily: "heading",
+      color: "gray.8"
+    },
+    "> .active": {
+      borderBottom: "2px solid currentColor",
+      paddingBottom: "4px",
+      fontWeight: "medium"
+    }
+  },
   menuListItem: {
     borderRadius: "small",
     py: 1,
@@ -164,7 +180,7 @@ const SiteHeader = ({ user }: Props) => {
         </Alert>
       )}
       <Flex as="header" sx={style.header}>
-        <Heading as="h1" sx={{ mb: "0px", mr: "auto", p: 2 }}>
+        <Heading as="h1" sx={{ mb: "0px", mr: "auto", pt: 2 }}>
           <Link to="/" sx={style.logoLink}>
             <Logo sx={{ width: "15rem" }} />
           </Link>
@@ -180,10 +196,29 @@ const SiteHeader = ({ user }: Props) => {
           </React.Fragment>
         ) : "resource" in user ? (
           <React.Fragment>
-            <SupportMenu />
+            <span sx={style.linkItem}>
+              <NavLink exact to="/">
+                My maps
+              </NavLink>
+            </span>
             {user.resource.organizations.length > 0 && (
               <OrganizationDropdown organizations={user.resource.organizations} />
             )}
+            <span sx={style.linkItem}>
+              <NavLink exact to="/maps">
+                Community maps
+              </NavLink>
+            </span>
+            <span
+              sx={{
+                svg: { display: "none" },
+                span: {
+                  backgroundColor: "transparent !important"
+                }
+              }}
+            >
+              <SupportMenu />
+            </span>
             <Wrapper onSelection={handleSelection(history)} sx={{ ml: 3 }}>
               <MenuButton sx={style.menuButton}>
                 <Avatar

--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -41,7 +41,7 @@ export const initialState = {
   globalProjects: { isPending: false },
   globalProjectsPagination: {
     currentPage: 1,
-    limit: 10,
+    limit: 8,
     totalItems: undefined,
     totalPages: undefined
   },

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -131,44 +131,46 @@ const HomeScreen = ({ projects, user }: StateProps) => {
             <Flex
               sx={{
                 flexDirection: "column",
-                alignItems: "center",
+                alignItems: "start",
                 maxWidth: "500px",
                 mt: 7,
                 mx: "auto"
               }}
             >
-              <Box sx={{ mb: 5, mx: "auto" }}>
+              <Box sx={{ mb: 5 }}>
                 <NoMapsIllustration />
               </Box>
-              <Heading sx={{ variant: "text.h4", textAlign: "center" }}>
-                Welcome to DistrictBuilder!
-              </Heading>
-
-              <Text sx={{ fontSize: 3, color: "text", textAlign: "center", mb: 5 }}>
-                Start building your first map or check out our{" "}
+              <Heading sx={{ variant: "text.h4" }}>Welcome to DistrictBuilder!</Heading>
+              <Text sx={{ fontSize: 3, color: "text", mb: 5, mt: 3 }}>
+                We believe in the power of individuals like you to draw maps that reflect local
+                communities and lead to fair representation. We are excited to see what you build!
+                And for extra help, check out the{" "}
                 <Styled.a
-                  href="https://github.com/PublicMapping/districtbuilder/wiki/Getting-Started-with-DistrictBuilder"
+                  href="https://github.com/PublicMapping/districtbuilder/wiki/G
+etting-Started-with-DistrictBuilder"
                   target="_blank"
                 >
-                  Getting Started Guide
+                  getting started guide
                 </Styled.a>{" "}
-                to learn how!
+                or see <Styled.a href="/maps">community maps</Styled.a>.
               </Text>
-              <Styled.a
-                as={Link}
-                to="/create-project"
-                sx={{ variant: "links.button", fontSize: 3, px: 4, py: 2 }}
-              >
-                <Icon name="plus-circle" />
-                Create a map
-              </Styled.a>
-              <Styled.a
-                as={Link}
-                to="/import-project"
-                sx={{ variant: "links.secondaryButton", fontSize: 3, px: 6, py: 2, mt: 2 }}
-              >
-                Import map
-              </Styled.a>
+              <Flex>
+                <Styled.a
+                  as={Link}
+                  to="/create-project"
+                  sx={{ variant: "links.button", fontSize: 3, px: 4, py: 2 }}
+                >
+                  <Icon name="plus-circle" />
+                  Create a map
+                </Styled.a>
+                <Styled.a
+                  as={Link}
+                  to="/import-project"
+                  sx={{ variant: "links.secondaryButton", fontSize: 3, px: 4, py: 2, ml: 2 }}
+                >
+                  Import map
+                </Styled.a>
+              </Flex>
             </Flex>
           )
         ) : null}

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -146,8 +146,7 @@ const HomeScreen = ({ projects, user }: StateProps) => {
                 communities and lead to fair representation. We are excited to see what you build!
                 And for extra help, check out the{" "}
                 <Styled.a
-                  href="https://github.com/PublicMapping/districtbuilder/wiki/G
-etting-Started-with-DistrictBuilder"
+                  href="https://github.com/PublicMapping/districtbuilder/wiki/Getting-Started-with-DistrictBuilder"
                   target="_blank"
                 >
                   getting started guide

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -68,13 +68,13 @@ const PublishedMapsListScreen = ({ globalProjects, user, pagination }: StateProp
   return (
     <Flex sx={{ height: "100%", flexDirection: "column" }}>
       <SiteHeader user={user} />
-      <Box>
+      <Box sx={{ flex: 1 }}>
         {projects ? (
           <Box sx={style.projects}>
-            <Heading as="h2" sx={{ mb: "3" }}>
-              <span>All published maps</span>
+            <Heading as="h2" sx={{ my: "3" }}>
+              <span>Community maps</span>
             </Heading>
-            <Text>A collection of maps built by all DistrictBuilder users globally</Text>
+            <Text>Explore published maps from across the entire DistrictBuilder community</Text>
             <Box sx={style.featuredProjectContainer}>
               {projects.length > 0 ? (
                 projects.map((project: ProjectNest) => (
@@ -85,15 +85,23 @@ const PublishedMapsListScreen = ({ globalProjects, user, pagination }: StateProp
               )}
             </Box>
             {pagination.totalPages && (
-              <PaginationFooter
-                currentPage={pagination.currentPage}
-                totalPages={pagination.totalPages}
-                setPage={number => store.dispatch(globalProjectsFetchPage(number))}
-              />
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center"
+                }}
+              >
+                <PaginationFooter
+                  currentPage={pagination.currentPage}
+                  totalPages={pagination.totalPages}
+                  setPage={number => store.dispatch(globalProjectsFetchPage(number))}
+                />
+              </Box>
             )}
           </Box>
         ) : (
-          <Flex sx={{ justifyContent: "center" }}>
+          <Flex sx={{ justifyContent: "center", alignItems: "center", height: "100%" }}>
             <Spinner variant="spinner.large" />
           </Flex>
         )}

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -17,7 +17,6 @@ const appButtonStyles = {
   fontWeight: "medium",
   borderRadius: "3px",
   cursor: "pointer",
-  transition: "0.2s background ease-out, 0.2s background-color ease-out",
   "& > svg": {
     mr: 1
   },
@@ -273,8 +272,7 @@ const theme: Theme & StyledSystemTheme = {
       ...appButtonStyles,
       ...{
         bg: "transparent",
-        color: "blue.6",
-        fontWeight: "bold",
+        color: "blue.5",
         padding: 0,
         "&:hover:not([disabled]):not(:active)": {
           textDecoration: "underline",
@@ -508,11 +506,10 @@ const theme: Theme & StyledSystemTheme = {
       color: "gray.2"
     },
     a: {
-      color: "blue.6",
-      fontWeight: "bold",
+      color: "blue.5",
       textDecoration: "none",
       "&:visited": {
-        color: "blue.6"
+        color: "blue.5"
       },
       "&:hover:not([disabled]):not(:active)": {
         textDecoration: "underline"


### PR DESCRIPTION
## Overview

- Change "All maps" to "Community maps"
- Add "My maps" (the maps I've made) and "Community maps" to the primary navigation
- Make style more consistent across primary navigation
- Overhaul copy for the "My maps" empty state, to make it more inspiring and add a link to the community maps
- Clean up styles for pagination on "Community maps"
- Reduce number of maps on "Community maps" from 10 to 8, because we are displaying the maps in rows of 4 and a total number divisible by 4 looks better
- Improve spinner on loading maps, which previously doubled the size of the container card

### Demo

![Screen Shot 2021-06-09 at 11 45 24 PM](https://user-images.githubusercontent.com/1809908/121517590-8efed780-c9bd-11eb-970f-28faf0365f23.png)
![Screen Shot 2021-06-09 at 11 45 43 PM](https://user-images.githubusercontent.com/1809908/121517592-8f976e00-c9bd-11eb-8ba7-f91dadc776f4.png)

### Notes



## Testing Instructions

- Create a new account, or use an account with no maps so you can view the empty state
- Take a look at the "My maps" and "Community maps" tabs
- Confirm that they look similar to the attached screenshots