### PR TITLE
Add support for archived regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add user export to organization admin screen [#812](https://github.com/PublicMapping/districtbuilder/pull/812)
 - Add support for calculating PVI / handling '16 & '20 election data [#818](https://github.com/PublicMapping/districtbuilder/pull/818)
 - Add tooltip for population deviation in project sidebar [#819](https://github.com/PublicMapping/districtbuilder/pull/819)
+- Add ability to archive regions as read-only to reduce memory requirements [#831](https://github.com/PublicMapping/districtbuilder/pull/831)
 
 ### Changed
 

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -166,6 +166,7 @@ const ProjectSidebar = ({
   readonly saving: SavingState;
   readonly isReadOnly: boolean;
 } & LoadingProps) => {
+  const hasElectionData = Object.keys(geojson?.features[0].properties.voting || {}).length > 0;
   const multElections = hasMultipleElections(staticMetadata);
   const polLabel = multElections
     ? "Cook Partisan Voting Index (2016 / 2020)"
@@ -201,7 +202,7 @@ const ProjectSidebar = ({
                   <span>Race</span>
                 </Tooltip>
               </Styled.th>
-              {staticMetadata?.voting && (
+              {hasElectionData && (
                 <Styled.th sx={{ ...style.th, ...style.number }}>
                   <Tooltip content={polLabel}>
                     <span>{multElections ? "PVI" : "Pol."}</span>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -76,6 +76,7 @@ import { State } from "../../reducers";
 import { connect } from "react-redux";
 import { MAPBOX_STYLE, MAPBOX_TOKEN } from "../../constants/map";
 import { KEYBOARD_SHORTCUTS } from "./keyboardShortcuts";
+import Icon from "../Icon";
 
 function removeEvaluateMetricLayers(map: MapboxGL.Map) {
   map.setLayoutProperty(DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID, "visibility", "none");
@@ -184,6 +185,7 @@ interface Props {
   readonly evaluateMetric?: EvaluateMetric;
   readonly evaluateMode: boolean;
   readonly isReadOnly: boolean;
+  readonly isArchived: boolean;
   readonly limitSelectionToCounty: boolean;
   readonly findMenuOpen: boolean;
   readonly findTool: FindTool;
@@ -201,6 +203,21 @@ type Label = Feature<Point, LabelId>;
 type Labels = FeatureCollection<Point, LabelId>;
 
 const style: ThemeUIStyleObject = {
+  archivedMessage: {
+    position: "absolute",
+    bg: "muted",
+    width: "auto",
+    top: 3,
+    left: 3,
+    border: "1px solid",
+    borderColor: "gray.2",
+    borderRadius: "small",
+    boxShadow: "large",
+    p: 3,
+    display: "inline-block",
+    minWidth: "fit-content",
+    zIndex: "200"
+  },
   legendBox: {
     position: "absolute",
     bg: "muted",
@@ -259,6 +276,7 @@ const DistrictsMap = ({
   geoLevelIndex,
   lockedDistricts,
   isReadOnly,
+  isArchived,
   limitSelectionToCounty,
   findMenuOpen,
   evaluateMetric,
@@ -896,6 +914,12 @@ const DistrictsMap = ({
       <MapTooltip map={map || undefined} />
       <MapMessage map={map || undefined} maxZoom={maxZoom} />
       <FindMenu map={map} />
+      {!evaluateMode && isArchived && (
+        <Box sx={style.archivedMessage}>
+          <Icon name="alert-triangle" /> This map is using an archived region and can no longer be
+          edited.
+        </Box>
+      )}
       {evaluateMode && evaluateMetric && evaluateMetric.key === "countySplits" && (
         <Box sx={style.legendBox}>
           <Flex sx={{ alignItems: "center" }}>

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -226,7 +226,10 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
             const regionConfig =
               regionConfigs.resource.find(
                 config =>
-                  !config.hidden && config.regionCode === stateAbbrev && config.countryCode === "US"
+                  !config.hidden &&
+                  !config.archived &&
+                  config.regionCode === stateAbbrev &&
+                  config.countryCode === "US"
               ) || null;
             if (regionConfig) {
               setImportResource({ data: regionConfig, isPending: true });

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -53,6 +53,7 @@ interface StateProps {
   readonly districtDrawing: DistrictDrawingState;
   readonly isLoading: boolean;
   readonly isReadOnly: boolean;
+  readonly isArchived: boolean;
   readonly mapLabel: string | undefined;
   readonly user: Resource<IUser>;
   readonly electionYear: ElectionYear;
@@ -84,6 +85,7 @@ const ProjectScreen = ({
   mapLabel,
   isLoading,
   isReadOnly,
+  isArchived,
   user,
   electionYear
 }: StateProps) => {
@@ -205,6 +207,7 @@ const ProjectScreen = ({
                 evaluateMode={evaluateMode}
                 evaluateMetric={evaluateMetric}
                 isReadOnly={isReadOnly}
+                isArchived={isArchived}
                 limitSelectionToCounty={districtDrawing.limitSelectionToCounty}
                 label={mapLabel}
                 map={map}
@@ -250,6 +253,7 @@ function mapStateToProps(state: State): StateProps {
       ("isPending" in state.project.staticData && state.project.staticData.isPending),
     projectNotFound:
       "statusCode" in state.project.projectData && state.project.projectData.statusCode === 404,
+    isArchived: project !== undefined && project.regionConfig.archived,
     isReadOnly:
       !("resource" in state.user) ||
       (project !== undefined && state.user.resource.id !== project.user.id) ||

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -232,7 +232,7 @@ const ProjectScreen = ({
 };
 
 function mapStateToProps(state: State): StateProps {
-  const project = destructureResource(state.project.projectData, "project");
+  const project: IProject | undefined = destructureResource(state.project.projectData, "project");
   return {
     project,
     geojson: destructureResource(state.project.projectData, "geojson"),
@@ -252,7 +252,8 @@ function mapStateToProps(state: State): StateProps {
       "statusCode" in state.project.projectData && state.project.projectData.statusCode === 404,
     isReadOnly:
       !("resource" in state.user) ||
-      (project !== undefined && state.user.resource.id !== project.user.id),
+      (project !== undefined && state.user.resource.id !== project.user.id) ||
+      (project !== undefined && project.regionConfig.archived),
     user: state.user
   };
 }

--- a/src/server/migrations/1624298721363-region_config_archived_flag.ts
+++ b/src/server/migrations/1624298721363-region_config_archived_flag.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class regionConfigArchivedFlag1624298721363 implements MigrationInterface {
+    name = 'regionConfigArchivedFlag1624298721363'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "region_config" ADD "archived" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "region_config" DROP COLUMN "archived"`);
+    }
+
+}

--- a/src/server/migrations/1624394377454-alter_region_config_uniqueness_index.ts
+++ b/src/server/migrations/1624394377454-alter_region_config_uniqueness_index.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class alterRegionConfigUniquenessIndex1624394377454 implements MigrationInterface {
+  name = "alterRegionConfigUniquenessIndex1624394377454";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "UQ_region_code"`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_region_code" ON "region_config" ("country_code", "region_code") WHERE hidden <> TRUE AND archived <> TRUE`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "UQ_region_code"`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_region_code" ON "region_config" ("country_code", "region_code") WHERE hidden <> TRUE`
+    );
+  }
+}

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -98,7 +98,11 @@ export class DistrictsController {
     const blockToDistricts = Object.fromEntries(unflaggedRows);
 
     const regionCode = FIPS[stateFips];
-    const regionConfig = await this.regionConfigService.findOne({ regionCode, hidden: false });
+    const regionConfig = await this.regionConfigService.findOne({
+      regionCode,
+      hidden: false,
+      archived: false
+    });
     const geoCollection = regionConfig && (await this.topologyService.get(regionConfig.s3URI));
     if (!geoCollection) {
       throw new InternalServerErrorException();

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -9,7 +9,6 @@ import {
 import { FileInterceptor } from "@nestjs/platform-express";
 import csvParse from "csv-parse";
 import { Express } from "express";
-import { GeometryCollection } from "topojson-specification";
 
 import {
   DistrictsDefinition,
@@ -105,7 +104,7 @@ export class DistrictsController {
       throw new InternalServerErrorException();
     }
     const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
-    const baseGeoUnitLayer = geoCollection.topology.objects[baseGeoLevel] as GeometryCollection;
+    const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
 
     // The geounit hierarchy and district definition have the same structure (except the
     // hierarchy always goes out to the base geounit level), so we use it as a starting point
@@ -115,7 +114,7 @@ export class DistrictsController {
         if (typeof hierarchyNumOrArray === "number") {
           // The numbers found in the hierarchy are the base geounit indices of the topology.
           // Access this item in the topology to find it's base geounit id.
-          const props: any = baseGeoUnitLayer.geometries[hierarchyNumOrArray].properties;
+          const props: any = baseGeoUnitProperties[hierarchyNumOrArray];
           const id = props[baseGeoLevel];
           const districtAssignment = parseInt(blockToDistricts[id], 10);
           if (blockToDistricts[id]) {
@@ -135,7 +134,7 @@ export class DistrictsController {
         }
       });
 
-    const districtsDefinition = mapToDefinition(geoCollection.getGeoUnitHierarchy());
+    const districtsDefinition = mapToDefinition(geoCollection.hierarchyDefinition);
     // Find unmatched records
     records.forEach((record, i) => {
       if (!matchingRows[record[0]] && !flaggedRows[i]) {

--- a/src/server/src/districts/entities/geo-unit-properties.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-properties.entity.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../../shared/entities";
 import { GeoUnitTopology } from "./geo-unit-topology.entity";
 
-// A slimmed down version of GeoUniTopology without the geometries, only the feature properties
+// A slimmed down version of GeoUnitTopology without the geometries, only the feature properties
 export class GeoUnitProperties {
   public readonly hierarchy: ReadonlyArray<GeoUnitHierarchy>;
   static fromTopology(geoUnitTopology: GeoUnitTopology): GeoUnitProperties {

--- a/src/server/src/districts/entities/geo-unit-properties.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-properties.entity.ts
@@ -1,0 +1,29 @@
+import {
+  GeoUnitDefinition,
+  HierarchyDefinition,
+  GeoUnitHierarchy,
+  IStaticMetadata
+} from "../../../../shared/entities";
+import { GeoUnitTopology } from "./geo-unit-topology.entity";
+
+// A slimmed down version of GeoUniTopology without the geometries, only the feature properties
+export class GeoUnitProperties {
+  public readonly hierarchy: ReadonlyArray<GeoUnitHierarchy>;
+  static fromTopology(geoUnitTopology: GeoUnitTopology): GeoUnitProperties {
+    return new GeoUnitProperties(
+      geoUnitTopology.definition,
+      geoUnitTopology.hierarchyDefinition,
+      geoUnitTopology.staticMetadata,
+      geoUnitTopology.topologyProperties
+    );
+  }
+
+  private constructor(
+    public readonly definition: GeoUnitDefinition,
+    public readonly hierarchyDefinition: HierarchyDefinition,
+    public readonly staticMetadata: IStaticMetadata,
+    public readonly topologyProperties: {
+      readonly [layer: string]: readonly Record<string, unknown>[];
+    }
+  ) {}
+}

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -24,6 +24,7 @@ import {
 import { getAllBaseIndices, getDemographics, getVoting } from "../../../../shared/functions";
 import { DistrictsGeoJSON } from "../../projects/entities/project.entity";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
+import { mapValues } from "lodash";
 
 interface GeoUnitHierarchy {
   geom: Polygon | MultiPolygon;
@@ -275,8 +276,16 @@ export class GeoUnitTopology {
     };
   }
 
+  get topologyProperties() {
+    return mapValues(this.topology.objects, collection =>
+      collection.type === "GeometryCollection"
+        ? collection.geometries.map(feature => feature.properties || {})
+        : []
+    );
+  }
+
   // Generates the geounit hierarchy corresponding to a geo unit definition structure
-  getGeoUnitHierarchy() {
+  get hierarchyDefinition() {
     const geoLevelIds = this.staticMetadata.geoLevelHierarchy.map(level => level.id);
     const definition = { groups: geoLevelIds.slice().reverse() };
     return groupForHierarchy(this.topology, definition);

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -109,7 +109,6 @@ export class TopologyService {
           voting,
           geoLevels
         );
-        this.logger.debug(`finished calculating computed data for s3URI ${s3URI}`);
         // For archived read-only regions, we get the properties of the topology (which are used for exports)
         // and let the much larger TopoJSON geometries get garbage collected
         return archived ? GeoUnitProperties.fromTopology(geoUnitTopology) : geoUnitTopology;

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -27,15 +27,15 @@ export class TopologyService {
 
   constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
     void repo.find().then(regionConfigs => {
-      this._layers = regionConfigs
-        .map(regionConfig => regionConfig.s3URI)
-        .reduce(
-          (layers, s3URI) => ({
-            ...layers,
-            [s3URI]: this.fetchLayer(s3URI)
-          }),
-          {}
-        );
+      this._layers = regionConfigs.reduce(
+        (layers, regionConfig) => ({
+          ...layers,
+          [regionConfig.s3URI]: regionConfig.archived
+            ? Promise.resolve(void 0)
+            : this.fetchLayer(regionConfig.s3URI)
+        }),
+        {}
+      );
     });
   }
 

--- a/src/server/src/project-templates/controllers/project-templates.controller.ts
+++ b/src/server/src/project-templates/controllers/project-templates.controller.ts
@@ -24,9 +24,10 @@ import { ProjectTemplatesService } from "../services/project-templates.service";
 import { TopologyService } from "../../districts/services/topology.service";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
 import { getDemographicLabel } from "../../../../shared/functions";
+import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.entity";
 
 function getIds(
-  topoLayers: { [s3uri: string]: GeoUnitTopology },
+  topoLayers: { [s3uri: string]: GeoUnitTopology | GeoUnitProperties },
   prop: "demographics" | "voting"
 ): readonly string[] {
   return [
@@ -103,7 +104,7 @@ export class ProjectTemplatesController {
     }
     const projectRows = await this.service.findAdminOrgProjectsWithDistrictProperties(slug);
     const regionURIs = new Set(projectRows.map(row => row.regionS3URI));
-    const topoLayers: { [s3uri: string]: GeoUnitTopology } = {};
+    const topoLayers: { [s3uri: string]: GeoUnitTopology | GeoUnitProperties } = {};
     // eslint-disable-next-line
     for (const [s3uri, layerPromise] of Object.entries(this.topologyService.layers() || {})) {
       const layer = await layerPromise;

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -29,7 +29,6 @@ import stringify from "csv-stringify/lib/sync";
 import { Response } from "express";
 import { convert } from "geojson2shp";
 import * as _ from "lodash";
-import { GeometryCollection } from "topojson-specification";
 import isUUID from "validator/lib/isUUID";
 
 import { MakeDistrictsErrors } from "../../../../shared/constants";
@@ -297,7 +296,7 @@ export class ProjectsController implements CrudController<Project> {
   // Helper for obtaining a topology for a given S3 URI, throws exception if not found
   async getGeoUnitTopology(s3URI: string): Promise<GeoUnitTopology> {
     const geoCollection = await this.topologyService.get(s3URI);
-    if (!geoCollection) {
+    if (!geoCollection || !("topology" in geoCollection)) {
       throw new NotFoundException(
         `Topology ${s3URI} not found`,
         MakeDistrictsErrors.TOPOLOGY_NOT_FOUND
@@ -396,9 +395,15 @@ export class ProjectsController implements CrudController<Project> {
     @Param("id") projectId: ProjectId
   ): Promise<string> {
     const project = await this.getProject(req, projectId);
-    const geoCollection = await this.getGeoUnitTopology(project.regionConfig.s3URI);
+    const geoCollection = await this.topologyService.get(project.regionConfig.s3URI);
+    if (!geoCollection) {
+      throw new NotFoundException(
+        `Topology ${project.regionConfig.s3URI} not found`,
+        MakeDistrictsErrors.TOPOLOGY_NOT_FOUND
+      );
+    }
     const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
-    const baseGeoUnitLayer = geoCollection.topology.objects[baseGeoLevel] as GeometryCollection;
+    const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
 
     // First column is the base geounit id, second column is the district id
     const mutableCsvRows: [number, number][] = [];
@@ -415,7 +420,7 @@ export class ProjectsController implements CrudController<Project> {
         if (typeof districtOrArray === "number" && typeof hierarchyNumOrArray === "number") {
           // The numbers found in the hierarchy are the base geounit indices of the topology.
           // Access this item in the topology to find it's base geounit id.
-          const props: any = baseGeoUnitLayer.geometries[hierarchyNumOrArray].properties;
+          const props: any = baseGeoUnitProperties[hierarchyNumOrArray];
           mutableCsvRows.push([props[baseGeoLevel], districtOrArray]);
         } else if (typeof hierarchyNumOrArray !== "number") {
           // Keep recursing into the hierarchy until we reach the end
@@ -431,7 +436,7 @@ export class ProjectsController implements CrudController<Project> {
         }
       });
     };
-    accumulateCsvRows(project.districtsDefinition, geoCollection.getGeoUnitHierarchy());
+    accumulateCsvRows(project.districtsDefinition, geoCollection.hierarchyDefinition);
 
     return stringify(mutableCsvRows, {
       header: true,

--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -51,7 +51,7 @@ export class RegionConfig implements IRegionConfig {
   @Column({ type: "boolean", default: false })
   hidden: boolean;
 
-  // Archived regions are hidden, and also do not have data loaded and so their projects cannot be editted
+  // Archived regions are hidden, and also do not have data loaded and so their projects cannot be edited
   @Column({ type: "boolean", default: false })
   archived: boolean;
 }

--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -46,6 +46,12 @@ export class RegionConfig implements IRegionConfig {
   @Column({ type: "timestamp with time zone", default: () => "NOW()" })
   version: Date;
 
+  // Hidden regions have data loaded and can be used to edit projects,
+  // but do not appear in the list of regions when creating a new project
   @Column({ type: "boolean", default: false })
   hidden: boolean;
+
+  // Archived regions are hidden, and also do not have data loaded and so their projects cannot be editted
+  @Column({ type: "boolean", default: false })
+  archived: boolean;
 }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -170,6 +170,7 @@ export interface IRegionConfig {
   readonly s3URI: S3URI;
   readonly version: Date;
   readonly hidden: boolean;
+  readonly archived: boolean;
 }
 
 interface ProjectTemplateFields {


### PR DESCRIPTION
## Overview

Adds support for archiving regions.

Archived regions:
 - Don't have topojson data kept in memory (so they are not resource intensive)
 - Projects for archived regions can't be edited

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_projects_3e64db60-0e9a-4c7f-8785-5771716eb39d (1)](https://user-images.githubusercontent.com/4432106/122999639-87a3da80-d37c-11eb-8d32-e43e4ab948a9.png)


### Notes

 - Downloading the full TopoJSON only to throw away the geometries isn't the most efficient way to go about things - if we find the startup times are not acceptable on production, a simple optimization would be to create new static files from our existing regions that contain the feature properties in the TopoJSON files as well as a pre-computed `HierarchyDefinition`.

## Testing Instructions

- `scripts/update`
- Set one of your `region_config` rows to be `archived, and restart `scripts/server`
   - existing projects for that region should still be viewable, but no longer editable
   - all evaluate mode subpages should function correctly
   - all exports should function correctly
   - there should be no regressions for projects for a non-archived region

Closes #814 
