### PR TITLE
Add user ID to server-side rollbar logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add evaluate mode metric view for competitiveness [#824](https://github.com/PublicMapping/districtbuilder/pull/824)
 - Add expandable metrics viewer with ability to pin metrics to sidebar [#827](https://github.com/PublicMapping/districtbuilder/pull/827)
 - Update population deviation helper text [#848](https://github.com/PublicMapping/districtbuilder/pull/848)
+- Add user id and IP address to rollbar server side error logging [#841](https://github.com/PublicMapping/districtbuilder/pull/841)
+
 
 ### Changed
 


### PR DESCRIPTION
## Overview

Adds user_id to server-side rollbar implementation, enabling for grouping of occurrences by user

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/124033953-97e53680-d9c8-11eb-8b27-3350f86190d5.png)


### Notes

It looks like there is already some sort of ip_address field being captured (as can be seen in the above screenshot). Is this value correct? It is strange that it doesn't seem to ever load if you go to the IP addresses tab, though:

![image](https://user-images.githubusercontent.com/66973361/124034064-c3682100-d9c8-11eb-8ac4-79a42853102e.png)


## Testing Instructions

- Find a way to make the server return a 500 error (I had to introduce a `throw new Error("foo");` to test this in development)
- Expect: rollbar error is logged and user ID is captured (if logged in)

Closes #789 
