### PR TITLE
Add import file error for unavailable regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
 - Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 - Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
+- Show file error when attempting to import a CSV for an unsupported region [#875](https://github.com/PublicMapping/districtbuilder/pull/875)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -313,6 +313,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
               }
             } else {
               setImportResource({ data: null });
+              setFileError(`State ${stateAbbrev} not currently supported`);
             }
           } else {
             setFileError("File must have at least one record");


### PR DESCRIPTION
## Overview

Displays an import file error if a user attempts to import a CSV containing rows from a state not currently supported in DistrictBuilder

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/127229588-34aaffae-dba6-4e13-9fb9-2d2b67931510.png)


### Notes

@dmcglone Thoughts on what this text should be?

## Testing Instructions

- Attempt to import a file for a state not included in local DB database (e.g., California)
- Expect: Error is displayed as shown above

Closes #852 
