### PR TITLE
Add populationDeviation and Chamber selection to Import Project screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add majority race metric to project sidebar [#853](https://github.com/PublicMapping/districtbuilder/pull/853)
 - Add additional keyboard shortcuts [#854](https://github.com/PublicMapping/districtbuilder/pull/854)
 - Add configurable slider to increase size of paintbrush selection tool [#835](https://github.com/PublicMapping/districtbuilder/pull/835)
+- Add populationDeviation and chamber to import project screen [#845](https://github.com/PublicMapping/districtbuilder/pull/845)
 
 
 ### Changed

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -64,6 +64,25 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
               ON CONFLICT DO NOTHING;
             "
 
+        # Add chambers to the database
+        docker-compose \
+            exec database psql -U districtbuilder districtbuilder -c "
+              INSERT INTO chamber
+              VALUES (
+                'e7f5999f-88d9-4c58-ab85-f65eae843ea1',
+                'House of Representatives',
+                 18,
+                '6c440b8d-c26e-4bae-850f-dbff37fe0209'
+              ),
+              (
+                '2202e945-161b-4f84-a282-5d65c7ba16b7',
+                'House of Representatives',
+                 18,
+                '96bca832-99b3-4c4d-8913-ab4ca82ec442'
+              )
+              ON CONFLICT DO NOTHING;
+            "
+
         # Add testing organization
         ./scripts/manage update-organization dev-data/azavea.yaml
         

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -213,7 +213,7 @@ export interface CreateProjectData {
   readonly name: string;
   readonly numberOfDistricts: number;
   readonly regionConfig: Pick<IRegionConfig, "id">;
-  readonly chamber?: Pick<IChamber, "id">;
+  readonly chamber?: Pick<IChamber, "id"> | null;
   readonly districtsDefinition?: DistrictsDefinition;
   readonly populationDeviation?: number;
   readonly projectTemplate?: Pick<IProjectTemplate, "id">;


### PR DESCRIPTION
## Overview

- Add populationDeviation and Chamber selection to Import Project screen
- Create chambers in `./scripts/load-dev-data` so that chambers are available for PA and IL

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/124976911-d8af0200-dffd-11eb-85a2-9f4fcbe851b4.png)


### Notes

- To test this, we need to have chambers in the DB - I thought we had these, but they seem to have been removed from `load-dev-data` at some point. I added back in SQL to create chambers for PA and IL

- I considered refactoring `CreateProjectScreen` and `ImportProjectScreen` to become one component, or to leverage shared functions across the two since they are now relatively similar - however, I decided against it with my rationale being mostly based around the fact that we are unlikely to use any of these components in other places, and we also don't currently have anything around Organization included as part of the Import workflow, which I think would be pretty difficult to implement.

## Testing Instructions

- `./scripts/load-dev-data`
- Import Project - drag a CSV (such as one attached)
- Expect: Chambers listed for PA or IL, population deviation box displayed
- Select a chamber, and a populationDeviation that is something other than 5
- Expect: Project is imported with the specified parameters


Closes #628 
