### PR TITLE
Clear eslint cache before running react-scripts start/build tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --testPathPattern=src/client",
+    "start": "npm run clear_cache:eslint && react-scripts start",
+    "build": "npm run clear_cache:eslint && react-scripts build",
+    "test": "npm run clear_cache:eslint && react-scripts test --testPathPattern=src/client",
     "eject": "react-scripts eject",
     "compile": "tsc",
     "watch": "tsc --watch",
     "fix": "eslint --fix 'src/*.{ts,tsx}' 'src/client/**/*.{ts,tsx}' 'src/shared/**/*.ts'",
     "lint": "eslint 'src/*.{ts,tsx}' 'src/client/**/*.{ts,tsx}' 'src/shared/**/*.ts'",
     "format": "prettier --write 'src/{client,shared}/**/*.{ts,tsx,json,css}'",
-    "check-format": "prettier --check 'src/{client,shared}/**/*.{ts,tsx,json,css}'"
+    "check-format": "prettier --check 'src/{client,shared}/**/*.{ts,tsx,json,css}'",
+    "clear_cache:eslint": "rm -rf node_modules/.cache/eslint-loader"
   },
   "dependencies": {
     "@redux-beacon/google-tag-manager": "1.0.1",


### PR DESCRIPTION
## Overview

I've been encountering `eslint` issues that weren't replicable on CI / other developers machines.
This SO post (https://stackoverflow.com/a/63788215) suggested the `eslint` cache could be the issue, and indeed adding these changes to our `package.json` seems to have fixed the issue.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- this line from `scripts/update` would fail on `develop` w/ spurious lint issues, now it succeeds `docker-compose run --rm --no-deps client bash -c "yarn install && yarn compile && yarn build"`
