### PR TITLE
WIP: Make paint brush size configurable via slider

### DIFF
--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -10,6 +10,8 @@ export enum SelectionTool {
   PaintBrush = "PAINTBRUSH"
 }
 
+export type PaintBrushSize = 1 | 2 | 3 | 4 | 5;
+
 export enum FindTool {
   Unassigned = "UNASSIGNED",
   NonContiguous = "NON_CONTIGUOUS"
@@ -39,6 +41,7 @@ export const setHighlightedGeounits = createAction("Add highlighted geounit ids"
 export const clearHighlightedGeounits = createAction("Clear highlighted geounit ids")();
 
 export const setSelectionTool = createAction("Set selection tool")<SelectionTool>();
+export const setPaintBrushSize = createAction("Set paint brush size")<PaintBrushSize>();
 
 export const setGeoLevelIndex = createAction("Set geoLevel index")<{
   readonly index: number;

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
-import React from "react";
-import { Flex, Box, Label, Button, jsx, Select, ThemeUIStyleObject } from "theme-ui";
+import React, { useState } from "react";
+import { Flex, Box, Label, Button, jsx, Select, Slider, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
 import { geoLevelLabel, capitalizeFirstLetter, canSwitchGeoLevels } from "../functions";
 import MapSelectionOptionsFlyout from "./MapSelectionOptionsFlyout";
@@ -12,7 +12,9 @@ import {
   setSelectionTool,
   SelectionTool,
   setMapLabel,
-  ElectionYear
+  ElectionYear,
+  PaintBrushSize,
+  setPaintBrushSize
 } from "../actions/districtDrawing";
 import store from "../store";
 
@@ -63,6 +65,16 @@ const style: ThemeUIStyleObject = {
       borderBottomColor: "blue.5",
       color: "blue.8"
     }
+  },
+  sliderContainer: {
+    position: "absolute",
+    display: "flex",
+    backgroundColor: "#fff",
+    borderRadius: "2px",
+    border: "1px solid",
+    padding: "5px",
+    top: "100px",
+    zIndex: 99999
   }
 };
 
@@ -126,6 +138,7 @@ const MapHeader = ({
   label,
   metadata,
   selectionTool,
+  paintBrushSize,
   geoLevelIndex,
   selectedGeounits,
   isReadOnly,
@@ -135,6 +148,7 @@ const MapHeader = ({
   readonly label?: string;
   readonly metadata?: IStaticMetadata;
   readonly selectionTool: SelectionTool;
+  readonly paintBrushSize: PaintBrushSize;
   readonly geoLevelIndex: number;
   readonly selectedGeounits: GeoUnits;
   readonly advancedEditingEnabled?: boolean;
@@ -142,6 +156,7 @@ const MapHeader = ({
   readonly limitSelectionToCounty: boolean;
   readonly electionYear: ElectionYear;
 }) => {
+  const [isPaintBrushSizeSliderVisible, setPaintBrushSizeSliderVisibility] = useState(false);
   const topGeoLevelName = metadata
     ? metadata.geoLevelHierarchy[metadata.geoLevelHierarchy.length - 1].id
     : undefined;
@@ -196,12 +211,32 @@ const MapHeader = ({
                 <Button
                   sx={{ ...style.selectionButton }}
                   className={buttonClassName(selectionTool === SelectionTool.PaintBrush)}
-                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.PaintBrush))}
+                  onClick={() => {
+                    setPaintBrushSizeSliderVisibility(true);
+                    store.dispatch(setSelectionTool(SelectionTool.PaintBrush));
+                  }}
                 >
                   <Icon name="paint-brush" />
                 </Button>
               </Tooltip>
             </Flex>
+            {isPaintBrushSizeSliderVisible ? (
+              <Box sx={style.sliderContainer}>
+                <Box>Brush size</Box>
+                <Slider
+                  min={1}
+                  max={5}
+                  step={1}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    store.dispatch(
+                      setPaintBrushSize(parseInt(e.target.value, 10) as PaintBrushSize)
+                    );
+                  }}
+                  defaultValue={paintBrushSize}
+                />
+                <Box>{paintBrushSize}</Box>
+              </Box>
+            ) : null}
 
             <Box sx={{ position: "relative", mr: 3, pt: "6px" }}>
               <MapSelectionOptionsFlyout

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -17,6 +17,7 @@ import {
   setPaintBrushSize
 } from "../actions/districtDrawing";
 import store from "../store";
+import icons from "../icons";
 
 const style: ThemeUIStyleObject = {
   buttonGroup: {
@@ -183,42 +184,47 @@ const MapHeader = ({
           />
         ))
     : [];
+  const selectionToolIcons: ReadonlyArray<{
+    readonly tooltipContent: string;
+    readonly tool: SelectionTool;
+    readonly iconName: keyof typeof icons;
+  }> = [
+    {
+      tooltipContent: "Point-and-click selection",
+      tool: SelectionTool.Default,
+      iconName: "hand-pointer"
+    },
+    {
+      tooltipContent: "Rectangle selection",
+      tool: SelectionTool.Rectangle,
+      iconName: "draw-square"
+    },
+    {
+      tooltipContent: "Paint brush selection",
+      tool: SelectionTool.PaintBrush,
+      iconName: "paint-brush"
+    }
+  ];
   return (
     <Flex sx={style.header}>
       <Flex>
         {!isReadOnly && (
           <React.Fragment>
             <Flex sx={{ ...style.buttonGroup, mr: 2 }}>
-              <Tooltip content="Point-and-click selection">
-                <Button
-                  sx={{ ...style.selectionButton }}
-                  className={buttonClassName(selectionTool === SelectionTool.Default)}
-                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.Default))}
-                >
-                  <Icon name="hand-pointer" />
-                </Button>
-              </Tooltip>
-              <Tooltip content="Rectangle selection">
-                <Button
-                  sx={{ ...style.selectionButton }}
-                  className={buttonClassName(selectionTool === SelectionTool.Rectangle)}
-                  onClick={() => store.dispatch(setSelectionTool(SelectionTool.Rectangle))}
-                >
-                  <Icon name="draw-square" />
-                </Button>
-              </Tooltip>
-              <Tooltip content="Paint brush selection">
-                <Button
-                  sx={{ ...style.selectionButton }}
-                  className={buttonClassName(selectionTool === SelectionTool.PaintBrush)}
-                  onClick={() => {
-                    setPaintBrushSizeSliderVisibility(true);
-                    store.dispatch(setSelectionTool(SelectionTool.PaintBrush));
-                  }}
-                >
-                  <Icon name="paint-brush" />
-                </Button>
-              </Tooltip>
+              {selectionToolIcons.map(({ tooltipContent, tool, iconName }) => (
+                <Tooltip key={iconName} content={tooltipContent}>
+                  <Button
+                    sx={{ ...style.selectionButton }}
+                    className={buttonClassName(selectionTool === tool)}
+                    onClick={() => {
+                      setPaintBrushSizeSliderVisibility(tool === SelectionTool.PaintBrush);
+                      store.dispatch(setSelectionTool(tool));
+                    }}
+                  >
+                    <Icon name={iconName} />
+                  </Button>
+                </Tooltip>
+              ))}
             </Flex>
             {isPaintBrushSizeSliderVisible ? (
               <Box sx={style.sliderContainer}>

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -73,9 +73,12 @@ const style: ThemeUIStyleObject = {
     backgroundColor: "#fff",
     borderRadius: "2px",
     border: "1px solid",
+    borderColor: "gray.2",
     padding: "5px",
     top: "100px",
-    zIndex: 99999
+    zIndex: 99999,
+    justifyContent: "space-evenly",
+    width: "300px"
   }
 };
 
@@ -228,7 +231,7 @@ const MapHeader = ({
             </Flex>
             {isPaintBrushSizeSliderVisible ? (
               <Box sx={style.sliderContainer}>
-                <Box>Brush size</Box>
+                <Box sx={{ flexShrink: 0 }}>Brush size</Box>
                 <Slider
                   min={1}
                   max={5}
@@ -238,6 +241,7 @@ const MapHeader = ({
                       setPaintBrushSize(parseInt(e.target.value, 10) as PaintBrushSize)
                     );
                   }}
+                  sx={{ width: "150px" }}
                   defaultValue={paintBrushSize}
                 />
                 <Box>{paintBrushSize}</Box>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -15,7 +15,8 @@ import {
   replaceSelectedGeounits,
   FindTool,
   setZoomToDistrictId,
-  ElectionYear
+  ElectionYear,
+  PaintBrushSize
 } from "../../actions/districtDrawing";
 import { getDistrictColor } from "../../constants/colors";
 import {
@@ -179,6 +180,7 @@ interface Props {
   readonly hoveredDistrictId: number | null;
   readonly zoomToDistrictId: number | null;
   readonly selectionTool: SelectionTool;
+  readonly paintBrushSize: PaintBrushSize;
   readonly geoLevelIndex: number;
   readonly lockedDistricts: LockedDistricts;
   readonly evaluateMetric?: EvaluateMetric;
@@ -256,6 +258,7 @@ const DistrictsMap = ({
   hoveredDistrictId,
   zoomToDistrictId,
   selectionTool,
+  paintBrushSize,
   geoLevelIndex,
   lockedDistricts,
   isReadOnly,
@@ -884,11 +887,33 @@ const DistrictsMap = ({
     selectedGeounits
   ]);
 
+  const brushCircleRadius = 30 * paintBrushSize;
+
   return (
     <Box ref={mapRef} sx={{ width: "100%", height: "100%", position: "relative" }}>
       <MapTooltip map={map || undefined} />
       <MapMessage map={map || undefined} maxZoom={maxZoom} />
       <FindMenu map={map} />
+      <div
+        id="brush-circle"
+        style={{
+          visibility: "hidden",
+          opacity: 0.5,
+          position: "absolute",
+          zIndex: 999,
+          marginTop: (brushCircleRadius / 2) * -1,
+          marginLeft: (brushCircleRadius / 2) * -1
+        }}
+      >
+        <svg height={brushCircleRadius} width={brushCircleRadius}>
+          <circle
+            cx={brushCircleRadius / 2}
+            cy={brushCircleRadius / 2}
+            r={brushCircleRadius / 2}
+            strokeWidth="0"
+          ></circle>
+        </svg>
+      </div>
       {evaluateMode && evaluateMetric && evaluateMetric.key === "countySplits" && (
         <Box sx={style.legendBox}>
           <Flex sx={{ alignItems: "center" }}>

--- a/src/client/components/map/PaintBrushSelectionTool.ts
+++ b/src/client/components/map/PaintBrushSelectionTool.ts
@@ -55,6 +55,8 @@ const PaintBrushSelectionTool: ISelectionTool = {
     // Save mouseDown for removal upon disabling
     this.mouseDown = mouseDown; // eslint-disable-line
 
+    const brushCircle = document.getElementById("brush-circle");
+
     // eslint-disable-next-line
     let batchGeounits = { add: {}, remove: {} };
     const throttledStoreToRedux = throttle(() => {
@@ -86,6 +88,13 @@ const PaintBrushSelectionTool: ISelectionTool = {
     function updateSelection(e: MouseEvent) {
       // Capture the ongoing xy coordinates
       const current = mousePos(e);
+      /* eslint-disable */
+      if (brushCircle) {
+        brushCircle.style.visibility = "visible";
+        brushCircle.style.top = current.y + "px";
+        brushCircle.style.left = current.x + "px";
+      }
+      /* eslint-enable */
       const features = getFeaturesAtPoint(current);
       const geoUnits = featuresToUnlockedGeoUnits(
         features,
@@ -148,6 +157,11 @@ const PaintBrushSelectionTool: ISelectionTool = {
         currentCounty = undefined;
       }
       setActive(false);
+      /* eslint-disable */
+      if (brushCircle) {
+        brushCircle.style.visibility = "hidden";
+      }
+      /* eslint-enable */
     }
 
     function getFeaturesAtPoint(

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -36,7 +36,9 @@ import {
   setMapLabel,
   toggleKeyboardShortcutsModal,
   setElectionYear,
-  ElectionYear
+  ElectionYear,
+  PaintBrushSize,
+  setPaintBrushSize
 } from "../actions/districtDrawing";
 import { updateDistrictsDefinition, updateDistrictLocks } from "../actions/projectData";
 import { SelectionTool } from "../actions/districtDrawing";
@@ -114,6 +116,7 @@ export interface DistrictDrawingState {
   readonly zoomToDistrictId: number | null;
   readonly highlightedGeounits: GeoUnits;
   readonly selectionTool: SelectionTool;
+  readonly paintBrushSize: PaintBrushSize;
   readonly showAdvancedEditingModal: boolean;
   readonly showCopyMapModal: boolean;
   readonly showKeyboardShortcutsModal: boolean;
@@ -136,6 +139,7 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   zoomToDistrictId: null,
   highlightedGeounits: {},
   selectionTool: SelectionTool.Default,
+  paintBrushSize: 1,
   showAdvancedEditingModal: false,
   showCopyMapModal: false,
   showImportFlagsModal: false,
@@ -268,6 +272,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
       return {
         ...state,
         selectionTool: action.payload
+      };
+    case getType(setPaintBrushSize):
+      return {
+        ...state,
+        paintBrushSize: action.payload
       };
     case getType(setGeoLevelIndex): {
       if ("resource" in state.staticData && "resource" in state.projectData) {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -201,6 +201,7 @@ const ProjectScreen = ({
                 hoveredDistrictId={districtDrawing.hoveredDistrictId}
                 zoomToDistrictId={districtDrawing.zoomToDistrictId}
                 selectionTool={districtDrawing.selectionTool}
+                paintBrushSize={districtDrawing.paintBrushSize}
                 geoLevelIndex={presentDrawingState.geoLevelIndex}
                 lockedDistricts={presentDrawingState.lockedDistricts}
                 evaluateMode={evaluateMode}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -169,6 +169,7 @@ const ProjectScreen = ({
               label={mapLabel}
               metadata={staticMetadata}
               selectionTool={districtDrawing.selectionTool}
+              paintBrushSize={districtDrawing.paintBrushSize}
               geoLevelIndex={presentDrawingState.geoLevelIndex}
               selectedGeounits={presentDrawingState.selectedGeounits}
               limitSelectionToCounty={districtDrawing.limitSelectionToCounty}


### PR DESCRIPTION
## Overview
Make paint brush size configurable via slider

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![db_paint_brush_wip_demo](https://user-images.githubusercontent.com/2926237/122458606-01ebed80-cf7e-11eb-895c-9ef9d1d3484b.gif)

### Notes
This is still very much a WIP. Here's what's been implemented so far:
* There is a slider that's styled
* The slider will be toggled appropriately based on selection tool
* The slider remembers the size you picked last
* A slider circle is shown on the page that corresponds to the size you picked (NOTE: This is not specified as required in the issue, but I think we need to somehow visually indicate the paintbrush area as you're using it)

Not yet implemented:
* Taking the paint brush size into account when selecting features (note that the Mapbox API's `queryRenderedFeatures` takes either a point or a bounding box and not a circle; we should probably get input from @jfrankl as to whether or paintbrush tool should be a circle in the first place since, noting that making a box would make implementation easier but may also look weird/not be what we want).

## Testing Instructions
* Select the paintbrush tool and the slider should show
* Default should be 1
* Select a different size
* Choose a different selection tool and the slider should be hidden
* Choose the paintbrush tool again and it should have remembered your size from before
* Click and hold and drag to select features on the map and you should see a partially opaque circle which corresponds to the size you choose
* TODO: All features under the paintbrush tool are selected as you drag, not just what's directly intersecting with your cursor

Closes #742 
