### PR TITLE
Increase healthcheck DB timeout to 3 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 - Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
 - Show file error when attempting to import a CSV for an unsupported region [#875](https://github.com/PublicMapping/districtbuilder/pull/875)
+- Increased timeout on database healthcheck [#877](https://github.com/PublicMapping/districtbuilder/pull/877)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/server/src/healthcheck/healthcheck.controller.ts
+++ b/src/server/src/healthcheck/healthcheck.controller.ts
@@ -20,7 +20,7 @@ export class HealthcheckController {
   @HealthCheck()
   healthCheck(): Promise<HealthCheckResult> {
     return this.health.check([
-      async () => this.db.pingCheck("database"),
+      async () => this.db.pingCheck("database", { timeout: 3000 }),
       () => this.topoLoaded.isHealthy("topology")
     ]);
   }


### PR DESCRIPTION
## Overview

We've been experiencing increased healthcheck failures lately from slow database response times, leading to application servers cycling out and occasional temporary site outages.

The 3 second timeout matches the timeout on the load balancer target group, which should help us at least keep the site up more during times of heavy load.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

@colekettler had suggested exploring if the healthcheck query could be simplified, but it is already incredibly simple (`SELECT 1`), so my assumption is that the slowness of the response is not specific to the healthcheck but rather a side effect of some other performance issue.

## Testing Instructions

I'm frankly unsure of how to test this, other than just assuming the documentation is correct.

Closes #867 
