### PR TITLE
Add Majority Minority evaluate view

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
+      "@typescript-eslint/no-floating-promises": "off",
       "functional/functional-parameters": "off",
       "functional/prefer-type-literal": "off",
       "functional/no-conditional-statement": ["off"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
+- Add majority-minority evaluate mode view [#839](https://github.com/PublicMapping/districtbuilder/pull/839)
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
       - BASE_URL=${BASE_URL:-http://server:3005}
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=250
+      # Without this, ESLint will not respect our .eslintrc.js files when run via react-scripts start.
+      # This is apparently no longer needed in later versions of react-scripts, but for our version
+      # this is the way to force ESLint to respect our .eslintrc.js config files.
+      - EXTEND_ESLINT=true
       - PORT=3003
     volumes:
       - ./:/home/node/app

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -62,11 +62,11 @@ const Row = ({
 
 const DemographicsTooltip = ({
   demographics,
-  isMinorityMajority,
+  isMajorityMinority,
   abbreviate
 }: {
   readonly demographics: { readonly [id: string]: number };
-  readonly isMinorityMajority?: boolean;
+  readonly isMajorityMinority?: boolean;
   readonly abbreviate?: boolean;
 }) => {
   const percentages = mapValues(
@@ -91,7 +91,7 @@ const DemographicsTooltip = ({
       <Styled.table sx={{ margin: "0", width: "100%" }}>
         <tbody>{rows}</tbody>
       </Styled.table>
-      {isMinorityMajority && (
+      {isMajorityMinority && (
         <Box>
           <Divider sx={{ my: 1, borderColor: "gray.6" }} />
           <Box>* Minority majority district</Box>

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -35,7 +35,8 @@ import {
   computeDemographicSplit,
   has16Election,
   has20Election,
-  demographicsHasOther
+  demographicsHasOther,
+  isMajorityMinority
 } from "../functions";
 import store from "../store";
 import { DistrictGeoJSON, DistrictsGeoJSON, SavingState } from "../types";
@@ -547,7 +548,6 @@ const SidebarRow = memo(
     const intermediateDeviation = Math.ceil(deviation + selectedDifference);
     const absoluteDeviation = Math.floor(Math.abs(deviation + selectedDifference));
     const populationDisplay = intermediatePopulation.toLocaleString();
-    const isMinorityMajority = demographics.white / demographics.population < 0.5;
     const deviationDisplay =
       intermediateDeviation === 0
         ? "0"
@@ -674,7 +674,7 @@ const SidebarRow = memo(
                 demographics.population > 0 ? (
                   <DemographicsTooltip
                     demographics={demographics}
-                    isMinorityMajority={isMinorityMajority}
+                    isMajorityMinority={isMajorityMinority(district)}
                   />
                 ) : (
                   <em>
@@ -688,7 +688,7 @@ const SidebarRow = memo(
                 <span sx={style.chart}>
                   <DemographicsChart demographics={demographics} />
                 </span>
-                {isMinorityMajority && <span sx={style.minorityMajorityFlag}>*</span>}
+                {isMajorityMinority(district) && <span sx={style.minorityMajorityFlag}>*</span>}
               </span>
             </Tooltip>
           </Styled.td>

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -11,6 +11,7 @@ import CountySplitMetricDetail from "./detail/CountySplit";
 import EqualPopulationMetricDetail from "./detail/EqualPopulation";
 import { Resource } from "../../resource";
 import CompetitivenessMetricDetail from "./detail/Competitiveness";
+import MajorityRaceMetricDetail from "./detail/MajorityRace";
 
 const style: ThemeUIStyleObject = {
   header: {
@@ -124,6 +125,8 @@ const ProjectEvaluateMetricDetail = ({
           <EqualPopulationMetricDetail metric={metric} geojson={geojson} />
         ) : metric && "type" in metric && metric.key === "competitiveness" ? (
           <CompetitivenessMetricDetail metric={metric} geojson={geojson} />
+        ) : metric && "type" in metric && metric.key === "majorityMinority" ? (
+          <MajorityRaceMetricDetail metric={metric} geojson={geojson} />
         ) : (
           <Box>
             <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -10,7 +10,7 @@ import {
   Party
 } from "../../types";
 import store from "../../store";
-import { hasMultipleElections } from "../../functions";
+import { hasMultipleElections, isMajorityMinority } from "../../functions";
 import { regionPropertiesFetch } from "../../actions/regionConfig";
 import ProjectEvaluateMetricDetail from "./ProjectEvaluateMetricDetail";
 import ProjectEvaluateSummary from "./ProjectEvaluateSummary";
@@ -216,18 +216,18 @@ const ProjectEvaluateSidebar = ({
       description: "are compact",
       value: avgCompactness
     },
-    // TODO: Minority-Majority updates (#750)
-    // {
-    //   key: "minorityMajority",
-    //   name: "Minority-Majority",
-    //   type: "fraction",
-    //   description: "are minority-majority",
-    //   shortText:
-    //     "A district in which the majority of the constituents are racial or ethnic minorities",
-    //   longText:
-    //     "A district in which the majority of the constituents are racial or ethnic minorities",
-    //   value: 1
-    // },
+    {
+      key: "majorityMinority",
+      name: "Majority-Minority",
+      type: "fraction",
+      description: "are majority-minority",
+      shortText:
+        "A majority-minority district is a district in which a racial minority group or groups comprise a majority of the district's total population.",
+      longText:
+        'A majority-minority district is a district in which a racial minority group or groups comprise a majority of the district\'s total population. The display indicates districts where a minority race has a simple majority (Black, Hispanic, etc.), or where the sum of multiple minority races combine to a majority (called "Coalition" districts).',
+      total: geojson?.features.filter(f => f.id !== 0).length || 0,
+      value: geojson?.features.filter(f => isMajorityMinority(f)).length || 0
+    },
     {
       key: "countySplits",
       name: `${geoLevel ? geoLevelLabelSingular(geoLevel) : ""} splits`,

--- a/src/client/components/evaluate/detail/MajorityRace.tsx
+++ b/src/client/components/evaluate/detail/MajorityRace.tsx
@@ -1,0 +1,144 @@
+/** @jsx jsx */
+import { Box, Flex, jsx, Styled, ThemeUIStyleObject, Heading } from "theme-ui";
+import { DistrictsGeoJSON, EvaluateMetricWithValue } from "../../../types";
+import Tooltip from "../../Tooltip";
+import DemographicsTooltip from "../../DemographicsTooltip";
+import DemographicsChart from "../../DemographicsChart";
+import { capitalizeFirstLetter, isMajorityMinority } from "../../../functions";
+
+const style: ThemeUIStyleObject = {
+  table: {
+    mx: 0,
+    mb: 2,
+    width: "100%"
+  },
+  th: {
+    fontWeight: "bold",
+    color: "gray.7",
+    bg: "muted",
+    fontSize: 1,
+    textAlign: "left",
+    pt: 2,
+    px: 2,
+    height: "32px",
+    position: "sticky",
+    top: "0",
+    zIndex: 2,
+    userSelect: "none",
+    "&::after": {
+      height: "1px",
+      content: "''",
+      display: "block",
+      width: "100%",
+      bg: "gray.2",
+      bottom: "-1px",
+      position: "absolute",
+      left: 0,
+      right: 0
+    }
+  },
+  td: {
+    fontWeight: "body",
+    color: "gray.8",
+    fontSize: 1,
+    p: 2,
+    textAlign: "left",
+    verticalAlign: "bottom",
+    position: "relative"
+  },
+  colFirst: {
+    pl: 0
+  },
+  colLast: {
+    pr: 0
+  },
+  blankValue: {
+    color: "gray.2"
+  },
+  number: {
+    textAlign: "right"
+  }
+};
+
+const MajorityRaceMetricDetail = ({
+  metric,
+  geojson
+}: {
+  readonly metric: EvaluateMetricWithValue;
+  readonly geojson?: DistrictsGeoJSON;
+}) => {
+  return (
+    <Box>
+      <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
+        Your map has {metric.value?.toString() || " "} Majority-Minority districts
+      </Heading>
+      <Styled.table sx={style.table}>
+        <thead>
+          <Styled.tr>
+            <Styled.th sx={{ ...style.th, ...style.colFirst }}>Number</Styled.th>
+            <Styled.th sx={style.th}>Majority Race</Styled.th>
+            <Styled.th sx={{ ...style.th, ...style.number, ...style.colLast }}>
+              Demographics
+            </Styled.th>
+          </Styled.tr>
+        </thead>
+        <tbody>
+          {geojson?.features.map(
+            (feature, id) =>
+              id > 0 && (
+                <Styled.tr key={id}>
+                  <Styled.td sx={{ ...style.td, ...style.colFirst }}>{id}</Styled.td>
+
+                  <Styled.td sx={style.td}>
+                    {feature.properties.majorityRace !== undefined ? (
+                      <Flex sx={{ alignItems: "center" }}>
+                        <Styled.div
+                          sx={{
+                            mr: 2,
+                            width: "15px",
+                            height: "15px",
+                            borderRadius: "small",
+                            bg: feature.properties.majorityRaceFill
+                          }}
+                        ></Styled.div>
+                        <Box>{capitalizeFirstLetter(feature.properties.majorityRace)}</Box>
+                      </Flex>
+                    ) : (
+                      <Box sx={style.blankValue}>-</Box>
+                    )}
+                  </Styled.td>
+
+                  <Styled.td sx={{ ...style.td, ...style.number, ...style.colLast }}>
+                    <Tooltip
+                      placement="top-start"
+                      content={
+                        feature.properties.demographics.population > 0 ? (
+                          <DemographicsTooltip
+                            demographics={feature.properties.demographics}
+                            isMajorityMinority={isMajorityMinority(feature)}
+                          />
+                        ) : (
+                          <em>
+                            <strong>Empty district.</strong> Add people to this district to view the
+                            race chart
+                          </em>
+                        )
+                      }
+                    >
+                      <span sx={{ display: "inline-block" }}>
+                        <span sx={style.chart}>
+                          <DemographicsChart demographics={feature.properties.demographics} />
+                        </span>
+                      </span>
+                    </Tooltip>
+                  </Styled.td>
+                </Styled.tr>
+              )
+          )}
+        </tbody>
+      </Styled.table>
+    </Box>
+  );
+};
+
+export default MajorityRaceMetricDetail;

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -40,6 +40,8 @@ export const DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID = "districts-compactness"
 export const DISTRICTS_COMPETITIVENESS_CHOROPLETH_LAYER_ID = "districts-competitiveness";
 // Id for districts layer outline used in evaluate mode
 export const DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID = "districts-equal-population";
+// Id for districts layer outline used in evaluate mode
+export const DISTRICTS_MAJORITY_RACE_CHOROPLETH_LAYER_ID = "districts-majority-race";
 // Id for district labels layer used in evaluate mode
 export const DISTRICTS_EVALUATE_LABELS_LAYER_ID = "districts-evaluate-labels";
 // Id for topmost geolevel layer in Evaluate
@@ -89,7 +91,7 @@ export function getPviSteps(): ChoroplethSteps {
   return [
     [-100, "#a52a0d"],
     [-20, "#ed512c"],
-    [-5, "#CDCDCD"],
+    [-5, "#cdcdcd"],
     [5, "#6491b5"],
     [20, "#385d7a"]
   ];
@@ -106,14 +108,33 @@ export function getEqualPopulationStops(
   const popThreshold = popThresholdNum / 100;
   const isAvgFractional = avgPopulation % 1 !== 0;
   return [
-    [-1.0 * avgPopulation, "#D1E5F0"],
-    [-1 * (popThreshold + 0.02) * avgPopulation, "#66A9CF"],
-    [-1 * (popThreshold + 0.01) * avgPopulation, "#2166AC"],
-    [-1 * popThreshold * avgPopulation - (isAvgFractional ? 1 : 0.1), "#01665E"],
-    [popThreshold === 0 ? (isAvgFractional ? 1 : 0.1) : popThreshold * avgPopulation, "#EFBE60"],
-    [(popThreshold + 0.01) * avgPopulation, "#F5D092"],
-    [(popThreshold + 0.02) * avgPopulation, "#F7E1C3"]
+    [-1.0 * avgPopulation, "#c1e5f0"],
+    [-1 * (popThreshold + 0.02) * avgPopulation, "#66a9cf"],
+    [-1 * (popThreshold + 0.01) * avgPopulation, "#2166ac"],
+    [-1 * popThreshold * avgPopulation - (isAvgFractional ? 1 : 0.1), "#01665e"],
+    [popThreshold === 0 ? (isAvgFractional ? 1 : 0.1) : popThreshold * avgPopulation, "#efbe60"],
+    [(popThreshold + 0.01) * avgPopulation, "#f5d092"],
+    [(popThreshold + 0.02) * avgPopulation, "#f7e1c3"]
   ];
+}
+
+export function getMajorityRaceSplitFill(majorityRace: string, majorityRaceSplit: number): string {
+  const fills = getMajorityRaceFills();
+  return fills[majorityRace]
+    ? majorityRaceSplit > 0.65
+      ? fills[majorityRace][0]
+      : fills[majorityRace][1]
+    : "#ffffff";
+}
+
+export function getMajorityRaceFills(): { readonly [id: string]: readonly [string, string] } {
+  return {
+    white: ["#4a9dd4", "#aac3d4"],
+    black: ["#8dd3c5", "#c4e8e1"],
+    asian: ["#fdb35c", "#fcead6"],
+    hispanic: ["#cf6ade", "#dabdde"],
+    "minority coalition": ["#898989", "#ebe8eb"]
+  };
 }
 
 export function getEqualPopulationLabels(popThreshold: number) {
@@ -240,6 +261,22 @@ export function generateMapLayers(
           type: "interval",
           stops: getPviSteps()
         },
+        "fill-outline-color": "gray",
+        "fill-opacity": 0.9
+      }
+    },
+    DISTRICTS_PLACEHOLDER_LAYER_ID
+  );
+
+  map.addLayer(
+    {
+      id: DISTRICTS_MAJORITY_RACE_CHOROPLETH_LAYER_ID,
+      type: "fill",
+      source: DISTRICTS_SOURCE_ID,
+      layout: { visibility: "none" },
+      filter: ["match", ["get", "color"], ["transparent"], false, true],
+      paint: {
+        "fill-color": { type: "identity", property: "majorityRaceFill" },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9
       }

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -12,7 +12,7 @@ import {
   NestedArray,
   IStaticMetadata
 } from "../shared/entities";
-import { ChoroplethSteps, ElectionYear, Party } from "./types";
+import { ChoroplethSteps, DistrictGeoJSON, ElectionYear, Party } from "./types";
 
 import { Resource } from "./resource";
 import { DistrictsGeoJSON } from "./types";
@@ -134,6 +134,12 @@ export function getPartyVoteShareDisplay(percent?: number): string {
 export function computeDemographicSplit(demographic: number, total: number): string | undefined {
   const percent = total > 0 ? (demographic / total) * 100 : undefined;
   return percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0";
+}
+
+export function isMajorityMinority(f: DistrictGeoJSON): boolean {
+  return (
+    (f.properties.majorityRace && f.properties.majorityRace !== "white" && f.id !== 0) || false
+  );
 }
 
 /**

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -60,7 +60,7 @@ export type MetricKey =
   | "contiguity"
   | "competitiveness"
   | "compactness"
-  | "minorityMajority"
+  | "majorityMinority"
   | "countySplits";
 
 export interface BaseEvaluateMetric {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -99,6 +99,9 @@ export type DistrictProperties = {
   percentDeviation?: number;
   pvi?: number;
   populationDeviation?: number;
+  majorityRace?: string;
+  majorityRaceSplit?: number;
+  majorityRaceFill?: string;
   outlineWidthScaleFactor?: number;
   /* eslint-enable */
 };


### PR DESCRIPTION
## Overview

Adds an evaluate mode view for Majority Minority

- Majority race computed and displayed in sidebar
- Demographics chart included in sidebar
- Majority race and psuedo-choropleth (darker colors for greater share of majority race) included in map

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/123449266-7f7cb280-d5a9-11eb-9661-e136ae740460.png)


### Notes

I cribbed the colors from the wireframe, but I think we might be able to put a bit more thought into them. If a district is _not_ majority-minority (i.e., is majority white), the fact that it is displayed in green seems a little weird to me. I think we could probably improve the overall color scheme a bit to more effectively communicate the info that we want users to focus on @jfrankl @tgilcrest 

## Testing Instructions

- Create a map with districts that are majority-minority
- Open evaluate mode - expect districts to be included in count in summary
- Open Majority-Minority detail page - expect districts to be identified as majority-minority in sidebar and displayed on map

Closes #750 
