### PR TITLE
Add filter by state functionality to community maps page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add additional keyboard shortcuts [#854](https://github.com/PublicMapping/districtbuilder/pull/854)
 - Add configurable slider to increase size of paintbrush selection tool [#835](https://github.com/PublicMapping/districtbuilder/pull/835)
 - Add populationDeviation and chamber to import project screen [#845](https://github.com/PublicMapping/districtbuilder/pull/845)
-
+- Add filter by state functionality to community maps page [#851](https://github.com/PublicMapping/districtbuilder/pull/851)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "memoizee": "0.4.14",
     "polylabel": "^1.1.0",
     "prop-types": "15.7.2",
+    "query-string": "^7.0.1",
     "react": "16.11.0",
     "react-aria-menubutton": "^7.0.0",
     "react-aria-modal": "^4.0.0",
@@ -62,7 +63,8 @@
     "turf-polygon": "^1.0.3",
     "typesafe-actions": "5.1.0",
     "typescript": "3.7.5",
-    "use-clipboard-copy": "^0.1.2"
+    "use-clipboard-copy": "^0.1.2",
+    "use-query-params": "^1.2.3"
   },
   "browserslist": {
     "production": [

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -21,6 +21,8 @@ import theme from "./theme";
 import "./App.css";
 import StartProjectScreen from "./screens/StartProjectScreen";
 import PublishedMapsListScreen from "./screens/PublishedMapsListScreen";
+import { PushReplaceHistory, QueryParamProvider } from "use-query-params";
+import { createBrowserHistory } from "history";
 
 const PrivateRoute = ({ children, ...props }: RouteProps) => {
   const savedJWT = getJWT();
@@ -39,6 +41,17 @@ const PrivateRoute = ({ children, ...props }: RouteProps) => {
   );
 };
 
+const history = createBrowserHistory();
+const pushReplaceHistory: PushReplaceHistory = {
+  push: (location: Location): void => {
+    history.push(location);
+  },
+  replace: (location: Location): void => {
+    history.replace(location);
+  },
+  location: window.location
+};
+
 const App = () => (
   <ThemeProvider theme={theme}>
     <Toast />
@@ -53,7 +66,9 @@ const App = () => (
         </PrivateRoute>
         <Route path="/projects/:projectId" exact={true} component={ProjectScreen} />
         <Route path="/login" exact={true} component={LoginScreen} />
-        <Route path="/maps" exact={true} component={PublishedMapsListScreen} />
+        <QueryParamProvider history={pushReplaceHistory}>
+          <Route path="/maps" exact={true} component={PublishedMapsListScreen} />
+        </QueryParamProvider>
         <Route path="/register" exact={true} component={RegistrationScreen} />
         <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
         <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />

--- a/src/client/actions/projects.ts
+++ b/src/client/actions/projects.ts
@@ -7,6 +7,7 @@ export const projectsFetchSuccess = createAction("Projects fetch success")<reado
 export const projectsFetchFailure = createAction("Projects fetch failure")<string>();
 
 export const globalProjectsFetch = createAction("Global projects fetch")();
+export const globalProjectsSetRegion = createAction("Global projects set region")<string | null>();
 export const globalProjectsFetchPage = createAction("Global projects fetch page")<number>();
 export const globalProjectsFetchSuccess = createAction("Global projects fetch success")<
   PaginatedResponse<IProject>

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -179,9 +179,12 @@ export async function fetchProjects(): Promise<readonly IProject[]> {
 
 export async function fetchAllPublishedProjects(
   page: number,
-  limit: number
+  limit: number,
+  region?: string
 ): Promise<PaginatedResponse<IProject>> {
-  const endpoint = `/api/globalProjects?page=${page}&limit=${limit}&completed=true`;
+  const endpoint = region
+    ? `/api/globalProjects?page=${page}&limit=${limit}&completed=true&region=${region}`
+    : `/api/globalProjects?page=${page}&limit=${limit}&completed=true`;
   return new Promise((resolve, reject) => {
     apiAxios
       .get(endpoint)

--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -13,7 +13,8 @@ import {
   globalProjectsFetchPage,
   globalProjectsFetchSuccess,
   globalProjectsFetchFailure,
-  setDeleteProject
+  setDeleteProject,
+  globalProjectsSetRegion
 } from "../actions/projects";
 
 import { IProject } from "../../shared/entities";
@@ -31,6 +32,7 @@ export interface ProjectsState {
     readonly totalItems?: number;
     readonly totalPages?: number;
   };
+  readonly globalProjectsRegion: string | null;
   readonly archiveProjectPending: boolean;
 }
 
@@ -45,6 +47,7 @@ export const initialState = {
     totalItems: undefined,
     totalPages: undefined
   },
+  globalProjectsRegion: null,
   archiveProjectPending: false
 };
 
@@ -89,7 +92,8 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
           failActionCreator: globalProjectsFetchFailure,
           args: [
             state.globalProjectsPagination.currentPage,
-            state.globalProjectsPagination.limit
+            state.globalProjectsPagination.limit,
+            state.globalProjectsRegion
           ] as Parameters<typeof fetchAllPublishedProjects>
         })
       );
@@ -105,6 +109,15 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
         },
         Cmd.action(globalProjectsFetch())
       );
+    case getType(globalProjectsSetRegion):
+      return loop(
+        {
+          ...state,
+          globalProjectsRegion: action.payload || null
+        },
+        Cmd.action(globalProjectsFetch())
+      );
+
     case getType(globalProjectsFetchSuccess):
       return {
         ...state,
@@ -150,6 +163,7 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
                 )
               }
             : state.projects,
+        globalProjectsRegion: state.globalProjectsRegion,
         globalProjects:
           "resource" in state.globalProjects
             ? {

--- a/src/server/src/projects/controllers/globalProjects.controller.ts
+++ b/src/server/src/projects/controllers/globalProjects.controller.ts
@@ -23,8 +23,9 @@ export class GlobalProjectsController {
   async getAllGlobalProjects(
     @Query("page", ParseIntPipe) page = 1,
     @Query("limit", ParseIntPipe) limit = 10,
-    @Query("completed", new DefaultValuePipe(false), ParseBoolPipe) completed = false
+    @Query("completed", new DefaultValuePipe(false), ParseBoolPipe) completed = false,
+    @Query("region", new DefaultValuePipe(undefined)) region = undefined
   ): Promise<Pagination<Project>> {
-    return this.service.findAllPublishedProjectsPaginated({ page, limit, completed });
+    return this.service.findAllPublishedProjectsPaginated({ page, limit, completed, region });
   }
 }

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -9,6 +9,7 @@ import { paginate, Pagination, IPaginationOptions } from "nestjs-typeorm-paginat
 
 type AllProjectsOptions = IPaginationOptions & {
   readonly completed?: boolean;
+  readonly region?: string;
 };
 
 @Injectable()
@@ -49,6 +50,9 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
           "(project.districts->'features'->0->'properties'->'demographics'->'population')::integer = 0"
         )
       : builder;
-    return paginate<Project>(builderWithFilter, options);
+    const builderWithRegion = options.region
+      ? builderWithFilter.andWhere("regionConfig.regionCode = :region", { region: options.region })
+      : builderWithFilter;
+    return paginate<Project>(builderWithRegion, options);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6453,6 +6453,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -10655,6 +10660,16 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -11644,6 +11659,11 @@ serialize-javascript@^2.1.2:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
+serialize-query-params@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.3.5.tgz#ca6a6419219ead24cf3b55d7b4d6a4b716b70359"
+  integrity sha512-BrLH1RqgzVxm6dco+KP9S6BodeFiUVvKwtY3GSWQlupIdblT19KCGTRkHZ2yIU6Bjy0Prjts0tYe11VpTMbAeQ==
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -11969,6 +11989,11 @@ splaytree@^3.1.0:
   resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.0.tgz#17d4a0108a6da3627579690b7b847241e18ddec8"
   integrity sha512-gvUGR7xnOy0fLKTCxDeUZYgU/I1Tdf8M/lM1Qrf8L2TIOR5ipZjGk02uYcdv0o2x7WjVRgpm3iS2clLyuVAt0Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -12074,6 +12099,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -12870,6 +12900,13 @@ use-latest@^1.1.0:
   integrity sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-query-params@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.2.3.tgz#306c31a0cbc714e8a3b4bd7e91a6a9aaccaa5e22"
+  integrity sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==
+  dependencies:
+    serialize-query-params "^1.3.5"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Overview

- Add filter by state functionality to community maps page
- Add URL param filter to enable direct navigation to maps for a specific state

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/125999628-163e98aa-1f24-4411-a4b4-0521acad74b1.png)
![image](https://user-images.githubusercontent.com/66973361/125999656-0f3474dc-981a-4675-b2a4-7e02771d6a19.png)


### Notes

I'm struggling to figure out where the "0" that's being rendered when no maps exist is coming from - it shouldn't be there. We also may need a style pass on this, since there were no wireframes for the filter included in the issue

## Testing Instructions

- `./scripts/update`
- Navigate to the community maps page and select a state with at least one completed map
- Expect: navigate to `maps?region={STATE}`, and maps for that state are displayed
- Navigate to a URL for a state
- Expect: Map for state are displayed


Closes #833 
