### PR TITLE
Update display logic for political data columns in sidebar to correspond with alt data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Tweaks to org report downloads [#832](https://github.com/PublicMapping/districtbuilder/pull/832)
 - Update population deviation helper text [#848](https://github.com/PublicMapping/districtbuilder/pull/848)
+- Update display logic for political data in expandable metrics viewer [#864](https://github.com/PublicMapping/districtbuilder/pull/864)
 
 
 ### Fixed

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -753,7 +753,7 @@ const SidebarRow = memo(
               </Styled.td>
             )
           : null}
-        {voting && "democrat16" in voting
+        {voting && ("democrat16" in voting || "democrat" in voting)
           ? (pinnedMetricFields.includes("dem16") || expandedProjectMetrics) && (
               <Styled.td sx={{ ...style.td, ...style.number }}>
                 <Tooltip
@@ -770,18 +770,24 @@ const SidebarRow = memo(
                   }
                 >
                   <span>
-                    {getPartyVoteShareDisplay(
-                      voting.democrat16,
-                      voting.republican16,
-                      voting["other party16"]
-                    )}
+                    {"democrat16" in voting
+                      ? getPartyVoteShareDisplay(
+                          voting.democrat16,
+                          voting.republican16,
+                          voting["other party16"]
+                        )
+                      : getPartyVoteShareDisplay(
+                          voting.democrat,
+                          voting.republican,
+                          voting["other party"]
+                        )}
                     %
                   </span>
                 </Tooltip>
               </Styled.td>
             )
           : null}
-        {voting && "republican16" in voting
+        {voting && ("republican16" in voting || "republican" in voting)
           ? (pinnedMetricFields.includes("rep16") || expandedProjectMetrics) && (
               <Styled.td sx={{ ...style.td, ...style.number }}>
                 <Tooltip
@@ -798,18 +804,24 @@ const SidebarRow = memo(
                   }
                 >
                   <span>
-                    {getPartyVoteShareDisplay(
-                      voting.republican16,
-                      voting.democrat16,
-                      voting["other party16"]
-                    )}
+                    {"republican16" in voting
+                      ? getPartyVoteShareDisplay(
+                          voting.republican16,
+                          voting.democrat16,
+                          voting["other party16"]
+                        )
+                      : getPartyVoteShareDisplay(
+                          voting.republican,
+                          voting.democrat,
+                          voting["other party"]
+                        )}
                     %
                   </span>
                 </Tooltip>
               </Styled.td>
             )
           : null}
-        {voting && "other party16" in voting
+        {voting && ("other party16" in voting || "other party" in voting)
           ? (pinnedMetricFields.includes("other16") || expandedProjectMetrics) && (
               <Styled.td sx={{ ...style.td, ...style.number }}>
                 <Tooltip
@@ -826,11 +838,17 @@ const SidebarRow = memo(
                   }
                 >
                   <span>
-                    {getPartyVoteShareDisplay(
-                      voting["other party16"],
-                      voting.republican16,
-                      voting.democrat16
-                    )}
+                    {"other party16" in voting
+                      ? getPartyVoteShareDisplay(
+                          voting["other party16"],
+                          voting.republican16,
+                          voting.democrat16
+                        )
+                      : getPartyVoteShareDisplay(
+                          voting["other party"],
+                          voting.republican,
+                          voting.democrat
+                        )}
                     %
                   </span>
                 </Tooltip>

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -212,8 +212,14 @@ export const hasMultipleElections = (staticMetadata?: IStaticMetadata) =>
   staticMetadata?.voting?.some(file => file.id.endsWith("16")) &&
   staticMetadata?.voting?.some(file => file.id.endsWith("20"));
 
-export const has16Election = (staticMetadata?: IStaticMetadata) =>
-  staticMetadata?.voting?.some(file => file.id.endsWith("16"));
+export const has16Election = (staticMetadata?: IStaticMetadata) => {
+  return (
+    staticMetadata?.voting?.some(file => file.id.endsWith("16")) ||
+    (staticMetadata?.voting &&
+      Object.keys(staticMetadata?.voting || {}).length > 0 &&
+      !has20Election(staticMetadata))
+  );
+};
 
 export const demographicsHasOther = (staticMetadata?: IStaticMetadata) =>
   staticMetadata?.demographics?.some(file => file.id === "other");


### PR DESCRIPTION
## Overview

Support displaying political data in sidebar for states where 2016 political data is displayed as just `republican` or `democrat` instead of `republican16` / `democrat16`

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/126558848-11ba17f8-488b-4588-968d-5b656f80d16a.png)

### Notes

1. On some level, this fix seems clunky to me. Is there any way that we could just rename the columns in the data so that the year is always included? 
1. Are there any other potential data structures that we need to be aware of? Is it possible that 2020 data could be added later for some states where we currently have the party-only structure? If so, this seems like it may be problematic.


## Testing Instructions

- Go to a project in staging in a state with the data structure outlined above (e.g., Pennsylvania)
- Expect to see political data columns in expandable metrics viewer

Closes #855 
