### PR TITLE
Fix the duplicate project functionality on the home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tweaks to org report downloads [#832](https://github.com/PublicMapping/districtbuilder/pull/832)
 - Update population deviation helper text [#848](https://github.com/PublicMapping/districtbuilder/pull/848)
 - Update display logic for political data in expandable metrics viewer [#864](https://github.com/PublicMapping/districtbuilder/pull/864)
-
+- Update UX for duplication, showing a spinner when duplication is pending and redirecting when it completes [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 
 ### Fixed
 
 - Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Keyboard shortcuts no longer fire when form elements are focused [#823](https://github.com/PublicMapping/districtbuilder/pull/823)
 - Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
+- Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 - Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
 
 
@@ -66,7 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update race column to handle different race categories [#766](https://github.com/PublicMapping/districtbuilder/pull/766)
 - Cleanup text in evaluate mode [#776](https://github.com/PublicMapping/districtbuilder/pull/776)
-
 
 ### Fixed
 
@@ -90,7 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display warnings and row-level flags for district import [#708](https://github.com/PublicMapping/districtbuilder/pull/708)
 - Add keyboard shortcuts for map functions [#718](https://github.com/PublicMapping/districtbuilder/pull/718)
 - Added voting info to sidebar [#730](https://github.com/PublicMapping/districtbuilder/pull/730)
-
 
 ### Changed
 

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -66,10 +66,10 @@ export const updatedPinnedMetricsFailure = createAction("Update pinned metrics f
 export const updateProjectFailed = createAction("Update project failure")();
 
 export const duplicateProject = createAction("Duplicate project")<IProject>();
-export const duplicateProjectSuccess = createAction("Duplicate project success")<
-  DynamicProjectData
->();
+export const duplicateProjectSuccess = createAction("Duplicate project success")<IProject>();
 export const duplicateProjectFailure = createAction("Duplicate project failure")<string>();
+
+export const clearDuplicationState = createAction("Clear duplication state")();
 
 export const exportCsv = createAction("Export project CSV")<IProject>();
 export const exportCsvFailure = createAction("Export project CSV failure")<string>();

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../shared/entities";
 import { ElectionYear, EvaluateMetric } from "../types";
 
-import { projectDataFetch } from "../actions/projectData";
+import { projectDataFetch, clearDuplicationState } from "../actions/projectData";
 import { DistrictDrawingState } from "../reducers/districtDrawing";
 import { resetProjectState } from "../actions/root";
 import { userFetch } from "../actions/user";
@@ -121,6 +121,11 @@ const ProjectScreen = ({
     },
     []
   );
+
+  // Clear duplication state when mounting, in case the user navigated to project page from a post-duplication redirect
+  useEffect(() => {
+    store.dispatch(clearDuplicationState());
+  }, []);
 
   useEffect(() => {
     isLoggedIn && store.dispatch(userFetch());

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -37,6 +37,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
         "project.createdDt",
         "project.districts",
         "regionConfig.name",
+        "regionConfig.id",
         "user.id",
         "user.name"
       ])
@@ -65,10 +66,9 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
     userId: string,
     options: AllProjectsOptions
   ): Promise<Pagination<Project>> {
-    const builder = this.getProjectsBase().andWhere(
-      "project.archived = FALSE AND user.id = :userId",
-      { userId }
-    );
+    const builder = this.getProjectsBase()
+      .addSelect("project.districtsDefinition")
+      .andWhere("project.archived = FALSE AND user.id = :userId", { userId });
 
     return paginate<Project>(builder, options);
   }


### PR DESCRIPTION
## Overview

- Adds support back in for duplicating projects from the home screen, which was broken previously in #850 when `districtsDefinition` was removed from API response
- Updates UX for duplicating projects so that a user is redirected to a duplicated project after the duplication completes
- Leverages `isSaving` and `duplicatedProject` variables in Redux store to support

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

I don't _love_ the approach I took for handling the redirect - it seems like there may be a way to handle this with `Resource`, but it would require a bit of refactor at least and I'm not entirely sure that it's worthwhile. 

Also, I've noticed that locally the duplicate sometimes times out due to the region configs taking a while to load. I pushed to staging to confirm that this wasn't going to be a problem there, and it looks fine - might be a better idea to test this on staging, though.

## Testing Instructions

- Go to home screen and click the flyout menu button then 'Duplicate project'
- Expect: project is duplicated, and user is redirected to the new project page

Closes #870 
