### PR TITLE
Add tooltip for population deviation in project sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Vagrant Development Environment [#729](https://github.com/PublicMapping/districtbuilder/pull/729)
 - Add user export to organization admin screen [#812](https://github.com/PublicMapping/districtbuilder/pull/812)
 - Add support for calculating PVI / handling '16 & '20 election data [#818](https://github.com/PublicMapping/districtbuilder/pull/818)
+- Add tooltip for population deviation in project sidebar [#819](https://github.com/PublicMapping/districtbuilder/pull/819)
 
 ### Changed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -296,6 +296,7 @@ const SidebarRow = memo(
     isDistrictLocked,
     isDistrictHovered,
     isReadOnly,
+    popDeviation,
     popDeviationThreshold
   }: {
     readonly district: DistrictGeoJSON;
@@ -307,6 +308,7 @@ const SidebarRow = memo(
     readonly isDistrictLocked?: boolean;
     readonly isDistrictHovered: boolean;
     readonly isReadOnly: boolean;
+    readonly popDeviation: number;
     readonly popDeviationThreshold: number;
   }) => {
     const selectedDifference = selectedPopulationDifference || 0;
@@ -389,17 +391,53 @@ const SidebarRow = memo(
           {populationDisplay}
         </Styled.td>
         <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-          <span>{deviationDisplay}</span>
-          <span sx={style.deviationIcon}>
-            {(districtId === 0 && absoluteDeviation === 0) ||
-            (districtId !== 0 && absoluteDeviation <= popDeviationThreshold) ? (
-              <Icon name="circle-check-solid" color="#388a64" />
-            ) : intermediateDeviation < 0 ? (
-              <Icon name="arrow-circle-down-solid" color="gray.4" />
-            ) : (
-              <Icon name="arrow-circle-up-solid" color="#000000" />
-            )}
-          </span>
+          <Tooltip
+            placement="top-start"
+            content={
+              districtId !== 0 ? (
+                Math.abs(intermediateDeviation) <= popDeviationThreshold ? (
+                  <div>This district meets the {popDeviation}% population deviation tolerance</div>
+                ) : intermediateDeviation < 0 ? (
+                  <div>
+                    Add{" "}
+                    {Math.floor(
+                      Math.abs(intermediateDeviation) + popDeviationThreshold
+                    ).toLocaleString()}{" "}
+                    people to this district to meet the {popDeviation}% population deviation
+                    tolerance
+                  </div>
+                ) : (
+                  <div>
+                    Remove{" "}
+                    {Math.floor(intermediateDeviation - popDeviationThreshold).toLocaleString()}{" "}
+                    people from this district to meet the {popDeviation}% population deviation
+                    tolerance
+                  </div>
+                )
+              ) : intermediateDeviation > 0 ? (
+                <div>
+                  This population is not assigned to any district. Make sure all population is
+                  assigned to a district to complete your map.
+                </div>
+              ) : (
+                <div>All population has been assigned to a district.</div>
+              )
+            }
+          >
+            <span>
+              <span>{deviationDisplay}</span>
+              <span sx={style.deviationIcon}>
+                {(districtId === 0 && absoluteDeviation === 0) ||
+                (districtId !== 0 && absoluteDeviation <= popDeviationThreshold) ? (
+                  <Icon name="circle-check-solid" color="#388a64" />
+                ) : intermediateDeviation < 0 ? (
+                  <Icon name="arrow-circle-down-solid" color="gray.4" />
+                ) : (
+                  <Icon name="arrow-circle-up-solid" color="#000000" />
+                )}
+              </span>
+            </span>
+          </Tooltip>
         </Styled.td>
         <Styled.td sx={style.td}>
           <Tooltip
@@ -584,6 +622,7 @@ const SidebarRows = ({
             isDistrictHovered={districtId === hoveredDistrictId}
             districtId={districtId}
             isReadOnly={isReadOnly}
+            popDeviation={project.populationDeviation}
             popDeviationThreshold={averagePopulation * (project.populationDeviation / 100)}
           />
         ) : null;


### PR DESCRIPTION
## Overview

Adds a tooltip to the population deviation display in the project sidebar to help users to more easily identify the necessary changes to the district for compliance with the population deviation threshold.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/121930170-0f9c3b80-cd10-11eb-9aea-0edd32ba267a.png)


## Testing Instructions

- Create districts that are under the population threshold, within the population threshold tolerance, and above it
- Hover over population deviation displays - expect tooltips to be displayed for all districts

Closes #802 
