### PR TITLE
Add IP address and user ID to rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update map view for evaluate mode [#727](https://github.com/PublicMapping/districtbuilder/pull/727)
 - Show minority-majority districts in sidebar [#763](https://github.com/PublicMapping/districtbuilder/pull/763)
 - Add voting info to map tooltip [#751](https://github.com/PublicMapping/districtbuilder/pull/751)
+- Add user id and IP address to rollbar server side error logging [#841](https://github.com/PublicMapping/districtbuilder/pull/841)
 
 ### Changed
 

--- a/src/server/src/rollbar/rollbar-exception.filter.ts
+++ b/src/server/src/rollbar/rollbar-exception.filter.ts
@@ -13,7 +13,7 @@ import { RollbarService } from "./rollbar.service";
 export interface IGetUserAuthInfoRequest extends Request {
   user?: {
     id: number;
-  }
+  };
   socket: any;
 }
 
@@ -41,11 +41,16 @@ export class RollbarExceptionFilter extends BaseExceptionFilter {
     ) {
       const ctx = host.switchToHttp();
       const request = ctx.getRequest<IGetUserAuthInfoRequest>();
-      const customPayload = request.user ? {
-        user_id: request.user.id
-      } : {};
+      const customPayload = request.user
+        ? {
+            user_id: request.user.id
+          }
+        : {};
 
-      this.rollbar.error(exception, request, { ...customPayload, ip_address: request.headers.get('x-forwarded-for') || request.socket.remoteAddress });
+      this.rollbar.error(exception, request, {
+        ...customPayload,
+        ip_address: request.headers.get("x-forwarded-for") || request.socket.remoteAddress
+      });
     }
 
     // Delegate error messaging and response to default global exception filter


### PR DESCRIPTION
## Overview

Add IP address and user ID to rollbar

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

I'm not entirely sure how to test this. Currently, Rollbar is only enabled when Nest is not in debug mode, and I was thinking that I could disable that statement in code but this seems like a potentially bad practice of adding errors from testing to our primary Rollbar account. Also, I don't currently have access to DB logs in Rollbar.

Closes #789 
