### PR TITLE
Add maps to list of user projects on home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add populationDeviation and chamber to import project screen [#845](https://github.com/PublicMapping/districtbuilder/pull/845)
 - Add filter by state functionality to community maps page [#851](https://github.com/PublicMapping/districtbuilder/pull/851)
 - Add button to upload project to PlanScore via API [#847](https://github.com/PublicMapping/districtbuilder/pull/847)
+- Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add button to upload project to PlanScore via API [#847](https://github.com/PublicMapping/districtbuilder/pull/847)
 - Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850)
 
+
 ### Changed
 
 - Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)

--- a/src/client/GTM.ts
+++ b/src/client/GTM.ts
@@ -1,7 +1,7 @@
 import GoogleTagManager from "@redux-beacon/google-tag-manager";
 import { createMiddleware, EventsMap, EventDefinition } from "redux-beacon";
 import { updateDistrictsDefinition } from "./actions/projectData";
-import { projectsFetch } from "./actions/projects";
+import { userProjectsFetch } from "./actions/projects";
 import { projectFetch } from "./actions/projectData";
 import { regionConfigsFetch } from "./actions/regionConfig";
 import { getType } from "typesafe-actions";
@@ -10,7 +10,7 @@ import { getType } from "typesafe-actions";
 // add them to this list and they will automatically be tracked
 const trackingActionTypes = [
   projectFetch, // user loaded a project
-  projectsFetch, // user loaded the home page
+  userProjectsFetch, // user loaded the home page
   regionConfigsFetch, // user loaded the create project screen
   updateDistrictsDefinition // user saved a district
 ];

--- a/src/client/actions/projects.ts
+++ b/src/client/actions/projects.ts
@@ -2,9 +2,12 @@ import { createAction } from "typesafe-actions";
 import { IProject, ProjectId } from "../../shared/entities";
 import { PaginatedResponse } from "../types";
 
-export const projectsFetch = createAction("Projects fetch")();
-export const projectsFetchSuccess = createAction("Projects fetch success")<readonly IProject[]>();
-export const projectsFetchFailure = createAction("Projects fetch failure")<string>();
+export const userProjectsFetch = createAction("Projects fetch")();
+export const userProjectsFetchPage = createAction("User projects fetch page")<number>();
+export const userProjectsFetchSuccess = createAction("Projects fetch success")<
+  PaginatedResponse<IProject>
+>();
+export const userProjectsFetchFailure = createAction("Projects fetch failure")<string>();
 
 export const globalProjectsFetch = createAction("Global projects fetch")();
 export const globalProjectsSetRegion = createAction("Global projects set region")<string | null>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -169,10 +169,13 @@ export async function fetchProjectGeoJson(id: ProjectId): Promise<DistrictsGeoJS
   });
 }
 
-export async function fetchProjects(): Promise<readonly IProject[]> {
+export async function fetchProjects(
+  page: number,
+  limit: number
+): Promise<PaginatedResponse<IProject>> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .get("/api/projects?sort=updatedDt,DESC")
+      .get(`/api/projects?page=${page}&limit=${limit}&sort=updatedDt,DESC`)
       .then(response => resolve(response.data))
       .catch(error => reject(error.response.data));
   });

--- a/src/client/components/FeaturedProjectCard.tsx
+++ b/src/client/components/FeaturedProjectCard.tsx
@@ -1,15 +1,9 @@
 /** @jsx jsx */
-import { Box, Flex, Heading, jsx, Spinner, Text } from "theme-ui";
-import MapboxGL from "mapbox-gl";
-import { useEffect, useRef, useState } from "react";
-import bbox from "@turf/bbox";
+import { Box, Flex, Heading, jsx, Text } from "theme-ui";
 import { useHistory } from "react-router-dom";
 
-import { BBox2d } from "@turf/helpers/lib/geojson";
-
 import { ProjectNest } from "../../shared/entities";
