### PR TITLE
Fix overlap between keyboard shortcuts and paintbrush slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850)
 - Add histogram to evaluate mode metric view for competitiveness [#844](https://github.com/PublicMapping/districtbuilder/pull/844)
 - Added button to convert 2010 maps to 2020 [#878](https://github.com/PublicMapping/districtbuilder/pull/878)
+- Add keyboard shortcuts for incrementing and decrementing the paintbrush size [#874](https://github.com/PublicMapping/districtbuilder/pull/874)
 
 ### Changed
 
@@ -53,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
 - Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 - Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
+- Fix overlap between keyboard shortcuts and paintbrush size slider [#874](https://github.com/PublicMapping/districtbuilder/pull/874)
 - Show file error when attempting to import a CSV for an unsupported region [#875](https://github.com/PublicMapping/districtbuilder/pull/875)
 - Increased timeout on database healthcheck [#877](https://github.com/PublicMapping/districtbuilder/pull/877)
 

--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Flex, Box, Label, Button, jsx, Select, Slider, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
 import { ElectionYear } from "../types";
@@ -77,7 +77,7 @@ const style: ThemeUIStyleObject = {
     borderColor: "gray.2",
     padding: "5px",
     top: "100px",
-    zIndex: 99999,
+    zIndex: 1,
     justifyContent: "space-evenly",
     width: "300px"
   }
@@ -191,6 +191,15 @@ const MapHeader = ({
         ]
       : undefined;
 
+  // Close paintbrush slider if the user switches to another tool, open it if toggled from another tool
+  useEffect(() => {
+    if (selectionTool !== SelectionTool.PaintBrush) {
+      setPaintBrushSizeSliderVisibility(false);
+    } else {
+      setPaintBrushSizeSliderVisibility(true);
+    }
+  }, [selectionTool]);
+
   const labelOptions = labelFields
     ? labelFields.map(val => (
         <option key={val.id} value={val.id}>
@@ -247,9 +256,8 @@ const MapHeader = ({
                     sx={{ ...style.selectionButton }}
                     className={buttonClassName(selectionTool === tool)}
                     onClick={() => {
-                      setPaintBrushSizeSliderVisibility(
-                        tool === SelectionTool.PaintBrush && !isPaintBrushSizeSliderVisible
-                      );
+                      // Open slider on click if not already open
+                      setPaintBrushSizeSliderVisibility(tool === SelectionTool.PaintBrush);
                       store.dispatch(setSelectionTool(tool));
                     }}
                   >
@@ -271,7 +279,7 @@ const MapHeader = ({
                     );
                   }}
                   sx={{ width: "150px" }}
-                  defaultValue={paintBrushSize}
+                  value={paintBrushSize}
                 />
                 <Box>{paintBrushSize}</Box>
               </Box>

--- a/src/client/components/map/KeyboardShortcutsModal.tsx
+++ b/src/client/components/map/KeyboardShortcutsModal.tsx
@@ -4,7 +4,7 @@ import AriaModal from "react-aria-modal";
 import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
 import { connect } from "react-redux";
 
-import { toggleKeyboardShortcutsModal } from "../../actions/districtDrawing";
+import { SelectionTool, toggleKeyboardShortcutsModal } from "../../actions/districtDrawing";
 import { State } from "../../reducers";
 import store from "../../store";
 import { KEYBOARD_SHORTCUTS } from "./keyboardShortcuts";
@@ -30,6 +30,7 @@ const style: ThemeUIStyleObject = {
     p: 5,
     width: "small",
     maxWidth: "90vw",
+    zIndex: "10000",
     overflow: "visible"
   },
   table: {
@@ -65,11 +66,13 @@ const KeyboardShortcutsModal = ({
   showModal,
   isReadOnly,
   evaluateMode,
+  selectionTool,
   staticMetadata
 }: {
   readonly showModal: boolean;
   readonly isReadOnly: boolean;
   readonly evaluateMode: boolean;
+  readonly selectionTool?: SelectionTool;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
   const hideModal = () => void store.dispatch(toggleKeyboardShortcutsModal());
@@ -100,6 +103,7 @@ const KeyboardShortcutsModal = ({
                     shortcut =>
                       (!isReadOnly || shortcut.allowReadOnly) &&
                       (!evaluateMode || shortcut.allowInEvaluateMode) &&
+                      (selectionTool === SelectionTool.PaintBrush || !shortcut.onlyForPaintBrush) &&
                       (multipleElections || !shortcut.onlyForMultipleElections)
                   ).map((shortcut, index) => {
                     const key = (

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -438,6 +438,7 @@ const DistrictsMap = ({
           limitSelectionToCounty,
           evaluateMode,
           expandedProjectMetrics,
+          paintBrushSize,
           setTogglePan,
           electionYear
         });
@@ -453,6 +454,7 @@ const DistrictsMap = ({
       staticMetadata.geoLevelHierarchy.length,
       limitSelectionToCounty,
       evaluateMode,
+      paintBrushSize,
       expandedProjectMetrics,
       multipleElections,
       electionYear

--- a/src/client/components/map/keyboardShortcuts.ts
+++ b/src/client/components/map/keyboardShortcuts.ts
@@ -17,7 +17,9 @@ import {
   toggleKeyboardShortcutsModal,
   setElectionYear,
   toggleExpandedMetrics,
-  setZoomToDistrictId
+  setZoomToDistrictId,
+  PaintBrushSize,
+  setPaintBrushSize
 } from "../../actions/districtDrawing";
 import store from "../../store";
 import { showMapActionToast } from "../../functions";
@@ -34,6 +36,7 @@ interface MapContext {
   readonly evaluateMode: boolean;
   readonly expandedProjectMetrics: boolean;
   readonly electionYear: ElectionYear;
+  readonly paintBrushSize: PaintBrushSize;
   // eslint-disable-next-line
   readonly setTogglePan: (isSet: boolean) => void;
 }
@@ -46,6 +49,7 @@ interface KeyboardShortcut {
   readonly allowReadOnly?: boolean;
   readonly allowInEvaluateMode?: boolean;
   readonly onlyForMultipleElections?: boolean;
+  readonly onlyForPaintBrush?: boolean;
   readonly shift?: true | "optional";
   // eslint-disable-next-line
   readonly action: (context: MapContext) => void;
@@ -181,6 +185,26 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
       store.dispatch(toggleExpandedMetrics(!expandedProjectMetrics));
     },
     allowReadOnly: true
+  },
+  {
+    key: "b",
+    text: "Decrement paintbrush size",
+    action: ({ paintBrushSize }: MapContext) => {
+      paintBrushSize > 1
+        ? store.dispatch(setPaintBrushSize((paintBrushSize - 1) as PaintBrushSize))
+        : store.dispatch(setPaintBrushSize(1));
+    },
+    onlyForPaintBrush: true
+  },
+  {
+    key: "m",
+    text: "Increment paintbrush size",
+    action: ({ paintBrushSize }: MapContext) => {
+      paintBrushSize < 5
+        ? store.dispatch(setPaintBrushSize((paintBrushSize + 1) as PaintBrushSize))
+        : store.dispatch(setPaintBrushSize(5));
+    },
+    onlyForPaintBrush: true
   },
   {
     key: "l",

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -237,6 +237,7 @@ const ProjectScreen = ({
               <ConvertMapModal project={project} />
               <KeyboardShortcutsModal
                 isReadOnly={isReadOnly}
+                selectionTool={districtDrawing.selectionTool}
                 evaluateMode={evaluateMode}
                 staticMetadata={staticMetadata}
               />


### PR DESCRIPTION
## Overview

- Fixes the bug identified in #860 where the paintbrush slider rendered over top of the keyboard shortcuts modal
- Finalizes the UX improvements to paintbrush slider that were began in #871 . It was never explicitly spec'd out when the paintbrush size slider should be displayed, and it previously was not displaying the paintbrush slider if a user selected the paintbrush tool via keyboard shortcuts
- Adds new keyboard shortcuts for incrementing / decrementing the size of the paintbrush tool


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/127215142-a51a9ceb-d6d0-410a-8083-3e19539e021e.png)


![image](https://user-images.githubusercontent.com/66973361/127215108-0c755ccb-2449-41f8-9005-40492453ecad.png)


### Notes

Keyboard shortcuts weren't explicitly asked for around the paintbrush size slider, but they certainly are fun to use 😀 

I kind of randomly went with `B` and `M` for the increment / decrement functionality - perhaps there might be better choices here, @jfrankl ? 

## Testing Instructions

- Go to a project, select the paintbrush tool and then type `?` to open the shortcuts modal
- Expect: Shortcuts modal is rendered above the paintbrush slider
- Click `B` or `M` while the paintbrush tool is selected.
- Expect: Paintbrush is incremented / decremented


Closes #860 
