### PR TITLE
Add support for multiple elections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display target population symbols in sidebar [#720](https://github.com/PublicMapping/districtbuilder/issues/720)
 - List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796)
 - Add map export to organization admin screen [#805](https://github.com/PublicMapping/districtbuilder/pull/805)
-<<<<<<< HEAD
 - Add support for Vagrant Development Environment [#729](https://github.com/PublicMapping/districtbuilder/pull/729)
-=======
 - Add user export to organization admin screen [#812](https://github.com/PublicMapping/districtbuilder/pull/812)
->>>>>>> Update CHANGELOG
+- Add support for calculating PVI / handling '16 & '20 election data [#818](https://github.com/PublicMapping/districtbuilder/pull/818)
 
 ### Changed
 

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -52,6 +52,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/PA/2021-02-08T18:07:18.957Z/',
                 DEFAULT,
                 DEFAULT
+              ), (
+                '6c440b8d-c26e-4bae-850f-dbff37fe0209',
+                'Illinois',
+                'US',
+                'IL',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/IL/2021-06-04T15:05:37.089Z/',
+                DEFAULT,
+                DEFAULT
              )
               ON CONFLICT DO NOTHING;
             "
@@ -62,7 +70,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Add user to testing organization
         docker-compose \
             exec database psql -U districtbuilder districtbuilder -c "
-              INSERT INTO organization_users_user VALUES((SELECT id FROM organization WHERE slug = 'azavea'), (SELECT id FROM \"user\" ORDER BY id LIMIT 1));
+              INSERT INTO organization_users_user VALUES((SELECT id FROM organization WHERE slug = 'azavea'), (SELECT id FROM \"user\" ORDER BY id LIMIT 1)) ON CONFLICT DO NOTHING;
             "
 
         # Set testing organization admin (no-op if there are no users) 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -2,6 +2,8 @@ import { createAction } from "typesafe-actions";
 import { DistrictId, EvaluateMetric, GeoUnits } from "../../shared/entities";
 import { SavingState } from "../types";
 
+export type ElectionYear = "16" | "20";
+
 export enum SelectionTool {
   Default = "DEFAULT",
   Rectangle = "RECTANGLE",
@@ -51,6 +53,8 @@ export const setGeoLevelVisibility = createAction("Set geolevel visibility")<rea
 export const toggleDistrictLocked = createAction("Toggle district locked")<DistrictId>();
 
 export const toggleLimitDrawingToWithinCounty = createAction("Limit drawing to within county")();
+
+export const setElectionYear = createAction("Set election year for tooltip data")<ElectionYear>();
 
 export const toggleKeyboardShortcutsModal = createAction("Show keyboard shortcuts modal")();
 

--- a/src/client/components/DemographicsChart.tsx
+++ b/src/client/components/DemographicsChart.tsx
@@ -31,11 +31,11 @@ const DemographicsChart = ({
       <Bar width={percentages.asian} color={demographicsColors.asian} />
       <Bar width={percentages.hispanic} color={demographicsColors.hispanic} />
       {"other" in percentages && <Bar width={percentages.other} color={demographicsColors.other} />}
-      {"nativeAmerican" in percentages && (
-        <Bar width={percentages.nativeAmerican} color={demographicsColors.nativeAmerican} />
+      {"native" in percentages && (
+        <Bar width={percentages.native} color={demographicsColors.native} />
       )}
-      {"pacificIslander" in percentages && (
-        <Bar width={percentages.pacificIslander} color={demographicsColors.pacificIslander} />
+      {"pacific" in percentages && (
+        <Bar width={percentages.pacific} color={demographicsColors.pacific} />
       )}
     </Flex>
   );

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -11,7 +11,8 @@ const style: ThemeUIStyleObject = {
     py: 0,
     pr: 2,
     whiteSpace: "nowrap",
-    textTransform: "capitalize"
+    textTransform: "capitalize",
+    width: "70px"
   },
   number: {
     flex: "auto",

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -26,11 +26,13 @@ const style: ThemeUIStyleObject = {
 const Row = ({
   id,
   percent,
-  color
+  color,
+  abbreviate
 }: {
   readonly id: string;
   readonly percent?: number;
   readonly color: string;
+  readonly abbreviate?: boolean;
 }) => (
   <Styled.tr
     sx={{
@@ -38,7 +40,7 @@ const Row = ({
       border: "none"
     }}
   >
-    <Styled.td sx={style.label}>{getDemographicLabel(id)}</Styled.td>
+    <Styled.td sx={style.label}>{abbreviate ? id : getDemographicLabel(id)}</Styled.td>
     <Styled.td sx={{ minWidth: "50px", py: 0 }}>
       <Box
         style={{
@@ -60,29 +62,29 @@ const Row = ({
 
 const DemographicsTooltip = ({
   demographics,
-  isMinorityMajority
+  isMinorityMajority,
+  abbreviate
 }: {
   readonly demographics: { readonly [id: string]: number };
   readonly isMinorityMajority?: boolean;
+  readonly abbreviate?: boolean;
 }) => {
   const percentages = mapValues(
     demographics,
     (population: number) =>
       (demographics.population ? population / demographics.population : 0) * 100
   );
-  const races = [
-    "white",
-    "black",
-    "asian",
-    "hispanic",
-    "nativeAmerican",
-    "pacificIslander",
-    "other"
-  ] as const;
+  const races = ["white", "black", "asian", "hispanic", "native", "pacific", "other"] as const;
   const rows = races
     .filter(race => percentages[race] !== undefined)
     .map((id: typeof races[number]) => (
-      <Row key={id} id={id} percent={percentages[id]} color={demographicsColors[id]} />
+      <Row
+        key={id}
+        id={id}
+        percent={percentages[id]}
+        color={demographicsColors[id]}
+        abbreviate={abbreviate}
+      />
     ));
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -11,7 +11,8 @@ import {
   setGeoLevelIndex,
   setSelectionTool,
   SelectionTool,
-  setMapLabel
+  setMapLabel,
+  ElectionYear
 } from "../actions/districtDrawing";
 import store from "../store";
 
@@ -128,7 +129,8 @@ const MapHeader = ({
   geoLevelIndex,
   selectedGeounits,
   isReadOnly,
-  limitSelectionToCounty
+  limitSelectionToCounty,
+  electionYear
 }: {
   readonly label?: string;
   readonly metadata?: IStaticMetadata;
@@ -138,6 +140,7 @@ const MapHeader = ({
   readonly advancedEditingEnabled?: boolean;
   readonly isReadOnly: boolean;
   readonly limitSelectionToCounty: boolean;
+  readonly electionYear: ElectionYear;
 }) => {
   const topGeoLevelName = metadata
     ? metadata.geoLevelHierarchy[metadata.geoLevelHierarchy.length - 1].id
@@ -204,6 +207,8 @@ const MapHeader = ({
               <MapSelectionOptionsFlyout
                 limitSelectionToCounty={limitSelectionToCounty}
                 topGeoLevelName={topGeoLevelName}
+                metadata={metadata}
+                electionYear={electionYear}
               />
             </Box>
           </React.Fragment>

--- a/src/client/components/MapSelectionOptionsFlyout.tsx
+++ b/src/client/components/MapSelectionOptionsFlyout.tsx
@@ -1,21 +1,31 @@
 /** @jsx jsx */
-import { jsx, Checkbox, Label } from "theme-ui";
+import { jsx, Checkbox, Label, Select } from "theme-ui";
 import { Button as MenuButton, Wrapper, Menu } from "react-aria-menubutton";
 import { style } from "./MenuButton.styles";
 import store from "../store";
-import { toggleLimitDrawingToWithinCounty } from "../actions/districtDrawing";
+import {
+  toggleLimitDrawingToWithinCounty,
+  ElectionYear,
+  setElectionYear
+} from "../actions/districtDrawing";
 import Tooltip from "./Tooltip";
 import Icon from "./Icon";
-
-type MenuKeys = "limit-drawing-to-within-county";
+import { IStaticMetadata } from "../../shared/entities";
 
 const MapSelectionOptionsFlyout = ({
   limitSelectionToCounty,
-  topGeoLevelName
+  metadata,
+  topGeoLevelName,
+  electionYear
 }: {
   readonly limitSelectionToCounty: boolean;
+  readonly metadata?: IStaticMetadata;
   readonly topGeoLevelName?: string;
+  readonly electionYear: ElectionYear;
 }) => {
+  const votingIds = metadata?.voting?.map(file => file.id) || [];
+  const hasMultipleElections =
+    votingIds.some(id => id.endsWith("16")) && votingIds.some(id => id.endsWith("20"));
   return (
     <Wrapper closeOnSelection={false}>
       <Tooltip content="Drawing options">
@@ -59,6 +69,28 @@ const MapSelectionOptionsFlyout = ({
               Limit drawing to within {topGeoLevelName}
             </Label>
           </li>
+          {hasMultipleElections && (
+            <li>
+              <Label
+                htmlFor="election-dropdown"
+                sx={{ display: "inline-block", width: "auto", mb: 0, mr: 2 }}
+              >
+                Election data:
+              </Label>
+              <Select
+                id="election-dropdown"
+                value={electionYear}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                  const year = e.currentTarget.value;
+                  (year === "16" || year === "20") && store.dispatch(setElectionYear(year));
+                }}
+                sx={{ width: "150px" }}
+              >
+                <option value={"16"}>Presidential 2016</option>
+                <option value={"20"}>Presidential 2020</option>
+              </Select>
+            </li>
+          )}
         </ul>
       </Menu>
     </Wrapper>

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { Fragment, memo, useEffect, useMemo, useState } from "react";
+import React, { Fragment, memo, useEffect, useState } from "react";
 import { Box, Button, Flex, jsx, Styled, ThemeUIStyleObject } from "theme-ui";
 
 import {
@@ -29,7 +29,8 @@ import {
   getPartyColor,
   getTargetPopulation,
   mergeGeoUnits,
-  calculatePVI
+  calculatePVI,
+  hasMultipleElections
 } from "../functions";
 import store from "../store";
 import { DistrictGeoJSON, DistrictsGeoJSON, SavingState } from "../types";
@@ -165,12 +166,10 @@ const ProjectSidebar = ({
   readonly saving: SavingState;
   readonly isReadOnly: boolean;
 } & LoadingProps) => {
-  const hasMultElections =
-    staticMetadata?.voting?.some(file => file.id.endsWith("16")) &&
-    staticMetadata?.voting?.some(file => file.id.endsWith("20"));
-  const polLabel = hasMultElections
-    ? "Cook Partisan Voting Index (2021)"
-    : "Political lean (2016 presidential)";
+  const multElections = hasMultipleElections(staticMetadata);
+  const polLabel = multElections
+    ? "Cook Partisan Voting Index (2016 / 2020)"
+    : "Political Lean (2016)";
   return (
     <Flex sx={style.sidebar} className="map-sidebar">
       <ProjectSidebarHeader
@@ -205,7 +204,7 @@ const ProjectSidebar = ({
               {staticMetadata?.voting && (
                 <Styled.th sx={{ ...style.th, ...style.number }}>
                   <Tooltip content={polLabel}>
-                    <span>Pol.</span>
+                    <span>{multElections ? "PVI" : "Pol."}</span>
                   </Tooltip>
                 </Styled.th>
               )}
@@ -348,7 +347,7 @@ const SidebarRow = memo(
     const partyLabel = pvi && pvi > 0 ? "D" : "R";
     const votingDisplay =
       pvi !== undefined ? (
-        <Box sx={{ color }}>{`${partyLabel}+${pvi.toLocaleString(undefined, {
+        <Box sx={{ color }}>{`${partyLabel}+${Math.abs(pvi).toLocaleString(undefined, {
           maximumFractionDigits: 0
         })}`}</Box>
       ) : (

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -292,7 +292,6 @@ const SidebarRow = memo(
     selected,
     selectedPopulationDifference,
     demographics,
-    votingIds,
     deviation,
     districtId,
     isDistrictLocked,
@@ -304,7 +303,6 @@ const SidebarRow = memo(
     readonly selected: boolean;
     readonly selectedPopulationDifference?: number;
     readonly demographics: DemographicCounts;
-    readonly votingIds: readonly string[];
     readonly deviation: number;
     readonly districtId: number;
     readonly isDistrictLocked?: boolean;
@@ -435,6 +433,7 @@ const SidebarRow = memo(
               placement="top-start"
               content={
                 pvi !== undefined ? (
+                  <VotingSidebarTooltip voting={voting} />
                 ) : (
                   <em>
                     <strong>Empty district.</strong> Add people to this district to view the vote
@@ -516,12 +515,6 @@ const SidebarRows = ({
     | undefined
   >(undefined);
 
-  const votingIds = useMemo(
-    () =>
-      staticMetadata && staticMetadata.voting ? staticMetadata.voting.map(props => props.id) : [],
-    [staticMetadata]
-  );
-
   // Asynchronously recalculate demographics on state changes with web workers
   useEffect(() => {
     // eslint-disable-next-line
@@ -593,7 +586,6 @@ const SidebarRows = ({
             districtId={districtId}
             isReadOnly={isReadOnly}
             popDeviationThreshold={averagePopulation * (project.populationDeviation / 100)}
-            votingIds={votingIds}
           />
         ) : null;
       })}

--- a/src/client/components/VotingMapTooltip.tsx
+++ b/src/client/components/VotingMapTooltip.tsx
@@ -9,7 +9,8 @@ const style: ThemeUIStyleObject = {
     textAlign: "left",
     py: 0,
     pr: 2,
-    textTransform: "capitalize"
+    textTransform: "capitalize",
+    width: "70px"
   },
   number: {
     flex: "auto",
@@ -55,23 +56,33 @@ const Row = ({
   </Styled.tr>
 );
 
-const VotingMapTooltip = ({
-  voting,
-  votingIds
-}: {
-  readonly voting: { readonly [id: string]: number };
-  readonly votingIds: readonly string[];
-}) => {
+const VotingMapTooltip = ({ voting }: { readonly voting: { readonly [id: string]: number } }) => {
   const total = sum(Object.values(voting));
   const percentages = mapValues(voting, (votes: number) => (total ? votes / total : 0) * 100);
-  const rows = votingIds.map(party => (
-    <Row key={party} label={party} percent={percentages[party]} color={getPartyColor(party)} />
-  ));
+  const order = ["republican", "democrat"];
+  // eslint-disable-next-line
+  const rows = Object.entries(percentages)
+    .sort(([a], [b]) => order.indexOf(b) - order.indexOf(a))
+    .map(([party, percent]) => (
+      <Row key={party} label={party} percent={percent} color={getPartyColor(party)} />
+    ));
 
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>
       <Styled.table sx={{ margin: "0", width: "100%" }}>
-        <tbody>{rows}</tbody>
+        <tbody>
+          <Row label={"Dem."} percent={percentages["democrat"]} color={getPartyColor("democrat")} />
+          <Row
+            label={"Rep."}
+            percent={percentages["republican"]}
+            color={getPartyColor("republican")}
+          />
+          <Row
+            label={"Other"}
+            percent={percentages["other party"]}
+            color={getPartyColor("other party")}
+          />
+        </tbody>
       </Styled.table>
     </Box>
   );

--- a/src/client/components/VotingSidebarTooltip.tsx
+++ b/src/client/components/VotingSidebarTooltip.tsx
@@ -76,7 +76,7 @@ const getRows = ({
   readonly voting: DemographicCounts;
   readonly year?: ElectionYear;
 }) => {
-  const votesForYear = year ? extractYear(voting, year) : voting;
+  const votesForYear = extractYear(voting, year);
   const total = sum(Object.values(votesForYear));
   const order = ["republican", "democrat"];
   // eslint-disable-next-line

--- a/src/client/components/VotingSidebarTooltip.tsx
+++ b/src/client/components/VotingSidebarTooltip.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
-import { mapKeys, mapValues, pickBy, sum } from "lodash";
+import { mapValues, sum } from "lodash";
 import { Box, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
 
-import { getPartyColor, capitalizeFirstLetter } from "../functions";
+import { getPartyColor, capitalizeFirstLetter, extractYear } from "../functions";
 import { DemographicCounts } from "../../shared/entities";
 import React from "react";
+import { ElectionYear } from "../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
   header: {
@@ -68,21 +69,14 @@ const Row = ({
   </Styled.tr>
 );
 
-function extractYear(voting: DemographicCounts, suffix: string): DemographicCounts {
-  return mapKeys(
-    pickBy(voting, (val, key) => key.endsWith(suffix)),
-    (val, key) => key.slice(0, -suffix.length)
-  );
-}
-
-const Rows = ({
+const getRows = ({
   voting,
-  suffix
+  year
 }: {
   readonly voting: DemographicCounts;
-  readonly suffix?: string;
+  readonly year?: ElectionYear;
 }) => {
-  const votesForYear = suffix ? extractYear(voting, suffix) : voting;
+  const votesForYear = year ? extractYear(voting, year) : voting;
   const total = sum(Object.values(votesForYear));
   const order = ["republican", "democrat"];
   // eslint-disable-next-line
@@ -100,13 +94,13 @@ const Rows = ({
       color={getPartyColor(party)}
     />
   ));
-  return rows ? <React.Fragment>{rows}</React.Fragment> : null;
+  return rows.length > 0 ? rows : null;
 };
 
 const VotingSidebarTooltip = ({ voting }: { readonly voting: DemographicCounts }) => {
-  const rows16 = <Rows voting={voting} suffix={"16"} />;
-  const rows20 = <Rows voting={voting} suffix={"20"} />;
-  const unspecifiedRows = !rows16 && !rows20 && <Rows voting={voting} />;
+  const rows16 = getRows({ voting, year: "16" });
+  const rows20 = getRows({ voting, year: "20" });
+  const unspecifiedRows = !rows16 && !rows20 && getRows({ voting });
 
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>

--- a/src/client/components/map/KeyboardShortcutsModal.tsx
+++ b/src/client/components/map/KeyboardShortcutsModal.tsx
@@ -8,6 +8,8 @@ import { toggleKeyboardShortcutsModal } from "../../actions/districtDrawing";
 import { State } from "../../reducers";
 import store from "../../store";
 import { KEYBOARD_SHORTCUTS } from "./keyboardShortcuts";
+import { IStaticMetadata } from "../../../shared/entities";
+import { hasMultipleElections } from "../../functions";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -62,15 +64,18 @@ const style: ThemeUIStyleObject = {
 const KeyboardShortcutsModal = ({
   showModal,
   isReadOnly,
-  evaluateMode
+  evaluateMode,
+  staticMetadata
 }: {
   readonly showModal: boolean;
   readonly isReadOnly: boolean;
   readonly evaluateMode: boolean;
+  readonly staticMetadata?: IStaticMetadata;
 }) => {
   const hideModal = () => void store.dispatch(toggleKeyboardShortcutsModal());
   const os = navigator.appVersion.indexOf("Mac") !== -1 ? "Mac" : "pc";
   const meta = os === "Mac" ? "⌘" : "CTRL";
+  const multipleElections = hasMultipleElections(staticMetadata);
 
   return showModal ? (
     <AriaModal
@@ -94,7 +99,8 @@ const KeyboardShortcutsModal = ({
                   {KEYBOARD_SHORTCUTS.filter(
                     shortcut =>
                       (!isReadOnly || shortcut.allowReadOnly) &&
-                      (!evaluateMode || shortcut.allowInEvaluateMode)
+                      (!evaluateMode || shortcut.allowInEvaluateMode) &&
+                      (multipleElections || !shortcut.onlyForMultipleElections)
                   ).map((shortcut, index) => {
                     const key = (
                       <span sx={style.keyCombo}>

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -238,7 +238,7 @@ const MapTooltip = ({
         </Grid>
         <Divider sx={{ my: 1, borderColor: "gray.6" }} />
         <Box sx={{ width: "100%" }}>
-          <DemographicsTooltip demographics={data.demographics} />
+          <DemographicsTooltip demographics={data.demographics} abbreviate={true} />
           {voting && (
             <React.Fragment>
               <Divider sx={{ my: 1, borderColor: "gray.6" }} />

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -1,12 +1,17 @@
 /** @jsx jsx */
 import throttle from "lodash/throttle";
 import MapboxGL from "mapbox-gl";
-import React, { useEffect, useRef, useState, useMemo } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { connect } from "react-redux";
 import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 
 import { DemographicCounts, GeoUnits, IProject, IStaticMetadata } from "../../../shared/entities";
-import { areAnyGeoUnitsSelected, destructureResource, geoLevelLabel } from "../../functions";
+import {
+  areAnyGeoUnitsSelected,
+  destructureResource,
+  geoLevelLabel,
+  extractYear
+} from "../../functions";
 import { getTotalSelectedDemographics } from "../../worker-functions";
 import { featuresToGeoUnits, SET_FEATURE_DELAY } from "./index";
 import { State } from "../../reducers";
@@ -14,6 +19,7 @@ import DemographicsTooltip from "../DemographicsTooltip";
 import VotingMapTooltip from "../VotingMapTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 import { getLabel } from "./labels";
+import { ElectionYear } from "../../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
   tooltip: {
@@ -54,13 +60,15 @@ const MapTooltip = ({
   highlightedGeounits,
   staticMetadata,
   project,
-  map
+  map,
+  electionYear
 }: {
   readonly geoLevelIndex: number;
   readonly highlightedGeounits: GeoUnits;
   readonly staticMetadata?: IStaticMetadata;
   readonly project?: IProject;
   readonly map?: MapboxGL.Map;
+  readonly electionYear: ElectionYear;
 }) => {
   const [point, setPoint] = useState({ x: 0, y: 0 });
   const [feature, setFeature] = useState<MapboxGL.MapboxGeoJSONFeature | undefined>(undefined);
@@ -70,12 +78,6 @@ const MapTooltip = ({
   const invertedGeoLevelIndex = staticMetadata
     ? staticMetadata.geoLevelHierarchy.length - geoLevelIndex - 1
     : undefined;
-
-  const votingIds = useMemo(
-    () =>
-      staticMetadata && staticMetadata.voting ? staticMetadata.voting.map(props => props.id) : [],
-    [staticMetadata]
-  );
 
   useEffect(() => {
     const throttledSetFeature = throttle(
@@ -195,6 +197,10 @@ const MapTooltip = ({
   if (map && data !== undefined) {
     const x = point.x;
     const y = point.y;
+    const votingForYear =
+      electionYear && data.voting ? extractYear(data.voting, electionYear) : data.voting;
+    const voting =
+      votingForYear && Object.keys(votingForYear).length > 0 ? votingForYear : data.voting;
 
     return (
       <Box
@@ -233,10 +239,10 @@ const MapTooltip = ({
         <Divider sx={{ my: 1, borderColor: "gray.6" }} />
         <Box sx={{ width: "100%" }}>
           <DemographicsTooltip demographics={data.demographics} />
-          {data.voting && (
+          {voting && (
             <React.Fragment>
               <Divider sx={{ my: 1, borderColor: "gray.6" }} />
-              <VotingMapTooltip voting={data.voting} votingIds={votingIds} />
+              <VotingMapTooltip voting={voting} />
             </React.Fragment>
           )}
         </Box>
@@ -251,7 +257,8 @@ function mapStateToProps(state: State) {
     geoLevelIndex: state.project.undoHistory.present.state.geoLevelIndex,
     highlightedGeounits: state.project.highlightedGeounits,
     project: destructureResource(state.project.projectData, "project"),
-    staticMetadata: destructureResource(state.project.staticData, "staticMetadata")
+    staticMetadata: destructureResource(state.project.staticData, "staticMetadata"),
+    electionYear: state.project.electionYear
   };
 }
 

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -13,7 +13,9 @@ import {
   undo,
   redo,
   toggleLimitDrawingToWithinCounty,
-  toggleKeyboardShortcutsModal
+  toggleKeyboardShortcutsModal,
+  ElectionYear,
+  setElectionYear
 } from "../../actions/districtDrawing";
 import store from "../../store";
 import { showMapActionToast } from "../../functions";
@@ -28,6 +30,7 @@ interface MapContext {
   readonly numGeolevels: number;
   readonly limitSelectionToCounty: boolean;
   readonly evaluateMode: boolean;
+  readonly electionYear: ElectionYear;
   // eslint-disable-next-line
   readonly setTogglePan: (isSet: boolean) => void;
 }
@@ -39,6 +42,7 @@ interface KeyboardShortcut {
   readonly meta?: true;
   readonly allowReadOnly?: boolean;
   readonly allowInEvaluateMode?: boolean;
+  readonly onlyForMultipleElections?: boolean;
   readonly shift?: true | "optional";
   // eslint-disable-next-line
   readonly action: (context: MapContext) => void;
@@ -194,6 +198,16 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
             ? "No longer limit selection to county"
             : "Limiting selection to county"
         );
+    }
+  },
+  {
+    key: "y",
+    text: "Toggle election year displayed in map tooltip",
+    onlyForMultipleElections: true,
+    action: ({ electionYear }: MapContext) => {
+      const newYear = electionYear === "16" ? "20" : "16";
+      store.dispatch(setElectionYear(newYear)) &&
+        showMapActionToast(`Displaying data for the 20${newYear} election`);
     }
   },
   {

--- a/src/client/components/map/labels.ts
+++ b/src/client/components/map/labels.ts
@@ -3,6 +3,9 @@ import { geoLevelLabelSingular } from "../../functions";
 
 export function getLabel(geoLevelId?: string, feature?: MapboxGeoJSONFeature) {
   if (feature && feature.properties && typeof feature.properties.name === "string") {
+    if (geoLevelId === "county" && !feature.properties.name.endsWith("County")) {
+      return `${feature.properties.name} County`;
+    }
     return feature.properties.name;
   } else if (feature && geoLevelId) {
     return `${geoLevelId} #${feature.id}`;

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -438,7 +438,7 @@ export const demographicsColors = {
   black: "#80B1D3",
   asian: "#FDB462",
   hispanic: "#BEBADA",
-  nativeAmerican: "#FB8071",
-  pacificIslander: "#B3DE69",
+  native: "#FB8071",
+  pacific: "#B3DE69",
   other: "#B3DE69"
 };

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,5 +1,5 @@
 import { toast } from "react-toastify";
-import { cloneDeep } from "lodash";
+import { cloneDeep, mapKeys, pickBy } from "lodash";
 
 import {
   DemographicCounts,
@@ -9,12 +9,14 @@ import {
   GeoUnits,
   GeoUnitIndices,
   GeoUnitHierarchy,
-  NestedArray
+  NestedArray,
+  IStaticMetadata
 } from "../shared/entities";
 import { Resource } from "./resource";
 import { DistrictsGeoJSON } from "./types";
 import { isThisYear, isToday } from "date-fns";
 import format from "date-fns/format";
+import { ElectionYear } from "./actions/districtDrawing";
 
 export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
   return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
@@ -102,6 +104,15 @@ export function calculatePVI(voting: DemographicCounts): number | undefined {
     }
   }
   return undefined;
+}
+export const hasMultipleElections = (staticMetadata?: IStaticMetadata) =>
+  staticMetadata?.voting?.some(file => file.id.endsWith("16")) &&
+  staticMetadata?.voting?.some(file => file.id.endsWith("20"));
+
+export function extractYear(voting: DemographicCounts, year?: ElectionYear): DemographicCounts {
+  return mapKeys(year ? pickBy(voting, (val, key) => key.endsWith(year)) : voting, (val, key) =>
+    key.slice(0, -2)
+  );
 }
 
 /*

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -34,7 +34,9 @@ import {
   selectEvaluationMetric,
   setZoomToDistrictId,
   setMapLabel,
-  toggleKeyboardShortcutsModal
+  toggleKeyboardShortcutsModal,
+  setElectionYear,
+  ElectionYear
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
@@ -122,6 +124,7 @@ export interface DistrictDrawingState {
   readonly findIndex?: number;
   readonly findTool: FindTool;
   readonly limitSelectionToCounty: boolean;
+  readonly electionYear: ElectionYear;
   readonly saving: SavingState;
   readonly undoHistory: UndoHistory;
   readonly mapLabel: string | undefined;
@@ -142,6 +145,7 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   evaluateMetric: undefined,
   findTool: FindTool.Unassigned,
   limitSelectionToCounty: false,
+  electionYear: "16",
   saving: "unsaved",
   mapLabel: "undefined",
   undoHistory: {
@@ -244,6 +248,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
       return {
         ...state,
         limitSelectionToCounty: !state.limitSelectionToCounty
+      };
+    case getType(setElectionYear):
+      return {
+        ...state,
+        electionYear: action.payload
       };
     case getType(setHighlightedGeounits):
       return {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { Redirect, useParams } from "react-router-dom";
 import { Flex, jsx, Spinner, ThemeUIStyleObject } from "theme-ui";
 
-import { areAnyGeoUnitsSelected, destructureResource, getTargetPopulation } from "../functions";
+import { areAnyGeoUnitsSelected, destructureResource } from "../functions";
 import { DistrictsGeoJSON } from "../types";
 import {
   GeoUnitHierarchy,
@@ -89,15 +89,9 @@ const ProjectScreen = ({
 }: StateProps) => {
   const { projectId } = useParams();
   const [map, setMap] = useState<MapboxGL.Map | undefined>(undefined);
-  const [avgDistrictPopulation, setAvgDistrictPopulation] = useState<number | undefined>(undefined);
   const isLoggedIn = getJWT() !== null;
   const isFirstLoadPending = isLoading && (project === undefined || staticMetadata === undefined);
   const presentDrawingState = districtDrawing.undoHistory.present.state;
-  useEffect(() => {
-    if (geojson && !avgDistrictPopulation) {
-      setAvgDistrictPopulation(getTargetPopulation(geojson));
-    }
-  }, [geojson, avgDistrictPopulation]);
 
   // Warn the user when attempting to leave the page with selected geounits
   useBeforeunload(event => {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -217,7 +217,11 @@ const ProjectScreen = ({
                 />
               )}
               <CopyMapModal project={project} />
-              <KeyboardShortcutsModal isReadOnly={isReadOnly} evaluateMode={evaluateMode} />
+              <KeyboardShortcutsModal
+                isReadOnly={isReadOnly}
+                evaluateMode={evaluateMode}
+                staticMetadata={staticMetadata}
+              />
               <Flex id="tour-start" sx={style.tourStart}></Flex>
             </React.Fragment>
           ) : null}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -38,6 +38,8 @@ import { useBeforeunload } from "react-beforeunload";
 import PageNotFoundScreen from "./PageNotFoundScreen";
 import SiteHeader from "../components/SiteHeader";
 import ProjectEvaluateSidebar from "../components/evaluate/ProjectEvaluateSidebar";
+import { ElectionYear } from "../actions/districtDrawing";
+
 interface StateProps {
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
@@ -53,6 +55,7 @@ interface StateProps {
   readonly isReadOnly: boolean;
   readonly mapLabel: string | undefined;
   readonly user: Resource<IUser>;
+  readonly electionYear: ElectionYear;
 }
 
 const style: ThemeUIStyleObject = {
@@ -81,7 +84,8 @@ const ProjectScreen = ({
   mapLabel,
   isLoading,
   isReadOnly,
-  user
+  user,
+  electionYear
 }: StateProps) => {
   const { projectId } = useParams();
   const [map, setMap] = useState<MapboxGL.Map | undefined>(undefined);
@@ -176,6 +180,7 @@ const ProjectScreen = ({
               limitSelectionToCounty={districtDrawing.limitSelectionToCounty}
               advancedEditingEnabled={project?.advancedEditingEnabled}
               isReadOnly={isReadOnly}
+              electionYear={electionYear}
             />
           ) : (
             <Flex></Flex>
@@ -239,6 +244,7 @@ function mapStateToProps(state: State): StateProps {
     evaluateMode: state.project.evaluateMode,
     evaluateMetric: state.project.evaluateMetric,
     mapLabel: state.project.mapLabel,
+    electionYear: state.project.electionYear,
     districtDrawing: state.project,
     regionProperties: state.regionConfig.regionProperties,
     isLoading:

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -75,5 +75,9 @@ export function getAggregatedCounts(
 }
 
 export function getDemographicLabel(id: string) {
-  return id.split(/(?=[A-Z])/).join(" ");
+  return id === "native"
+    ? "Native American"
+    : id === "pacific"
+    ? "Pacific Islander"
+    : id.split(/(?=[A-Z])/).join(" ");
 }


### PR DESCRIPTION
## Overview

This PR adds support for regions with election data for both the 2016 & 2020 presidential elections.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Election year control for map data:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8 (4)](https://user-images.githubusercontent.com/4432106/121903745-99d7a600-ccf6-11eb-9de5-3cf0eb8dfa37.png)
Map tooltip:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8 (5)](https://user-images.githubusercontent.com/4432106/121903915-c25fa000-ccf6-11eb-9cd2-85544960be84.png)
Sidebar tooltip:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8 (3)](https://user-images.githubusercontent.com/4432106/121903746-9a703c80-ccf6-11eb-93c8-585aa17b134c.png)
Sidebar label tooltip:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8 (2)](https://user-images.githubusercontent.com/4432106/121903747-9a703c80-ccf6-11eb-9e3f-253789c2bf3a.png)
New keyboard shortcut:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8 (1)](https://user-images.githubusercontent.com/4432106/121903749-9b08d300-ccf6-11eb-848f-07a6a50f120d.png)
Toast for new keyboard shortcut:
![localhost_3003_projects_659b2a51-b89e-4c61-b505-19677ec659a8](https://user-images.githubusercontent.com/4432106/121903750-9b08d300-ccf6-11eb-9302-f887bc72665e.png)


### Notes

We had originally written this in a more generic fashion, and I'm choosing in this PR to hardcode in support for the following three options instead, to make the code easier to work with:
 - Unspecified election, keys are `democrat` / `republican` / `other party` (what we currently have, I assume the election is 2016)
 - Both 2016 & 2020, keys are  `democrat16` / `republican16` / `other party16` /  `democrat20` / `republican20` / `other party20` (this is what the new IL data has)
 - Just 2016, but explicitly specified by the key name (We don't have any states like this yet, but I added support as I know some upcoming states will only have 2016 data and this should make the preprocessing easier)
 
 
 I played with putting this into the type signature for `IStaticMetadata.voting` (which currently allows any `string` keys), but backed away from it when it looked like a more extensive refactor than I wanted to get into.
 
 
## Testing Instructions

- Use the `load-dev-data` script or update your database to use the `IL` data in `s3://global-districtbuilder-dev-us-east-1/regions/US/IL/2021-06-04T15:05:37.089Z/`
  - Interactions on the map page should show election data, and the sidebar should show PVI
- Also ensure you have a state in your database with pre-existing election data, either `PA` or `VA`, to test for regressions
  - You should not be able to switch election years for a state with data for only 1 election
- For a state/region with no election data at all, there should also be no regressions



Closes #808 
Closes #807
