### PR TITLE
Fix breaking change for routing on `/register` and `/forgot-password`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Keyboard shortcuts no longer fire when form elements are focused [#823](https://github.com/PublicMapping/districtbuilder/pull/823)
+- Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -57,36 +57,36 @@ const App = () => (
     <Toast />
     <Router>
       <Switch>
-        <PrivateRoute path="/" exact={true}>
-          <HomeScreen />
-        </PrivateRoute>
-        <Route path="/o/:organizationSlug" exact={true} component={OrganizationScreen} />
-        <PrivateRoute path="/o/:organizationSlug/admin" exact={true}>
-          <OrganizationAdminScreen />
-        </PrivateRoute>
-        <Route path="/projects/:projectId" exact={true} component={ProjectScreen} />
-        <Route path="/login" exact={true} component={LoginScreen} />
         <QueryParamProvider history={pushReplaceHistory}>
+          <PrivateRoute path="/" exact={true}>
+            <HomeScreen />
+          </PrivateRoute>
+          <Route path="/o/:organizationSlug" exact={true} component={OrganizationScreen} />
+          <PrivateRoute path="/o/:organizationSlug/admin" exact={true}>
+            <OrganizationAdminScreen />
+          </PrivateRoute>
+          <Route path="/projects/:projectId" exact={true} component={ProjectScreen} />
+          <Route path="/login" exact={true} component={LoginScreen} />
           <Route path="/maps" exact={true} component={PublishedMapsListScreen} />
+          <Route path="/register" exact={true} component={RegistrationScreen} />
+          <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
+          <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />
+          <Route
+            path="/activate/:token/:organizationSlug"
+            exact={true}
+            component={ActivateAccountScreen}
+          />
+          <Route path="/password-reset/:token" exact={true} component={ResetPasswordScreen} />
+          <PrivateRoute path="/create-project" exact={true}>
+            <CreateProjectScreen />
+          </PrivateRoute>
+          <PrivateRoute path="/start-project" exact={true}>
+            <StartProjectScreen />
+          </PrivateRoute>
+          <PrivateRoute path="/import-project" exact={true}>
+            <ImportProjectScreen />
+          </PrivateRoute>
         </QueryParamProvider>
-        <Route path="/register" exact={true} component={RegistrationScreen} />
-        <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
-        <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />
-        <Route
-          path="/activate/:token/:organizationSlug"
-          exact={true}
-          component={ActivateAccountScreen}
-        />
-        <Route path="/password-reset/:token" exact={true} component={ResetPasswordScreen} />
-        <PrivateRoute path="/create-project" exact={true}>
-          <CreateProjectScreen />
-        </PrivateRoute>
-        <PrivateRoute path="/start-project" exact={true}>
-          <StartProjectScreen />
-        </PrivateRoute>
-        <PrivateRoute path="/import-project" exact={true}>
-          <ImportProjectScreen />
-        </PrivateRoute>
       </Switch>
     </Router>
   </ThemeProvider>


### PR DESCRIPTION
## Overview

Fixes breaking change introduced in https://github.com/PublicMapping/districtbuilder/pull/851/files#diff-653e49020a6d618fec5d77295bbc5526991eacdef0aedf041c8e0f1a57208d40R69-R71 where `/register` and `/forgot-password` ceased to work


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


## Testing Instructions

- `./scripts/server`
- Attempt to navigate to the /register page
- Expect: Register page is rendered and working

Closes #868 