-import { DistrictGeoJSON } from "../types";
-import { getDistrictColor } from "../constants/colors";
+import ProjectDistrictsMap from "./map/ProjectDistrictsMap";
 
 const style = {
   featuredProject: {
@@ -21,19 +15,6 @@ const style = {
       cursor: "pointer"
     }
   },
-  mapContainer: {
-    width: "100%",
-    height: "250px",
-    position: "relative",
-    p: "15px"
-  },
-  map: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0
-  },
   mapLabel: {
     p: "15px",
     borderColor: "gray.2",
@@ -43,72 +24,14 @@ const style = {
 } as const;
 
 const FeaturedProjectCard = ({ project }: { readonly project: ProjectNest }) => {
-  const mapRef = useRef<HTMLDivElement>(null);
-  const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const history = useHistory();
-
   function goToProject(project: ProjectNest) {
     history.push(`/projects/${project.id}`);
   }
 
-  // TODO #179 - the districts property can't be defined in the shared/entities.d.ts right now
-  // @ts-ignore
-  const districts: DistrictsGeoJSON | undefined = project.districts;
-
-  useEffect(() => {
-    if (mapRef.current === null) {
-      return;
-    }
-
-    districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
-      // eslint-disable-next-line
-      feature.properties.color = getDistrictColor(id);
-    });
-
-    const bounds = districts && (bbox(districts) as BBox2d);
-    const map = new MapboxGL.Map({
-      container: mapRef.current,
-      style: {
-        version: 8,
-        sources: {},
-        layers: []
-      },
-      bounds,
-      fitBoundsOptions: { padding: 15 },
-      interactive: false
-    });
-
-    map.on("load", function() {
-      districts &&
-        map.addSource("districts", {
-          type: "geojson",
-          data: districts
-        });
-      map.addLayer({
-        id: "districts",
-        type: "fill",
-        source: "districts",
-        layout: {},
-        paint: {
-          "fill-color": { type: "identity", property: "color" }
-        }
-      });
-      map.resize();
-
-      setMapLoaded(true);
-    });
-  }, [mapRef, districts]);
-
   return (
     <Flex sx={style.featuredProject} onClick={() => goToProject(project)}>
-      <Box sx={style.mapContainer}>
-        <Box ref={mapRef} sx={style.map}></Box>
-      </Box>
-      {!mapLoaded && (
-        <Box sx={{ ...style.mapContainer, ...{ position: "absolute" } }}>
-          <Spinner variant="spinner.small" />
-        </Box>
-      )}
+      <ProjectDistrictsMap project={project} context={"communityMaps"} />
       <Box sx={style.mapLabel}>
         <Heading
           as="h3"

--- a/src/client/components/HomeScreenProjectCard.tsx
+++ b/src/client/components/HomeScreenProjectCard.tsx
@@ -1,0 +1,110 @@
+/** @jsx jsx */
+import { Box, Flex, Heading, jsx } from "theme-ui";
+import { useHistory } from "react-router-dom";
+
+import { IProject } from "../../shared/entities";
+import ProjectListFlyout from "./ProjectListFlyout";
+import TimeAgo from "timeago-react";
+import ProjectDistrictsMap from "./map/ProjectDistrictsMap";
+
+const style = {
+  featuredProject: {
+    width: "100%",
+    bg: "#fff",
+    borderRadius: "2px",
+    display: "inline-block",
+    mb: "20px",
+    boxShadow: "small",
+    position: "relative"
+  },
+  mapLabel: {
+    p: "15px",
+    display: "inline-block",
+    width: "600px",
+    pl: "100px",
+    borderColor: "gray.2",
+    position: "absolute"
+  },
+  projectTitle: {
+    display: "inline-block",
+    width: "300px",
+    "&:hover": {
+      cursor: "pointer"
+    }
+  },
+  projectRow: {
+    textDecoration: "none",
+    display: "flex",
+    alignItems: "baseline",
+    borderRadius: "med",
+    marginRight: "auto",
+    px: 1,
+    "&:hover:not([disabled])": {
+      bg: "rgba(256,256,256,0.2)",
+      h2: {
+        color: "primary",
+        textDecoration: "underline"
+      },
+      p: {
+        color: "blue.6"
+      }
+    },
+    "&:focus": {
+      outline: "none",
+      boxShadow: "focus"
+    }
+  },
+  flyoutButton: {
+    position: "absolute",
+    top: "5px",
+    right: "10px"
+  }
+} as const;
+
+const HomeScreenProjectCard = ({ project }: { readonly project: IProject }) => {
+  const history = useHistory();
+
+  function goToProject(project: IProject) {
+    history.push(`/projects/${project.id}`);
+  }
+
+  return (
+    <Flex sx={style.featuredProject}>
+      <ProjectDistrictsMap project={project} context={"home"} />
+      <Box sx={style.mapLabel}>
+        <Box sx={style.projectTitle} onClick={() => goToProject(project)}>
+          <span sx={{ display: "inline-block" }}>
+            <Heading
+              as="h2"
+              sx={{
+                fontFamily: "heading",
+                variant: "text.h5",
+                fontWeight: "light",
+                mr: 3
+              }}
+            >
+              {project.name}
+            </Heading>
+          </span>
+          <p sx={{ fontSize: 2, color: "gray.7" }}>
+            ({project.regionConfig.name}, {project.numberOfDistricts} districts)
+          </p>
+        </Box>
+        <div
+          sx={{
+            fontWeight: "light",
+            color: "gray.5",
+            paddingLeft: "5px"
+          }}
+        >
+          Last updated <TimeAgo datetime={project.updatedDt} />
+        </div>
+      </Box>
+      <span sx={style.flyoutButton}>
+        <ProjectListFlyout project={project} sx={{ display: "inline-block" }} />
+      </span>
+    </Flex>
+  );
+};
+
+export default HomeScreenProjectCard;

--- a/src/client/components/map/ProjectDistrictsMap.tsx
+++ b/src/client/components/map/ProjectDistrictsMap.tsx
@@ -1,0 +1,114 @@
+/** @jsx jsx */
+import { Box, jsx, Spinner } from "theme-ui";
+import MapboxGL from "mapbox-gl";
+import React, { useEffect, useRef, useState } from "react";
+import bbox from "@turf/bbox";
+
+import { BBox2d } from "@turf/helpers/lib/geojson";
+
+import { ProjectNest } from "../../../shared/entities";
+import { DistrictGeoJSON } from "../../types";
+import { getDistrictColor } from "../../constants/colors";
+
+const style = {
+  mapContainer: {
+    height: "250px",
+    display: "inline-block",
+    position: "relative",
+    p: "15px"
+  },
+  map: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0
+  }
+} as const;
+
+const ProjectDistrictsMap = ({
+  project,
+  context
+}: {
+  readonly project: ProjectNest;
+  readonly context: "home" | "communityMaps";
+}) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [mapLoaded, setMapLoaded] = useState<boolean>(false);
+
+  // TODO #179 - the districts property can't be defined in the shared/entities.d.ts right now
+  // @ts-ignore
+  const districts: DistrictsGeoJSON | undefined = project.districts;
+
+  useEffect(() => {
+    if (mapRef.current === null) {
+      return;
+    }
+
+    districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
+      // eslint-disable-next-line
+      feature.properties.color = getDistrictColor(id);
+    });
+
+    const bounds = districts && (bbox(districts) as BBox2d);
+    const map = new MapboxGL.Map({
+      container: mapRef.current,
+      style: {
+        version: 8,
+        sources: {},
+        layers: []
+      },
+      bounds,
+      fitBoundsOptions: { padding: 15 },
+      interactive: false
+    });
+
+    function onLoad() {
+      districts &&
+        map.addSource("districts", {
+          type: "geojson",
+          data: districts
+        });
+      map.addLayer({
+        id: "districts",
+        type: "fill",
+        source: "districts",
+        layout: {},
+        paint: {
+          "fill-color": { type: "identity", property: "color" }
+        }
+      });
+      map.resize();
+      setMapLoaded(true);
+    }
+
+    map.on("load", onLoad);
+    return () => {
+      map.off("load", onLoad);
+    };
+  }, [mapRef, districts]);
+
+  return (
+    <React.Fragment>
+      <Box
+        sx={
+          context === "communityMaps"
+            ? { ...style.mapContainer, width: "100%" }
+            : { ...style.mapContainer, width: "300px" }
+        }
+      >
+        <Box
+          ref={mapRef}
+          sx={context === "communityMaps" ? style.map : { ...style.map, pl: "20px" }}
+        ></Box>
+      </Box>
+      {!mapLoaded && (
+        <Box sx={{ ...style.mapContainer, ...{ position: "absolute" } }}>
+          <Spinner variant="spinner.small" />
+        </Box>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default ProjectDistrictsMap;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -41,7 +41,7 @@ import { updateCurrentState } from "../reducers/undoRedo";
 import { IProject } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
 import { resetProjectState } from "../actions/root";
-import { projectsFetch } from "../actions/projects";
+import { userProjectsFetch } from "../actions/projects";
 import { DistrictsGeoJSON, DynamicProjectData, SavingState, StaticProjectData } from "../types";
 import { Resource } from "../resource";
 
@@ -466,7 +466,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       );
     }
     case getType(duplicateProjectSuccess):
-      return loop(state, Cmd.action(projectsFetch()));
+      return loop(state, Cmd.action(userProjectsFetch()));
     case getType(duplicateProjectFailure):
       return loop(state, Cmd.run(showActionFailedToast));
     case getType(exportCsv):

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Flex, jsx, Spinner, Box, Heading, Text, Label, Select } from "theme-ui";
-import { IProject, ProjectNest, IRegionConfig } from "../../shared/entities";
+import { IProject, ProjectNest, IRegionConfig, PaginationMetadata } from "../../shared/entities";
 import "../App.css";
 import { State } from "../reducers";
 import store from "../store";
