### PR TITLE
Add evaluate mode view for competitiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tooltip for population deviation in project sidebar [#819](https://github.com/PublicMapping/districtbuilder/pull/819)
 - Add ability to archive regions as read-only to reduce memory requirements [#831](https://github.com/PublicMapping/districtbuilder/pull/831)
 - Add voting info to labels selector [#840](https://github.com/PublicMapping/districtbuilder/pull/840)
+- Add evaluate mode metric view for competitiveness [#824](https://github.com/PublicMapping/districtbuilder/pull/824)
 
 ### Changed
 

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,8 +1,6 @@
 import { createAction } from "typesafe-actions";
-import { DistrictId, EvaluateMetric, GeoUnits } from "../../shared/entities";
-import { SavingState } from "../types";
-
-export type ElectionYear = "16" | "20";
+import { DistrictId, GeoUnits } from "../../shared/entities";
+import { SavingState, ElectionYear, EvaluateMetric } from "../types";
 
 export enum SelectionTool {
   Default = "DEFAULT",

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
+import { ElectionYear } from "../types";
+
 import { geoLevelLabel, capitalizeFirstLetter, canSwitchGeoLevels } from "../functions";
 import MapSelectionOptionsFlyout from "./MapSelectionOptionsFlyout";
 
@@ -11,8 +13,7 @@ import {
   setGeoLevelIndex,
   setSelectionTool,
   SelectionTool,
-  setMapLabel,
-  ElectionYear
+  setMapLabel
 } from "../actions/districtDrawing";
 import store from "../store";
 

--- a/src/client/components/MapSelectionOptionsFlyout.tsx
+++ b/src/client/components/MapSelectionOptionsFlyout.tsx
@@ -3,14 +3,11 @@ import { jsx, Checkbox, Label, Select } from "theme-ui";
 import { Button as MenuButton, Wrapper, Menu } from "react-aria-menubutton";
 import { style } from "./MenuButton.styles";
 import store from "../store";
-import {
-  toggleLimitDrawingToWithinCounty,
-  ElectionYear,
-  setElectionYear
-} from "../actions/districtDrawing";
+import { toggleLimitDrawingToWithinCounty, setElectionYear } from "../actions/districtDrawing";
 import Tooltip from "./Tooltip";
 import Icon from "./Icon";
 import { IStaticMetadata } from "../../shared/entities";
+import { ElectionYear } from "../types";
 
 const MapSelectionOptionsFlyout = ({
   limitSelectionToCounty,

--- a/src/client/components/PVIDisplay.tsx
+++ b/src/client/components/PVIDisplay.tsx
@@ -1,0 +1,61 @@
+/** @jsx jsx */
+import { Box, jsx } from "theme-ui";
+import { DistrictProperties } from "../../shared/entities";
+import { ElectionYear } from "../types";
+import { getPartyColor, calculatePVI } from "../functions";
+import Tooltip from "./Tooltip";
+import VotingSidebarTooltip from "./VotingSidebarTooltip";
+
+const BLANK_VALUE = "–";
+
+export function getPvi(properties: DistrictProperties, year?: ElectionYear) {
+  const voting = Object.keys(properties.voting || {}).length > 0 ? properties.voting : undefined;
+
+  return year !== "combined"
+    ? voting && calculatePVI(voting, year)
+    : voting && calculatePVI(voting);
+}
+
+const PVIDisplay = ({
+  properties,
+  year
+}: {
+  readonly properties: DistrictProperties;
+  readonly year?: ElectionYear;
+}) => {
+  // The voting object can be present but have no data, we treat this case as if it isn't there
+
+  const voting = Object.keys(properties.voting || {}).length > 0 ? properties.voting : undefined;
+  const pvi = getPvi(properties, year);
+
+  const color = getPartyColor(pvi && pvi > 0 ? "democrat" : "republican");
+  const partyLabel = pvi && pvi > 0 ? "D" : "R";
+  const votingDisplay =
+    pvi !== undefined ? (
+      <Box sx={{ color }}>{`${partyLabel}+${Math.abs(pvi).toLocaleString(undefined, {
+        maximumFractionDigits: 0
+      })}`}</Box>
+    ) : (
+      <span sx={{ color: "gray.2" }}>{BLANK_VALUE}</span>
+    );
+  return voting ? (
+    <Tooltip
+      placement="top-start"
+      content={
+        pvi !== undefined ? (
+          <VotingSidebarTooltip voting={voting} />
+        ) : (
+          <em>
+            <strong>Empty district.</strong> Add people to this district to view the vote totals
+          </em>
+        )
+      }
+    >
+      <span>{votingDisplay}</span>
+    </Tooltip>
+  ) : (
+    <span>No voting data available</span>
+  );
+};
+
+export default PVIDisplay;

--- a/src/client/components/VotingSidebarTooltip.tsx
+++ b/src/client/components/VotingSidebarTooltip.tsx
@@ -4,8 +4,9 @@ import { Box, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
 
 import { getPartyColor, capitalizeFirstLetter, extractYear } from "../functions";
 import { DemographicCounts } from "../../shared/entities";
+import { ElectionYear } from "../types";
+
 import React from "react";
-import { ElectionYear } from "../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
   header: {

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -1,13 +1,8 @@
 /** @jsx jsx */
-import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading, Text } from "theme-ui";
-import {
-  EvaluateMetric,
-  IProject,
-  IStaticMetadata,
-  RegionLookupProperties
-} from "../../../shared/entities";
+import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading, Text, Select } from "theme-ui";
+import { IProject, IStaticMetadata, RegionLookupProperties } from "../../../shared/entities";
 import Icon from "../Icon";
-import { DistrictsGeoJSON } from "../../types";
+import { DistrictsGeoJSON, EvaluateMetric, ElectionYear } from "../../types";
 import store from "../../store";
 import { selectEvaluationMetric } from "../../actions/districtDrawing";
 import ContiguityMetricDetail from "./detail/Contiguity";
@@ -15,6 +10,7 @@ import CompactnessMetricDetail from "./detail/Compactness";
 import CountySplitMetricDetail from "./detail/CountySplit";
 import EqualPopulationMetricDetail from "./detail/EqualPopulation";
 import { Resource } from "../../resource";
+import CompetitivenessMetricDetail from "./detail/Competitiveness";
 
 const style: ThemeUIStyleObject = {
   header: {
@@ -38,6 +34,8 @@ const ProjectEvaluateMetricDetail = ({
   project,
   regionProperties,
   geoLevel,
+  electionYear,
+  setElectionYear,
   staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
@@ -45,6 +43,8 @@ const ProjectEvaluateMetricDetail = ({
   readonly project?: IProject;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly geoLevel: string;
+  readonly electionYear: ElectionYear | undefined;
+  readonly setElectionYear: (year: ElectionYear) => void;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
   return (
@@ -87,6 +87,23 @@ const ProjectEvaluateMetricDetail = ({
           <Heading as="h1" sx={{ variant: "text.h4", m: 0, textTransform: "capitalize" }}>
             {metric.name}
           </Heading>
+          {"hasMultipleElections" in metric && metric.hasMultipleElections && (
+            <Box>
+              <Select
+                id="election-dropdown"
+                value={electionYear || undefined}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                  const year = e.currentTarget.value;
+                  (year === "16" || year === "20" || year === "combined") && setElectionYear(year);
+                }}
+                sx={{ width: "250px", ml: "20px" }}
+              >
+                <option value={"combined"}>Combined 2016 / 2020 PVI</option>
+                <option value={"16"}>2016 PVI</option>
+                <option value={"20"}>2020 PVI</option>
+              </Select>
+            </Box>
+          )}
         </Flex>
         <Text sx={style.metricText}>{metric.longText || "Lorem ipsum lorem ipsum"}</Text>
       </Flex>
@@ -105,6 +122,8 @@ const ProjectEvaluateMetricDetail = ({
           <ContiguityMetricDetail metric={metric} geojson={geojson} />
         ) : metric && "type" in metric && metric.key === "equalPopulation" ? (
           <EqualPopulationMetricDetail metric={metric} geojson={geojson} />
+        ) : metric && "type" in metric && metric.key === "competitiveness" ? (
+          <CompetitivenessMetricDetail metric={metric} geojson={geojson} />
         ) : (
           <Box>
             <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -1,9 +1,10 @@
 /** @jsx jsx */
 import { Box, IconButton, Flex, jsx, ThemeUIStyleObject, Heading, Text } from "theme-ui";
 
-import { EvaluateMetric, EvaluateMetricWithValue } from "../../../shared/entities";
 import Icon from "../Icon";
 import store from "../../store";
+import { EvaluateMetric, EvaluateMetricWithValue } from "../../types";
+import { formatPvi } from "../../functions";
 import { selectEvaluationMetric, toggleEvaluate } from "../../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
@@ -64,6 +65,8 @@ const ProjectEvaluateView = ({
     switch (metric.type) {
       case "fraction":
         return `${metric.value} / ${metric.total || 18}`;
+      case "pvi":
+        return formatPvi(metric.party, metric.value);
       case "percent":
         return metric.value !== undefined ? `${Math.floor(metric.value * 100)}%` : "";
       case "count":

--- a/src/client/components/evaluate/detail/Compactness.tsx
+++ b/src/client/components/evaluate/detail/Compactness.tsx
@@ -1,9 +1,9 @@
 /** @jsx jsx */
 import { Box, Flex, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
-import { EvaluateMetricWithValue, DistrictProperties } from "../../../../shared/entities";
 import { getCompactnessStops } from "../../map/index";
-import { DistrictsGeoJSON } from "../../../types";
+import { EvaluateMetricWithValue, DistrictsGeoJSON } from "../../../types";
 import { getCompactnessDisplay } from "../../ProjectSidebar";
+import { computeRowFill } from "../../../functions";
 
 const style: ThemeUIStyleObject = {
   table: {
@@ -63,22 +63,7 @@ const CompactnessMetricDetail = ({
   readonly metric: EvaluateMetricWithValue;
   readonly geojson?: DistrictsGeoJSON;
 }) => {
-  function computeRowFill(row: DistrictProperties) {
-    const val = row.compactness;
-    const choroplethStops = getCompactnessStops();
-    // eslint-disable-next-line
-    let i = 0;
-    // eslint-disable-next-line
-    while (i < choroplethStops.length) {
-      const r = choroplethStops[i];
-      if (val < r[0]) {
-        return r[1];
-      } else {
-        i++;
-      }
-    }
-    return "#fff";
-  }
+  const choroplethStops = getCompactnessStops();
   return (
     <Box>
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
@@ -107,7 +92,7 @@ const CompactnessMetricDetail = ({
                             width: "15px",
                             height: "15px",
                             borderRadius: "small",
-                            bg: computeRowFill(feature.properties)
+                            bg: computeRowFill(choroplethStops, feature.properties.compactness)
                           }}
                         ></Styled.div>
                         <Box>{getCompactnessDisplay(feature.properties)}</Box>

--- a/src/client/components/evaluate/detail/CountySplit.tsx
+++ b/src/client/components/evaluate/detail/CountySplit.tsx
@@ -1,14 +1,10 @@
 /** @jsx jsx */
 import { Box, Flex, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
-import {
-  EvaluateMetricWithValue,
-  IProject,
-  IStaticMetadata,
-  RegionLookupProperties
-} from "../../../../shared/entities";
+import { IProject, IStaticMetadata, RegionLookupProperties } from "../../../../shared/entities";
 import { useState, useEffect } from "react";
 import { getLabelLookup } from "../../map/labels";
 import { Resource } from "../../../resource";
+import { EvaluateMetricWithValue } from "../../../types";
 import { geoLevelLabel, geoLevelLabelSingular } from "../../../functions";
 
 const style: ThemeUIStyleObject = {

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -6,6 +6,8 @@ import { connect } from "react-redux";
 import { Box, Divider, Heading, jsx, Grid, ThemeUIStyleObject } from "theme-ui";
 
 import { DemographicCounts, GeoUnits, IProject, IStaticMetadata } from "../../../shared/entities";
+import { ElectionYear } from "../../types";
+
 import {
   areAnyGeoUnitsSelected,
   destructureResource,
@@ -19,7 +21,6 @@ import DemographicsTooltip from "../DemographicsTooltip";
 import VotingMapTooltip from "../VotingMapTooltip";
 import { levelToLineLayerId, levelToSelectionLayerId } from ".";
 import { getLabel } from "./labels";
-import { ElectionYear } from "../../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
   tooltip: {

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -18,6 +18,7 @@ import {
 import { getAllIndices } from "../../../shared/functions";
 import { isBaseGeoLevelAlwaysVisible, getTargetPopulation } from "../../functions";
 import { mapValues } from "lodash";
+import { ChoroplethSteps } from "../../types";
 
 // Vector tiles with geolevel data for this geography
 export const GEOLEVELS_SOURCE_ID = "db";
@@ -35,6 +36,8 @@ export const DISTRICTS_LOCK_LAYER_ID = "districts-locked";
 export const DISTRICTS_CONTIGUITY_CHLOROPLETH_LAYER_ID = "districts-contiguity";
 // Id for districts layer outline used in evaluate mode
 export const DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID = "districts-compactness";
+// Id for districts layer outline used in evaluate mode
+export const DISTRICTS_COMPETITIVENESS_CHOROPLETH_LAYER_ID = "districts-competitiveness";
 // Id for districts layer outline used in evaluate mode
 export const DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID = "districts-equal-population";
 // Id for district labels layer used in evaluate mode
@@ -68,7 +71,7 @@ export const filteredLabelLayers = [
   "poi-label"
 ];
 
-export function getCompactnessStops() {
+export function getCompactnessStops(): ChoroplethSteps {
   return [
     [0.3, "#edf8fb"],
     [0.4, "#b2e2e2"],
@@ -78,7 +81,28 @@ export function getCompactnessStops() {
   ];
 }
 
-export function getEqualPopulationStops(popThresholdNum: number, avgPopulation: number) {
+export function getCompactnessLabels() {
+  return ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
+}
+
+export function getPviSteps(): ChoroplethSteps {
+  return [
+    [-100, "#a52a0d"],
+    [-20, "#ed512c"],
+    [-5, "#CDCDCD"],
+    [5, "#6491b5"],
+    [20, "#385d7a"]
+  ];
+}
+
+export function getPviLabels() {
+  return ["> +20R", "+5R to +20R", "Even", "+5D to +20D", "> +20D"];
+}
+
+export function getEqualPopulationStops(
+  popThresholdNum: number,
+  avgPopulation: number
+): ChoroplethSteps {
   const popThreshold = popThresholdNum / 100;
   const isAvgFractional = avgPopulation % 1 !== 0;
   return [
@@ -90,10 +114,6 @@ export function getEqualPopulationStops(popThresholdNum: number, avgPopulation: 
     [(popThreshold + 0.01) * avgPopulation, "#F5D092"],
     [(popThreshold + 0.02) * avgPopulation, "#F7E1C3"]
   ];
-}
-
-export function getCompactnessLabels() {
-  return ["0-30%", "30-40%", "40-50%", "50-60%", ">60%"];
 }
 
 export function getEqualPopulationLabels(popThreshold: number) {
@@ -199,6 +219,26 @@ export function generateMapLayers(
         "fill-color": {
           property: "compactness",
           stops: getCompactnessStops()
+        },
+        "fill-outline-color": "gray",
+        "fill-opacity": 0.9
+      }
+    },
+    DISTRICTS_PLACEHOLDER_LAYER_ID
+  );
+
+  map.addLayer(
+    {
+      id: DISTRICTS_COMPETITIVENESS_CHOROPLETH_LAYER_ID,
+      type: "fill",
+      source: DISTRICTS_SOURCE_ID,
+      layout: { visibility: "none" },
+      filter: ["match", ["get", "color"], ["transparent"], false, true],
+      paint: {
+        "fill-color": {
+          property: "pvi",
+          type: "interval",
+          stops: getPviSteps()
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { DistrictId } from "../../../shared/entities";
+import { ElectionYear } from "../../types";
 
 import {
   setGeoLevelIndex,
@@ -14,7 +15,6 @@ import {
   redo,
   toggleLimitDrawingToWithinCounty,
   toggleKeyboardShortcutsModal,
-  ElectionYear,
   setElectionYear
 } from "../../actions/districtDrawing";
 import store from "../../store";

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -35,19 +35,14 @@ import {
   setZoomToDistrictId,
   setMapLabel,
   toggleKeyboardShortcutsModal,
-  setElectionYear,
-  ElectionYear
+  setElectionYear
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
-import {
-  DistrictId,
-  EvaluateMetric,
-  GeoUnits,
-  GeoUnitsForLevel,
-  LockedDistricts
-} from "../../shared/entities";
+import { DistrictId, GeoUnits, GeoUnitsForLevel, LockedDistricts } from "../../shared/entities";
+import { ElectionYear, EvaluateMetric } from "../types";
+
 import { ProjectState, initialProjectState } from "./project";
 import {
   pushEffect,

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -13,9 +13,10 @@ import {
   IStaticMetadata,
   RegionLookupProperties,
   IUser,
-  UintArrays,
-  EvaluateMetric
+  UintArrays
 } from "../../shared/entities";
+import { ElectionYear, EvaluateMetric } from "../types";
+
 import { projectDataFetch } from "../actions/projectData";
 import { DistrictDrawingState } from "../reducers/districtDrawing";
 import { resetProjectState } from "../actions/root";
@@ -38,7 +39,6 @@ import { useBeforeunload } from "react-beforeunload";
 import PageNotFoundScreen from "./PageNotFoundScreen";
 import SiteHeader from "../components/SiteHeader";
 import ProjectEvaluateSidebar from "../components/evaluate/ProjectEvaluateSidebar";
-import { ElectionYear } from "../actions/districtDrawing";
 
 interface StateProps {
   readonly project?: IProject;

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -54,3 +54,44 @@ export type SavingState = "unsaved" | "saving" | "saved" | "failed";
 export interface AuthLocationState {
   readonly from: H.Location;
 }
+
+export type MetricKey =
+  | "equalPopulation"
+  | "contiguity"
+  | "competitiveness"
+  | "compactness"
+  | "minorityMajority"
+  | "countySplits";
+
+export interface BaseEvaluateMetric {
+  readonly key: MetricKey;
+  readonly name: string;
+  readonly description: string;
+  readonly longText?: string;
+  readonly shortText?: string;
+}
+
+export type ElectionYear = "16" | "20" | "combined";
+
+export interface Party {
+  readonly color: string;
+  readonly label: "D" | "R";
+}
+
+export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
+  readonly type: "fraction" | "percent" | "count" | "pvi";
+  readonly value?: number;
+  readonly total?: number;
+  readonly party?: Party;
+  readonly hasMultipleElections?: boolean;
+  readonly electionYear?: ElectionYear;
+  readonly avgPopulation?: number;
+  readonly popThreshold?: number;
+  readonly status?: boolean;
+  // eslint-disable-next-line
+  readonly [key: string]: any;
+}
+
+export type EvaluateMetric = BaseEvaluateMetric | EvaluateMetricWithValue;
+
+export type ChoroplethSteps = readonly (readonly [number, string])[];

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -15,35 +15,6 @@ export interface IUser {
   readonly organizations: readonly OrganizationNest[];
 }
 
-export type MetricKey =
-  | "equalPopulation"
-  | "contiguity"
-  | "competitiveness"
-  | "compactness"
-  | "minorityMajority"
-  | "countySplits";
-
-export interface BaseEvaluateMetric {
-  readonly key: MetricKey;
-  readonly name: string;
-  readonly description: string;
-  readonly longText?: string;
-  readonly shortText?: string;
-}
-
-export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
-  readonly type: "fraction" | "percent" | "count";
-  readonly value?: number;
-  readonly total?: number;
-  readonly avgPopulation?: number;
-  readonly popThreshold?: number;
-  readonly status?: boolean;
-  // eslint-disable-next-line
-  readonly [key: string]: any;
-}
-
-export type EvaluateMetric = BaseEvaluateMetric | EvaluateMetricWithValue;
-
 export type UpdateUserData = Pick<IUser, "name" | "hasSeenTour">;
 
 export type OrganizationSlug = string;
@@ -105,6 +76,7 @@ export type DistrictProperties = {
   color?: string;
   outlineColor?: string;
   percentDeviation?: number;
+  pvi?: number;
   populationDeviation?: number;
   outlineWidthScaleFactor?: number;
   /* eslint-enable */


### PR DESCRIPTION
## Overview

- Adds a newly computed metric for Competitiveness, computed as the average PVI for all districts that have population
- Adds a new page for Competitiveness metric including a map and sidebar
- Add a dropdown to switch between 2016 / 2020 / combined PVI

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/122587151-7df03f00-d02b-11eb-8bde-f1eda51cda77.png)


### Notes

Per my Slack conversation earlier with @maurizi , there is still some ambiguity about whether we want to allow a switch for PVI / election margin to display both metrics here. These will likely be very similar, 

## Testing Instructions

- Create a map in a region that has voting data
- Create districts
- Go to evaluate mode - Competitiveness and review. Expect the PVI computations to match those included in the Project Sidebar

Closes #810 
