### PR TITLE
Add completed filter to community maps page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add button to display keyboard shortcuts modal [#787](https://github.com/PublicMapping/districtbuilder/pull/787)
 - Add configurable population deviation [#762](https://github.com/PublicMapping/districtbuilder/pull/762)
 - Display target population symbols in sidebar [#720](https://github.com/PublicMapping/districtbuilder/issues/720)
-- List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796)
+- List all published maps in new screen [#796](https://github.com/PublicMapping/districtbuilder/pull/796) & [#836](https://github.com/PublicMapping/districtbuilder/pull/836)
 - Add map export to organization admin screen [#805](https://github.com/PublicMapping/districtbuilder/pull/805)
 - Add support for Vagrant Development Environment [#729](https://github.com/PublicMapping/districtbuilder/pull/729)
 - Add user export to organization admin screen [#812](https://github.com/PublicMapping/districtbuilder/pull/812)

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -181,7 +181,7 @@ export async function fetchAllPublishedProjects(
   page: number,
   limit: number
 ): Promise<PaginatedResponse<IProject>> {
-  const endpoint = "/api/globalProjects?page=" + page.toString() + "&limit=" + limit.toString();
+  const endpoint = `/api/globalProjects?page=${page}&limit=${limit}&completed=true`;
   return new Promise((resolve, reject) => {
     apiAxios
       .get(endpoint)

--- a/src/server/src/projects/controllers/globalProjects.controller.ts
+++ b/src/server/src/projects/controllers/globalProjects.controller.ts
@@ -1,5 +1,12 @@
 // eslint-disable-next-line
-import { Controller, Get, ParseIntPipe, Query } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  ParseIntPipe,
+  Query,
+  ParseBoolPipe,
+  DefaultValuePipe
+} from "@nestjs/common";
 import { Project } from "../entities/project.entity";
 import { ProjectsService } from "../services/projects.service";
 
@@ -12,8 +19,9 @@ export class GlobalProjectsController {
   @Get()
   async getAllGlobalProjects(
     @Query("page", ParseIntPipe) page = 1,
-    @Query("limit", ParseIntPipe) limit = 10
+    @Query("limit", ParseIntPipe) limit = 10,
+    @Query("completed", new DefaultValuePipe(false), ParseBoolPipe) completed = false
   ): Promise<Pagination<Project>> {
-    return this.service.findAllPublishedProjectsPaginated({ page, limit });
+    return this.service.findAllPublishedProjectsPaginated({ page, limit, completed });
   }
 }

--- a/src/server/src/projects/controllers/globalProjects.controller.ts
+++ b/src/server/src/projects/controllers/globalProjects.controller.ts
@@ -1,4 +1,5 @@
-// eslint-disable-next-line
+// Not sure why, but eslint thinks these decorators are unused
+/* eslint-disable */
 import {
   Controller,
   Get,
@@ -7,6 +8,8 @@ import {
   ParseBoolPipe,
   DefaultValuePipe
 } from "@nestjs/common";
+/* eslint-enable */
+
 import { Project } from "../entities/project.entity";
 import { ProjectsService } from "../services/projects.service";
 


### PR DESCRIPTION


## Overview

Filters out maps on the Community Maps page that have population left in the unassigned district. This is intended to keep uninteresting maps filtered out, making the page more useful.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Before:
![localhost_3003_maps](https://user-images.githubusercontent.com/4432106/123283052-01e97180-d4d9-11eb-9bc7-2b79b29cb9c3.png)

After:
![localhost_3003_maps (1)](https://user-images.githubusercontent.com/4432106/123283059-03b33500-d4d9-11eb-97bd-0fef25a37586.png)


### Notes

Note that by default the API will still return uncompleted maps, unless `completed=true` is passed as a query parameter.

## Testing Instructions

- `scripts/server`
- go to the community maps page

Closes #826
