### PR TITLE
Don't allow keyboard shortcuts to mess with form elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
+- Keyboard shortcuts no longer fire when form elements are focused [#823](https://github.com/PublicMapping/districtbuilder/pull/823)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -364,6 +364,13 @@ const DistrictsMap = ({
 
   const downHandler = useCallback(
     (key: KeyboardEvent) => {
+      // Don't allow keyboard shortcuts to mess with form elements
+      if (
+        ["button", "select", "input"].includes(document.activeElement?.tagName.toLowerCase() || "")
+      ) {
+        return;
+      }
+
       const meta = navigator.appVersion.indexOf("Mac") !== -1 ? "metaKey" : "ctrlKey";
       const shortcut = KEYBOARD_SHORTCUTS.find(
         shortcut =>


### PR DESCRIPTION
## Overview

Prevents keyboard shortcuts from firing when changing the project name, or using the keyboard to choose an option in the labels dropdown.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

I don't think we have any `textarea` elements on the project screen right now, but I figure future-proofing can't hurt - and I couldn't think of any other elements that could interfere w/ our keyboard shortcuts if they have focus.

## Testing Instructions

- On this branch, you should be able to type in the prject name input, or use the keyboard to choose an option in the labels dropdown or election year dropdown
- When not focused on those, keyboard shortcuts should continue to work as normal

Closes #792 
