### PR TITLE
Add additional keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add expandable metrics viewer with ability to pin metrics to sidebar [#827](https://github.com/PublicMapping/districtbuilder/pull/827)
 - Add user id and IP address to rollbar server side error logging [#841](https://github.com/PublicMapping/districtbuilder/pull/841)
 - Add majority race metric to project sidebar [#853](https://github.com/PublicMapping/districtbuilder/pull/853)
+- Add additional keyboard shortcuts [#854](https://github.com/PublicMapping/districtbuilder/pull/854)
 
 ### Changed
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -433,6 +433,7 @@ const DistrictsMap = ({
           numGeolevels: staticMetadata.geoLevelHierarchy.length,
           limitSelectionToCounty,
           evaluateMode,
+          expandedProjectMetrics,
           setTogglePan,
           electionYear
         });
@@ -448,6 +449,7 @@ const DistrictsMap = ({
       staticMetadata.geoLevelHierarchy.length,
       limitSelectionToCounty,
       evaluateMode,
+      expandedProjectMetrics,
       multipleElections,
       electionYear
     ]

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -15,7 +15,9 @@ import {
   redo,
   toggleLimitDrawingToWithinCounty,
   toggleKeyboardShortcutsModal,
-  setElectionYear
+  setElectionYear,
+  toggleExpandedMetrics,
+  setZoomToDistrictId
 } from "../../actions/districtDrawing";
 import store from "../../store";
 import { showMapActionToast } from "../../functions";
@@ -30,6 +32,7 @@ interface MapContext {
   readonly numGeolevels: number;
   readonly limitSelectionToCounty: boolean;
   readonly evaluateMode: boolean;
+  readonly expandedProjectMetrics: boolean;
   readonly electionYear: ElectionYear;
   // eslint-disable-next-line
   readonly setTogglePan: (isSet: boolean) => void;
@@ -170,6 +173,22 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
     action: ({ evaluateMode }: MapContext) => {
       store.dispatch(toggleEvaluate(!evaluateMode));
     }
+  },
+  {
+    key: "p",
+    text: "Toggle expanded project metrics",
+    action: ({ expandedProjectMetrics }: MapContext) => {
+      store.dispatch(toggleExpandedMetrics(!expandedProjectMetrics));
+    },
+    allowReadOnly: true
+  },
+  {
+    key: "l",
+    text: "Zoom to selected district",
+    action: ({ selectedDistrictId }: MapContext) => {
+      store.dispatch(setZoomToDistrictId(selectedDistrictId));
+    },
+    allowReadOnly: true
   },
   {
     key: "z",


### PR DESCRIPTION
## Overview

- Add keyboard shortcut (`P`) to toggle expanded project metrics
- Add keyboard shortcut (`L`) to zoom to district

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/126187749-60c48fd5-0c52-436c-a1a2-55115586dbb4.png)


### Notes

While working on #853 , I thought it would be nice to have a toggle for collapsing / expanding project metrics. While I was digging back into keyboard shortcuts, I realized that we didn't currently have a shortcut for zooming to the currently selected district either which seems like it could be helpful 

## Testing Instructions

- Open a project and hit the `P` key - expect expanded project metrics to be toggled
- Open a project and hit the `L` key on a populated district - expect the map to zoom to that district
