### PR TITLE
Add voting info to labels selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for calculating PVI / handling '16 & '20 election data [#818](https://github.com/PublicMapping/districtbuilder/pull/818)
 - Add tooltip for population deviation in project sidebar [#819](https://github.com/PublicMapping/districtbuilder/pull/819)
 - Add ability to archive regions as read-only to reduce memory requirements [#831](https://github.com/PublicMapping/districtbuilder/pull/831)
+- Add voting info to labels selector [#840](https://github.com/PublicMapping/districtbuilder/pull/840)
 
 ### Changed
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -145,10 +145,34 @@ const MapHeader = ({
   const topGeoLevelName = metadata
     ? metadata.geoLevelHierarchy[metadata.geoLevelHierarchy.length - 1].id
     : undefined;
-  const labelOptions = metadata
-    ? metadata.demographics.map(val => (
+  const labelFields =
+    metadata && metadata.demographics
+      ? [
+          ...metadata.demographics.map(file => {
+            return {
+              id: file.id,
+              label: file.id
+            };
+          }),
+          ...(metadata.voting
+            ? metadata.voting.map(file => {
+                return {
+                  id: file.id,
+                  // Fix suffix on voting IDs if needed
+                  label:
+                    file.id.endsWith("16") || file.id.endsWith("20")
+                      ? file.id.slice(0, -2) + " '" + file.id.slice(-2)
+                      : file.id
+                };
+              })
+            : [])
+        ]
+      : undefined;
+
+  const labelOptions = labelFields
+    ? labelFields.map(val => (
         <option key={val.id} value={val.id}>
-          {capitalizeFirstLetter(val.id)}
+          {capitalizeFirstLetter(val.label)}
         </option>
       ))
     : [];


### PR DESCRIPTION
## Overview

Adds voting info to labels selector, which display vote totals for geounits when selected.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/123856322-f3db8c80-d8ee-11eb-9bf2-a3cfe21dfb2c.png)


### Notes

We may want to handle the formatting of the field names here - I wasn't able to devise an easy solution for this, and I guess the labels aren't _terrible_ currently (Democrat20, Other party20). I was thinking that it might make sense to change these labels further upstream in the geojson processing, but that likely requires some input from other stakeholders first.

## Testing Instructions

- Go to a state with voting data and look in the labels dropdown - expect to see voting fields displayed
- Click a voting field, expect to see voting totals displayed

Closes #731 
