### PR TITLE
Fix find menu button so it properly opens the find menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,7 @@ deployment/ansible/roles/azavea.*
 *.tfvars
 .idea/
 
+# Vagrant
+.vagrant/
+
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Keyboard shortcuts no longer fire when form elements are focused [#823](https://github.com/PublicMapping/districtbuilder/pull/823)
 - Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
+- Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Flex, Box, Label, Button, jsx, Select, Slider, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
 import { ElectionYear } from "../types";
-
+import { toggleFind } from "../actions/districtDrawing";
 import { geoLevelLabel, capitalizeFirstLetter, canSwitchGeoLevels } from "../functions";
 import MapSelectionOptionsFlyout from "./MapSelectionOptionsFlyout";
 
@@ -145,6 +145,7 @@ const MapHeader = ({
   selectionTool,
   paintBrushSize,
   geoLevelIndex,
+  findMenuOpen,
   selectedGeounits,
   isReadOnly,
   limitSelectionToCounty,
@@ -158,6 +159,7 @@ const MapHeader = ({
   readonly selectedGeounits: GeoUnits;
   readonly advancedEditingEnabled?: boolean;
   readonly isReadOnly: boolean;
+  readonly findMenuOpen: boolean;
   readonly limitSelectionToCounty: boolean;
   readonly electionYear: ElectionYear;
 }) => {
@@ -245,7 +247,9 @@ const MapHeader = ({
                     sx={{ ...style.selectionButton }}
                     className={buttonClassName(selectionTool === tool)}
                     onClick={() => {
-                      setPaintBrushSizeSliderVisibility(tool === SelectionTool.PaintBrush);
+                      setPaintBrushSizeSliderVisibility(
+                        tool === SelectionTool.PaintBrush && !isPaintBrushSizeSliderVisible
+                      );
                       store.dispatch(setSelectionTool(tool));
                     }}
                   >
@@ -285,7 +289,7 @@ const MapHeader = ({
         )}
         <Flex className="geolevel-button-group">{geoLevelOptions}</Flex>
       </Flex>
-      <Box sx={{ lineHeight: "1" }}>
+      <Box sx={{ lineHeight: "1", position: "absolute", right: "150px" }}>
         <Flex sx={{ alignItems: "baseline" }}>
           <Label
             htmlFor="population-dropdown"
@@ -306,6 +310,24 @@ const MapHeader = ({
             {labelOptions}
           </Select>
         </Flex>
+      </Box>
+      <Box sx={{ position: "relative", mr: "5px" }}>
+        <Button
+          sx={{ ...style.selectionButton }}
+          onClick={() => {
+            store.dispatch(toggleFind(!findMenuOpen));
+          }}
+        >
+          <Box
+            sx={{
+              borderBottom: findMenuOpen ? "solid 1px" : "none",
+              borderBottomColor: "secondary",
+              mb: findMenuOpen ? "-1px" : "0"
+            }}
+          >
+            <Icon name="search" /> Find
+          </Box>
+        </Button>
       </Box>
     </Flex>
   );

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
 import { Box, Button, Flex, jsx, ThemeUIStyleObject } from "theme-ui";
 import { IProject } from "../../shared/entities";
-import { undo, redo, toggleFind, toggleEvaluate } from "../actions/districtDrawing";
+import { undo, redo, toggleEvaluate } from "../actions/districtDrawing";
 import { heights } from "../theme";
 import CopyMapButton from "../components/CopyMapButton";
 import ExportMenu from "../components/ExportMenu";
@@ -51,7 +51,6 @@ const HeaderDivider = () => {
 };
 
 interface StateProps {
-  readonly findMenuOpen: boolean;
   readonly evaluateMode: boolean;
   readonly undoHistory: UndoHistory;
 }
@@ -83,7 +82,6 @@ const EvaluateButton = ({ evaluateMode }: { readonly evaluateMode: boolean }) =>
 );
 
 const ProjectHeader = ({
-  findMenuOpen,
   evaluateMode,
   map,
   project,
@@ -133,28 +131,6 @@ const ProjectHeader = ({
           <ShareMenu invert={true} project={project} />
           <SupportMenu invert={true} project={true} />
           {project ? <ExportMenu invert={true} project={project} /> : null}
-          <Box sx={{ position: "relative", mr: "5px" }}>
-            <Button
-              sx={{
-                ...{
-                  variant: "buttons.ghost",
-                  fontWeight: "light"
-                },
-                ...menuButtonStyle.menuButton
-              }}
-              onClick={() => store.dispatch(toggleFind(!findMenuOpen))}
-            >
-              <Box
-                sx={{
-                  borderBottom: findMenuOpen ? "solid 1px" : "none",
-                  borderBottomColor: "muted",
-                  mb: findMenuOpen ? "-1px" : "0"
-                }}
-              >
-                <Icon name="search" /> Find
-              </Box>
-            </Button>
-          </Box>
           <EvaluateButton evaluateMode={evaluateMode} />
         </React.Fragment>
       ) : (
@@ -170,7 +146,6 @@ const ProjectHeader = ({
 
 function mapStateToProps(state: State): StateProps {
   return {
-    findMenuOpen: state.project.findMenuOpen,
     evaluateMode: state.project.evaluateMode,
     undoHistory: state.project.undoHistory
   };

--- a/src/client/components/map/FindMenu.tsx
+++ b/src/client/components/map/FindMenu.tsx
@@ -19,7 +19,7 @@ const style: ThemeUIStyleObject = {
   menu: {
     position: "absolute",
     top: "-1px",
-    left: 2,
+    right: 2,
     width: "350px",
     backgroundColor: "muted",
     border: "1px solid",
@@ -27,6 +27,7 @@ const style: ThemeUIStyleObject = {
     borderColor: "gray.2",
     borderBottomLeftRadius: "4px",
     borderBottomRightRadius: "4px",
+    zIndex: 1000,
     fontSize: 1,
     alignItems: "center",
     p: 2

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -364,7 +364,7 @@ const DistrictsMap = ({
         showCompass: false,
         showZoom: true
       }),
-      "top-right"
+      "bottom-right"
     );
 
     map.dragRotate.disable();

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -46,6 +46,7 @@ interface StateProps {
   readonly staticMetadata?: IStaticMetadata;
   readonly staticGeoLevels: UintArrays;
   readonly projectNotFound?: boolean;
+  readonly findMenuOpen: boolean;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly evaluateMode: boolean;
   readonly evaluateMetric: EvaluateMetric | undefined;
@@ -81,6 +82,7 @@ const ProjectScreen = ({
   evaluateMetric,
   regionProperties,
   projectNotFound,
+  findMenuOpen,
   geoUnitHierarchy,
   districtDrawing,
   mapLabel,
@@ -173,6 +175,7 @@ const ProjectScreen = ({
               label={mapLabel}
               metadata={staticMetadata}
               selectionTool={districtDrawing.selectionTool}
+              findMenuOpen={findMenuOpen}
               paintBrushSize={districtDrawing.paintBrushSize}
               geoLevelIndex={presentDrawingState.geoLevelIndex}
               selectedGeounits={presentDrawingState.selectedGeounits}
@@ -249,6 +252,7 @@ function mapStateToProps(state: State): StateProps {
     geoUnitHierarchy: destructureResource(state.project.staticData, "geoUnitHierarchy"),
     evaluateMode: state.project.evaluateMode,
     evaluateMetric: state.project.evaluateMetric,
+    findMenuOpen: state.project.findMenuOpen,
     mapLabel: state.project.mapLabel,
     electionYear: state.project.electionYear,
     districtDrawing: state.project,


### PR DESCRIPTION
## Overview

- Fixes the bug identified in #859 around the find menu not opening
- Toggles the paintbrush size slider when the paintbrush icon is clicked 


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/127177440-05286026-de25-4b19-b1b4-cf592981ff42.png)


### Notes

It seemed like putting this on the right side was the _easiest_ solution here, but I'm not necessarily sure if it's the best solution from a UX perspective. Perhaps @jfrankl might have a better solution for how to make this more visually apparent / usable

## Testing Instructions

- Open a project
- Click the find menu; expect the find menu to appear

Closes #859 