@@ -23,12 +23,7 @@ import { useQueryParam, StringParam } from "use-query-params";
 
 interface StateProps {
   readonly globalProjects: Resource<readonly IProject[]>;
-  readonly pagination: {
-    readonly currentPage: number;
-    readonly limit: number;
-    readonly totalItems?: number;
-    readonly totalPages?: number;
-  };
+  readonly pagination: PaginationMetadata;
   readonly user: UserState;
   readonly region: string | null;
   readonly regionConfigs?: readonly IRegionConfig[];

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -7,6 +7,7 @@ import {
   GeoUnitHierarchy,
   DistrictProperties,
   DemographicCounts,
+  PaginationMetadata,
   IProject
 } from "../shared/entities";
 
@@ -20,13 +21,7 @@ export interface DynamicProjectData {
 
 export interface PaginatedResponse<T> {
   readonly items: readonly T[];
-  readonly meta: {
-    readonly currentPage: number;
-    readonly itemCount: number;
-    readonly itemsPerPage: number;
-    readonly totalItems: number;
-    readonly totalPages: number;
-  };
+  readonly meta: PaginationMetadata;
 }
 
 export interface StaticProjectData {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -4,6 +4,13 @@ export type UserId = string;
 
 export type PublicUserProperties = "id" | "name" | "email";
 
+export type PaginationMetadata = {
+  readonly currentPage: number;
+  readonly limit: number;
+  readonly totalItems?: number;
+  readonly totalPages?: number;
+};
+
 export type OrganizationNest = Pick<IOrganization, "slug" | "id" | "name" | "logoUrl">;
 
 export type MetricField =


### PR DESCRIPTION
## Overview

Add maps to user project cards on home screen

- Add pagination to `/api/projects` endpoint

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/125693683-2b6bd225-88d6-482c-ad16-71c40d51e6e8.png)


### Notes

The CSS is a bit wonky currently, this might need a style pass.

Additionally, I'm not totally sold on my direction of editing the `/api/projects` endpoint - it seems like it might have been a better idea to refactor the `globalProjects` endpoint to support filtering to only the user's projects. Extrapolating this further - could we possibly combine both of these screens into a single screen, with an option to view user projects or global projects? It seems like there is a lot of redundancy here, and especially if we want to support filtering in global projects (#833 ) it would be nice to have this in user projects as well .

## Testing Instructions

- `./scripts/server`
- With more than 4 projects, expect to see pagination and maps displayed for each project

Closes #790 
