### PR TITLE
Convert 2010 census region maps to 2020 census regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add button to upload project to PlanScore via API [#847](https://github.com/PublicMapping/districtbuilder/pull/847)
 - Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850)
 - Add histogram to evaluate mode metric view for competitiveness [#844](https://github.com/PublicMapping/districtbuilder/pull/844)
+- Added button to convert 2010 maps to 2020 [#878](https://github.com/PublicMapping/districtbuilder/pull/878)
 
 ### Changed
 

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -25,31 +25,30 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             -f docker-compose.yml \
             up -d database server
 
+        # Different regions for testing different scenarios:
+        #  - Dane County is a hidden / non-state region
+        #  - PA has '16 but not '20 political data
+        #  - IL has both '16 and '20 political data
+        #  - DE appears twice, with an archived '10 census version and an unarchived '20 census version
         docker-compose \
             exec database psql -U districtbuilder districtbuilder -c "
               INSERT INTO region_config
               VALUES (
-                'e7728e7d-cf2e-45e9-a8d8-e44699d87a21',
-                'Michigan',
-                'US',
-                'MI',
-                's3://global-districtbuilder-dev-us-east-1/regions/US/MI/2020-09-08T20:15:12.635Z/',
-                DEFAULT,
-                DEFAULT
-              ), (
                 '4a48268f-ddcf-4ae9-b41f-23cda93c3eba',
                 'Dane County',
                 'US',
                 'WI',
                 's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-02-08T15:19:22.145Z/',
                 DEFAULT,
+                TRUE,
                 DEFAULT
               ), (
                 '96bca832-99b3-4c4d-8913-ab4ca82ec442',
                 'Pennsylvania',
                 'US',
                 'PA',
-                's3://global-districtbuilder-dev-us-east-1/regions/US/PA/2021-02-08T18:07:18.957Z/',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/PA/2020-09-09T19:03:58.174Z/',
+                DEFAULT,
                 DEFAULT,
                 DEFAULT
               ), (
@@ -59,7 +58,26 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 'IL',
                 's3://global-districtbuilder-dev-us-east-1/regions/US/IL/2021-06-04T15:05:37.089Z/',
                 DEFAULT,
+                DEFAULT,
                 DEFAULT
+              ), (
+                '852fa086-de7c-4edd-b666-004b6ff8dc6c',
+                'Delaware',
+                'US',
+                'DE',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-09-09T19:50:10.921Z/',
+                DEFAULT,
+                DEFAULT,
+                FALSE
+              ), (
+                '411c5908-2a83-40e9-863b-303931a1c119',
+                'Delaware',
+                'US',
+                'DE',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2021-06-11T23:03:36.938Z/',
+                DEFAULT,
+                DEFAULT,
+                TRUE
              )
               ON CONFLICT DO NOTHING;
             "

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -62,8 +62,8 @@ export const toggleKeyboardShortcutsModal = createAction("Show keyboard shortcut
 export const showAdvancedEditingModal = createAction("Show advanced editing warning modal")<
   boolean
 >();
-
 export const showCopyMapModal = createAction("Show copy map modal")<boolean>();
+export const showConvertMapModal = createAction("Show convert map modal")<boolean>();
 export const setImportFlagsModal = createAction("Show import flags modal")<boolean>();
 
 export const undo = createAction("Undo project action")();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -149,6 +149,15 @@ export async function createProject({
   });
 }
 
+export async function convertAndCopyProject(id: ProjectId): Promise<IProject> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/projects/${id}/convert-and-copy`)
+      .then(response => resolve(response.data))
+      .catch(error => reject(error.response?.data || error));
+  });
+}
+
 async function fetchProject(id: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios

--- a/src/client/components/ConvertMapModal.tsx
+++ b/src/client/components/ConvertMapModal.tsx
@@ -1,0 +1,125 @@
+/** @jsx jsx */
+import React from "react";
+import AriaModal from "react-aria-modal";
+import { connect } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+
+import { IProject, IUser } from "../../shared/entities";
+import { showConvertMapModal } from "../actions/districtDrawing";
+import { resetProjectState } from "../actions/root";
+import { convertAndCopyProject } from "../api";
+import { showActionFailedToast } from "../functions";
+import { State } from "../reducers";
+import store from "../store";
+import { AuthModalContent } from "./AuthComponents";
+import { Resource } from "../resource";
+
+const style: ThemeUIStyleObject = {
+  footer: {
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 5
+  },
+  header: {
+    mb: 5
+  },
+  heading: {
+    fontFamily: "heading",
+    fontWeight: "light",
+    fontSize: 4
+  },
+  modal: {
+    bg: "muted",
+    p: 5,
+    width: "small",
+    maxWidth: "90vw",
+    overflow: "visible"
+  }
+};
+
+const ConvertMapModal = ({
+  project,
+  user,
+  showModal
+}: {
+  readonly project: IProject;
+  readonly user: Resource<IUser>;
+  readonly showModal: boolean;
+}) => {
+  const history = useHistory();
+
+  const hideModal = () => store.dispatch(showConvertMapModal(false));
+  const attributedName = `${project.name} by ${project.user.name}`;
+  const isLoggedIn = "resource" in user;
+
+  function goToProject(project: IProject) {
+    history.push(`/projects/${project.id}`);
+  }
+
+  return showModal ? (
+    <AriaModal
+      titleId="convert-map-modal-header"
+      onExit={hideModal}
+      initialFocus="#primary-action"
+      getApplicationNode={() => document.getElementById("root") as Element}
+      underlayStyle={{ paddingTop: "4.5rem" }}
+    >
+      <Box sx={style.modal}>
+        {!isLoggedIn ? (
+          <AuthModalContent project={project} />
+        ) : (
+          <React.Fragment>
+            <Box sx={style.header}>
+              <Heading as="h1" sx={style.heading} id="convert-map-modal-header">
+                Copy this map to use 2020 Census data?
+              </Heading>
+            </Box>
+            <Flex
+              as="form"
+              sx={{ flexDirection: "column" }}
+              onSubmit={(e: React.FormEvent) => {
+                e.preventDefault();
+                convertAndCopyProject(project.id)
+                  .then((newProject: IProject) => {
+                    // Need to reset the project state here, so when the redirect kicks in we don't have any
+                    // old state hanging around (undo history, etc.)
+                    store.dispatch(resetProjectState());
+                    goToProject(newProject);
+                  })
+                  .catch(showActionFailedToast);
+              }}
+            >
+              <Box>
+                This will create a copy of <strong>{attributedName}</strong> in your account,
+                converted to use 2020 Census data. You will be able to make changes to the copied
+                version.
+              </Box>
+              <Flex sx={style.footer}>
+                <Button id="primary-action" sx={{ marginBottom: 3 }} type="submit">
+                  Yes, copy to my account
+                </Button>
+                <Button
+                  id="cancel-convert-map-modal"
+                  onClick={hideModal}
+                  sx={{ variant: "buttons.linkStyle", margin: "0 auto" }}
+                >
+                  Cancel
+                </Button>
+              </Flex>
+            </Flex>
+          </React.Fragment>
+        )}
+      </Box>
+    </AriaModal>
+  ) : null;
+};
+
+function mapStateToProps(state: State) {
+  return {
+    showModal: state.project.showConvertMapModal,
+    user: state.user
+  };
+}
+
+export default connect(mapStateToProps)(ConvertMapModal);

--- a/src/client/components/ConvertMapModal.tsx
+++ b/src/client/components/ConvertMapModal.tsx
@@ -1,9 +1,9 @@
 /** @jsx jsx */
-import React from "react";
+import React, { useState } from "react";
 import AriaModal from "react-aria-modal";
 import { connect } from "react-redux";
 import { useHistory } from "react-router-dom";
-import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject, Spinner } from "theme-ui";
 
 import { IProject, IUser } from "../../shared/entities";
 import { showConvertMapModal } from "../actions/districtDrawing";
@@ -47,6 +47,7 @@ const ConvertMapModal = ({
   readonly user: Resource<IUser>;
   readonly showModal: boolean;
 }) => {
+  const [saving, setSaving] = useState(false);
   const history = useHistory();
 
   const hideModal = () => store.dispatch(showConvertMapModal(false));
@@ -80,6 +81,7 @@ const ConvertMapModal = ({
               sx={{ flexDirection: "column" }}
               onSubmit={(e: React.FormEvent) => {
                 e.preventDefault();
+                setSaving(true);
                 convertAndCopyProject(project.id)
                   .then((newProject: IProject) => {
                     // Need to reset the project state here, so when the redirect kicks in we don't have any
@@ -87,6 +89,7 @@ const ConvertMapModal = ({
                     store.dispatch(resetProjectState());
                     goToProject(newProject);
                   })
+                  .finally(() => setSaving(false))
                   .catch(showActionFailedToast);
               }}
             >
@@ -96,9 +99,23 @@ const ConvertMapModal = ({
                 version.
               </Box>
               <Flex sx={style.footer}>
-                <Button id="primary-action" sx={{ marginBottom: 3 }} type="submit">
-                  Yes, copy to my account
-                </Button>
+                {saving ? (
+                  <React.Fragment>
+                    <Spinner variant="spinner.large" sx={{ alignSelf: "center", mb: 4 }} />
+                    <Button
+                      id="primary-action"
+                      sx={{ marginBottom: 3 }}
+                      type="submit"
+                      disabled={true}
+                    >
+                      Converting
+                    </Button>
+                  </React.Fragment>
+                ) : (
+                  <Button id="primary-action" sx={{ marginBottom: 3 }} type="submit">
+                    Yes, copy to my account
+                  </Button>
+                )}
                 <Button
                   id="cancel-convert-map-modal"
                   onClick={hideModal}

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box, Flex, Text, jsx, ThemeUIStyleObject, Styled } from "theme-ui";
+import { Box, Button, Flex, Text, jsx, ThemeUIStyleObject, Styled } from "theme-ui";
 import bbox from "@turf/bbox";
 import { BBox2d } from "@turf/helpers/lib/geojson";
 
@@ -15,7 +15,8 @@ import {
   replaceSelectedGeounits,
   FindTool,
   setZoomToDistrictId,
-  PaintBrushSize
+  PaintBrushSize,
+  showConvertMapModal
 } from "../../actions/districtDrawing";
 import { getDistrictColor } from "../../constants/colors";
 import {
@@ -1023,8 +1024,13 @@ const DistrictsMap = ({
       </div>
       {!evaluateMode && isArchived && (
         <Box sx={style.archivedMessage}>
-          <Icon name="alert-triangle" /> This map is using an archived region and can no longer be
-          edited.
+          <Icon name="alert-triangle" /> This map is using an archived region for the 2010 Census
+          and can no longer be edited.
+          <Box>
+            <Button onClick={() => store.dispatch(showConvertMapModal(true))}>
+              Convert to 2020
+            </Button>
+          </Box>
         </Box>
       )}
       {evaluateMode && evaluateMetric && evaluateMetric.key === "countySplits" && (

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -19,6 +19,7 @@ import {
   setSelectionTool,
   showAdvancedEditingModal,
   showCopyMapModal,
+  showConvertMapModal,
   setImportFlagsModal,
   toggleDistrictLocked,
   undo,
@@ -114,6 +115,7 @@ export interface DistrictDrawingState {
   readonly paintBrushSize: PaintBrushSize;
   readonly showAdvancedEditingModal: boolean;
   readonly showCopyMapModal: boolean;
+  readonly showConvertMapModal: boolean;
   readonly showKeyboardShortcutsModal: boolean;
   readonly showImportFlagsModal: boolean;
   readonly findMenuOpen: boolean;
@@ -138,6 +140,7 @@ export const initialDistrictDrawingState: DistrictDrawingState = {
   paintBrushSize: 1,
   showAdvancedEditingModal: false,
   showCopyMapModal: false,
+  showConvertMapModal: false,
   showImportFlagsModal: false,
   showKeyboardShortcutsModal: false,
   findMenuOpen: false,
@@ -334,6 +337,11 @@ const districtDrawingReducer: LoopReducer<ProjectState, Action> = (
       return {
         ...state,
         showCopyMapModal: action.payload
+      };
+    case getType(showConvertMapModal):
+      return {
+        ...state,
+        showConvertMapModal: action.payload
       };
     case getType(setImportFlagsModal):
       return {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -39,6 +39,7 @@ import { useBeforeunload } from "react-beforeunload";
 import PageNotFoundScreen from "./PageNotFoundScreen";
 import SiteHeader from "../components/SiteHeader";
 import ProjectEvaluateSidebar from "../components/evaluate/ProjectEvaluateSidebar";
+import ConvertMapModal from "../components/ConvertMapModal";
 
 interface StateProps {
   readonly project?: IProject;
@@ -233,6 +234,7 @@ const ProjectScreen = ({
                 />
               )}
               <CopyMapModal project={project} />
+              <ConvertMapModal project={project} />
               <KeyboardShortcutsModal
                 isReadOnly={isReadOnly}
                 evaluateMode={evaluateMode}

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -11,14 +11,11 @@ import csvParse from "csv-parse";
 import { Express } from "express";
 
 import {
-  DistrictsDefinition,
-  GeoUnitHierarchy,
   ImportRowFlag,
   DistrictsImportApiResponse,
   DistrictImportField
 } from "../../../../shared/entities";
 import { FIPS } from "../../../../shared/constants";
-import {} from "../../../../shared/entities";
 import { TopologyService } from "../services/topology.service";
 
 import { RegionConfigsService } from "../../region-configs/services/region-configs.service";
@@ -44,7 +41,7 @@ export class DistrictsController {
     /* eslint-enable */
 
     // Array of flagged rows to be returned
-    let flaggedRows: ImportRowFlag[] = [];
+    const flaggedRows: ImportRowFlag[] = [];
 
     function setFlag(
       row: readonly string[],
@@ -53,6 +50,7 @@ export class DistrictsController {
       errorText: string
     ) {
       const flag = { rowNumber: rowNumber, errorText: errorText, rowValue: row, field: field };
+      // eslint-disable-next-line functional/immutable-data
       flaggedRows[rowNumber] = flag;
     }
     const stateFips: string = records[0][0]?.slice(0, 2);
@@ -67,7 +65,7 @@ export class DistrictsController {
     records.forEach((record, i) => {
       const rowFips = record[0]?.slice(0, 2);
       const blockId = record[0];
-      // eslint-disable-next-line
+      // eslint-disable-next-line functional/immutable-data
       blockIdCounts[blockId] = blockIdCounts[blockId] ? blockIdCounts[blockId] + 1 : 1;
       // Check to see if row fips is valid
       if (!(rowFips in FIPS)) {
@@ -114,7 +112,10 @@ export class DistrictsController {
     const districtsDefinition = geoCollection.importFromCSV(blockToDistricts);
 
     // Find unmatched records
-    const allBlockIds = new Set(baseGeoUnitProperties.map((props: any) => props[baseGeoLevel]));
+    const allBlockIds: Set<unknown> = new Set(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      baseGeoUnitProperties.map((props: any) => props[baseGeoLevel])
+    );
     records.forEach((record, i) => {
       if (!allBlockIds.has(record[0]) && !flaggedRows[i]) {
         setFlag(record, i, "BLOCKID", "Invalid block ID");

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -36,7 +36,7 @@ export class DistrictsController {
   async importCsv(@UploadedFile() file: Express.Multer.File): Promise<DistrictsImportApiResponse> {
     /* eslint-disable */
     const parser = csvParse(file.buffer, { fromLine: 2 });
-    let records = [];
+    let records: [string, string][] = [];
     // Seemingly the simplest way of getting all the records into an array is to iterate in a for-loop :(
     for await (const record of parser) {
       records.push(record);
@@ -45,8 +45,6 @@ export class DistrictsController {
 
     // Array of flagged rows to be returned
     let flaggedRows: ImportRowFlag[] = [];
-    let matchingRows: boolean[] = [];
-    let maxDistrictId: number = 0;
 
     function setFlag(
       row: readonly string[],
@@ -86,14 +84,10 @@ export class DistrictsController {
         setFlag(record, i, "BLOCKID", "Duplicate BLOCKID included in import");
       }
 
-      if (isNaN(record[1]) && !flaggedRows[i]) {
+      if (isNaN(Number(record[1])) && !flaggedRows[i]) {
         setFlag(record, i, "DISTRICT", "Invalid district ID, must be numeric");
       }
     });
-
-    const unflaggedRows = records.filter((record, i) => !flaggedRows[i]);
-
-    const blockToDistricts = Object.fromEntries(unflaggedRows);
 
     const regionCode = FIPS[stateFips];
     const regionConfig = await this.regionConfigService.findOne({
@@ -105,45 +99,31 @@ export class DistrictsController {
     if (!geoCollection) {
       throw new InternalServerErrorException();
     }
+    if (!("topology" in geoCollection)) {
+      // Only unarchived regions support imports
+      throw new InternalServerErrorException();
+    }
+
+    const unflaggedRows = records.filter((record, i) => !flaggedRows[i]);
     const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
     const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
 
-    // The geounit hierarchy and district definition have the same structure (except the
-    // hierarchy always goes out to the base geounit level), so we use it as a starting point
-    // and transform it into our districts definition.
-    const mapToDefinition = (hierarchySubset: GeoUnitHierarchy): DistrictsDefinition =>
-      hierarchySubset.map(hierarchyNumOrArray => {
-        if (typeof hierarchyNumOrArray === "number") {
-          // The numbers found in the hierarchy are the base geounit indices of the topology.
-          // Access this item in the topology to find it's base geounit id.
-          const props: any = baseGeoUnitProperties[hierarchyNumOrArray];
-          const id = props[baseGeoLevel];
-          const districtAssignment = parseInt(blockToDistricts[id], 10);
-          if (blockToDistricts[id]) {
-            // Allow editing of matching rows object
-            // eslint-disable-next-line
-            matchingRows[id] = true;
-          }
-          if (districtAssignment > maxDistrictId) {
-            maxDistrictId = districtAssignment;
-          }
-          return !isNaN(districtAssignment) ? districtAssignment : 0;
-        } else {
-          // Keep recursing into the hierarchy until we reach the end
-          const results = mapToDefinition(hierarchyNumOrArray);
-          // Simplify if possible
-          return results.every(item => item === results[0]) ? results[0] : results;
-        }
-      });
+    const blockToDistricts = Object.fromEntries(
+      unflaggedRows.map(([block, district]) => [block, Number(district)])
+    );
+    const districtsDefinition = geoCollection.importFromCSV(blockToDistricts);
 
-    const districtsDefinition = mapToDefinition(geoCollection.hierarchyDefinition);
     // Find unmatched records
+    const allBlockIds = new Set(baseGeoUnitProperties.map((props: any) => props[baseGeoLevel]));
     records.forEach((record, i) => {
-      if (!matchingRows[record[0]] && !flaggedRows[i]) {
+      if (!allBlockIds.has(record[0]) && !flaggedRows[i]) {
         setFlag(record, i, "BLOCKID", "Invalid block ID");
       }
     });
 
+    const maxDistrictId = Math.max(
+      ...districtsDefinition.flat(geoCollection.staticMetadata.geoLevels.length)
+    );
     const rowFlags = flaggedRows.filter(r => !!r);
 
     return {

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -27,7 +27,6 @@ import { getAllBaseIndices, getDemographics, getVoting } from "../../../../share
 import { DistrictsGeoJSON } from "../../projects/entities/project.entity";
 import { DistrictsDefinitionDto } from "./district-definition.dto";
 import { mapValues } from "lodash";
-import { GeoUnitProperties } from "./geo-unit-properties.entity";
 
 interface GeoUnitPolygonHierarchy {
   geom: Polygon | MultiPolygon;

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -25,7 +25,7 @@ interface Layers {
 export class TopologyService {
   private _layers?: Layers = undefined;
   private readonly logger = new Logger(TopologyService.name);
-  private s3 = new S3();
+  private readonly s3 = new S3();
 
   constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
     void repo.find().then(regionConfigs => {

--- a/src/server/src/projects/entities/crosswalk.entity.ts
+++ b/src/server/src/projects/entities/crosswalk.entity.ts
@@ -1,0 +1,10 @@
+export type FipsCode = string;
+
+export interface CrosswalkBlocks {
+  readonly fips: FipsCode;
+  readonly amount: number;
+}
+
+export default interface Crosswalk {
+  [newBlock: string]: readonly CrosswalkBlocks[];
+}

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../../shared/constants";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
 import { InternalServerErrorException, Logger } from "@nestjs/common";
+import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.entity";
 
 // TODO #179: Move to shared/entities
 export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
@@ -116,12 +117,12 @@ export class Project implements IProject {
     return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };
   }
 
-  exportToCsv(geoCollection: GeoUnitTopology): [number, number][] {
+  exportToCsv(geoCollection: GeoUnitTopology | GeoUnitProperties): [string, number][] {
     const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
     const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
 
     // First column is the base geounit id, second column is the district id
-    const mutableCsvRows: [number, number][] = [];
+    const mutableCsvRows: [string, number][] = [];
 
     // The geounit hierarchy and district definition have the same structure (except the
     // hierarchy always goes out to the base geounit level). Walk them both at the same time

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -6,7 +6,8 @@ import {
   DistrictProperties,
   DistrictsDefinition,
   IProject,
-  MetricField
+  MetricField,
+  GeoUnitHierarchy
 } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
@@ -16,9 +17,13 @@ import {
   DEFAULT_POPULATION_DEVIATION,
   DEFAULT_PINNED_METRIC_FIELDS
 } from "../../../../shared/constants";
+import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
+import { InternalServerErrorException, Logger } from "@nestjs/common";
 
 // TODO #179: Move to shared/entities
 export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
+
+const LOGGER = new Logger("Project");
 
 @Entity()
 export class Project implements IProject {
@@ -109,5 +114,45 @@ export class Project implements IProject {
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {
     return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };
+  }
+
+  exportToCsv(geoCollection: GeoUnitTopology): [number, number][] {
+    const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
+    const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
+
+    // First column is the base geounit id, second column is the district id
+    const mutableCsvRows: [number, number][] = [];
+
+    // The geounit hierarchy and district definition have the same structure (except the
+    // hierarchy always goes out to the base geounit level). Walk them both at the same time
+    // and collect the information needed for the CSV (base geounit id and district id).
+    const accumulateCsvRows = (
+      defnSubset: number | GeoUnitHierarchy,
+      hierarchySubset: GeoUnitHierarchy
+    ) => {
+      hierarchySubset.forEach((hierarchyNumOrArray, idx) => {
+        const districtOrArray = typeof defnSubset === "number" ? defnSubset : defnSubset[idx];
+        if (typeof districtOrArray === "number" && typeof hierarchyNumOrArray === "number") {
+          // The numbers found in the hierarchy are the base geounit indices of the topology.
+          // Access this item in the topology to find it's base geounit id.
+          const props: any = baseGeoUnitProperties[hierarchyNumOrArray];
+          mutableCsvRows.push([props[baseGeoLevel], districtOrArray]);
+        } else if (typeof hierarchyNumOrArray !== "number") {
+          // Keep recursing into the hierarchy until we reach the end
+          accumulateCsvRows(districtOrArray, hierarchyNumOrArray);
+        } else {
+          // This shouldn't ever happen, and would suggest a district definition/hierarchy mismatch
+          LOGGER.error(
+            "Hierarchy and districts definition mismatch",
+            districtOrArray.toString(),
+            hierarchyNumOrArray.toString()
+          );
+          throw new InternalServerErrorException();
+        }
+      });
+    };
+    accumulateCsvRows(this.districtsDefinition, geoCollection.hierarchyDefinition);
+
+    return mutableCsvRows;
   }
 }

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -1,16 +1,17 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
+import { ChambersModule } from "../chambers/chambers.module";
 import { DistrictsModule } from "../districts/districts.module";
+import { OrganizationsModule } from "../organizations/organizations.module";
+import { RegionConfigsModule } from "../region-configs/region-configs.module";
 import { UsersModule } from "../users/users.module";
 
-import { RegionConfigsModule } from "../region-configs/region-configs.module";
+import { GlobalProjectsController } from "./controllers/globalProjects.controller";
 import { ProjectsController } from "./controllers/projects.controller";
 import { Project } from "./entities/project.entity";
 import { ProjectsService } from "./services/projects.service";
-import { OrganizationsModule } from "../organizations/organizations.module";
-import { ChambersModule } from "../chambers/chambers.module";
-import { GlobalProjectsController } from "./controllers/globalProjects.controller";
+import { CrosswalkService } from "./services/crosswalk.service";
 
 @Module({
   imports: [
@@ -22,7 +23,7 @@ import { GlobalProjectsController } from "./controllers/globalProjects.controlle
     UsersModule
   ],
   controllers: [ProjectsController, GlobalProjectsController],
-  providers: [ProjectsService],
-  exports: [ProjectsService]
+  providers: [CrosswalkService, ProjectsService],
+  exports: [CrosswalkService, ProjectsService]
 })
 export class ProjectsModule {}

--- a/src/server/src/projects/services/crosswalk.service.ts
+++ b/src/server/src/projects/services/crosswalk.service.ts
@@ -21,8 +21,6 @@ export class CrosswalkService {
   private readonly logger = new Logger(CrosswalkService.name);
   private readonly s3 = new S3();
 
-  constructor() {}
-
   async getCrosswalk(regionCode: RegionCode): Promise<Crosswalk | undefined> {
     const stateFips = REGION_TO_FIPS[regionCode];
     const csvResponse = await this.s3
@@ -34,11 +32,13 @@ export class CrosswalkService {
       return;
     }
     const parser = csvParse(csvResponse.Body?.toString("utf8"), { relaxColumnCount: true });
-    let crosswalk: Crosswalk = {};
+    const crosswalk: Crosswalk = {};
+    // eslint-disable-next-line functional/no-loop-statement
     for await (const record of parser) {
       const items = record as readonly string[];
       const newFips = items[0];
       const blocks = _.chunk(items.slice(1), 2);
+      // eslint-disable-next-line functional/immutable-data
       crosswalk[newFips] = blocks.map(([fips, amount]) => ({ fips, amount: Number(amount) }));
     }
 

--- a/src/server/src/projects/services/crosswalk.service.ts
+++ b/src/server/src/projects/services/crosswalk.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from "@nestjs/common";
+import S3, { GetObjectRequest } from "aws-sdk/clients/s3";
+import csvParse from "csv-parse";
+import _ from "lodash";
+
+import Crosswalk from "../entities/crosswalk.entity";
+import { S3URI, RegionCode } from "../../../../shared/entities";
+import { REGION_TO_FIPS } from "../../../../shared/constants";
+
+const CROSSWALK_S3_FOLDER = "s3://global-districtbuilder-data-us-east-1/crosswalk-files/";
+
+function s3Options(path: S3URI, fileName: string): GetObjectRequest {
+  const url = new URL(path);
+  const pathWithoutLeadingSlash = url.pathname.substring(1);
+  const options = { Bucket: url.hostname, Key: `${pathWithoutLeadingSlash}${fileName}` };
+  return options;
+}
+
+@Injectable()
+export class CrosswalkService {
+  private readonly logger = new Logger(CrosswalkService.name);
+  private readonly s3 = new S3();
+
+  constructor() {}
+
+  async getCrosswalk(regionCode: RegionCode): Promise<Crosswalk | undefined> {
+    const stateFips = REGION_TO_FIPS[regionCode];
+    const csvResponse = await this.s3
+      .getObject(s3Options(CROSSWALK_S3_FOLDER, `block1020_crosswalk_${stateFips}.csv`))
+      .promise();
+
+    if (csvResponse.Body === undefined) {
+      this.logger.error("No crosswalk file found for ");
+      return;
+    }
+    const parser = csvParse(csvResponse.Body?.toString("utf8"), { relaxColumnCount: true });
+    let crosswalk: Crosswalk = {};
+    for await (const record of parser) {
+      const items = record as readonly string[];
+      const newFips = items[0];
+      const blocks = _.chunk(items.slice(1), 2);
+      crosswalk[newFips] = blocks.map(([fips, amount]) => ({ fips, amount: Number(amount) }));
+    }
+
+    return crosswalk;
+  }
+}

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -6,6 +6,7 @@ import { Repository, SelectQueryBuilder } from "typeorm";
 import { Project } from "../entities/project.entity";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { paginate, Pagination, IPaginationOptions } from "nestjs-typeorm-paginate";
+import { IProject } from "../../../../shared/entities";
 
 type AllProjectsOptions = IPaginationOptions & {
   readonly completed?: boolean;
@@ -18,7 +19,8 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
   constructor(@InjectRepository(Project) repo: Repository<Project>) {
     super(repo);
   }
-  save(project: Project): Promise<Project> {
+
+  save(project: Partial<Project>): Promise<Project> {
     // @ts-ignore
     return this.repo.save(project);
   }

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -6,7 +6,6 @@ import { Repository, SelectQueryBuilder } from "typeorm";
 import { Project } from "../entities/project.entity";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { paginate, Pagination, IPaginationOptions } from "nestjs-typeorm-paginate";
-import { IProject } from "../../../../shared/entities";
 
 type AllProjectsOptions = IPaginationOptions & {
   readonly completed?: boolean;

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -35,6 +35,9 @@ import * as _ from "lodash";
         persist: ["regionConfig"],
         eager: true
       }
+    },
+    filter: {
+      archived: false
     }
   },
   routes: {

--- a/src/server/src/region-configs/services/region-configs.service.ts
+++ b/src/server/src/region-configs/services/region-configs.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { CrudRequest, GetManyDefaultResponse, ParsedRequest } from "@nestjsx/crud";
 import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
-import { groupBy, last, map, sortBy } from "lodash";
 import { Repository } from "typeorm";
 
 import { RegionConfig } from "../entities/region-config.entity";

--- a/src/server/src/region-configs/services/region-configs.service.ts
+++ b/src/server/src/region-configs/services/region-configs.service.ts
@@ -7,34 +7,9 @@ import { Repository } from "typeorm";
 
 import { RegionConfig } from "../entities/region-config.entity";
 
-// eslint-disable functional/immutable-data
 @Injectable()
 export class RegionConfigsService extends TypeOrmCrudService<RegionConfig> {
   constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
     super(repo);
-  }
-
-  async getMany(
-    @ParsedRequest() req: CrudRequest
-  ): Promise<GetManyDefaultResponse<RegionConfig> | RegionConfig[]> {
-    const regionConfigs = await super.getMany(req);
-    if (!("length" in regionConfigs)) {
-      return regionConfigs;
-    }
-    return this.onlyLatestRegionConfigs(regionConfigs);
-  }
-
-  /*
-   * Only return latest version of each region config.
-   */
-  private onlyLatestRegionConfigs(regionConfigs: RegionConfig[]): RegionConfig[] {
-    return map(
-      groupBy(regionConfigs, (regionConfig: RegionConfig) => [
-        regionConfig.countryCode,
-        regionConfig.regionCode,
-        regionConfig.name
-      ]),
-      (regionConfigs: RegionConfig[]) => last(sortBy(regionConfigs, "version")) as RegionConfig
-    );
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,11 @@ export enum MakeDistrictsErrors {
   INVALID_DEFINITION = "INVALID_DEFINITION"
 }
 
+export enum ConvertProjectErrors {
+  REGION_NOT_ARCHIVED = "REGION_NOT_ARCHIVED",
+  NO_ACTIVE_REGION = "NO_ACTIVE_REGION"
+}
+
 export enum JoinOrganizationErrors {
   USER_NOT_FOUND = "USER_NOT_FOUND",
   ORGANIZATION_NOT_FOUND = "ORGANIZATION_NOT_FOUND"
@@ -113,6 +118,10 @@ export const FIPS: { readonly [fips: string]: string } = {
   "08": "CO",
   "09": "CT"
 };
+
+export const REGION_TO_FIPS = Object.fromEntries(
+  Object.entries(FIPS).map(([fips, state]) => [state, fips])
+);
 
 // Maximum allowable upload size, in bytes
 export const MaxUploadFileSize = 25_000_000;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -164,12 +164,13 @@ export type RegionConfigId = string;
 
 export type S3URI = string;
 export type HttpsURI = string;
+export type RegionCode = string;
 
 export interface IRegionConfig {
   readonly id: RegionConfigId;
   readonly name: string;
   readonly countryCode: string;
-  readonly regionCode: string;
+  readonly regionCode: RegionCode;
   readonly chambers: readonly IChamber[];
   readonly s3URI: S3URI;
   readonly version: Date;


### PR DESCRIPTION
## Overview

This adds a button to projects for archived 2010 regions, allowing them to be converted to new 2020 regions.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

2010 map:
![image](https://user-images.githubusercontent.com/4432106/127708923-4edc2c3b-d025-4447-83b6-0fe60775edc6.png)

Converted map:
![image](https://user-images.githubusercontent.com/4432106/127709097-5a5c3d82-c984-4e5e-9fb3-375d31eaeec4.png)

### Notes

The conversion process _mostly_ worked for the state I tested (DE), but note the 5 clearly incorrectly assigned blocks (4 of which have 0 population?), which I'm assuming is a data quality issue with the crosswalk file we need to look into further.

Overall the file format was more complex than I had initially assumed, and our conversion process is going to be inherently lossy, as census block boundaries don't entirely align from 1 census to the next.

## Testing Instructions

- Create a plan for a region that is on both our [2010 states list](https://docs.google.com/spreadsheets/d/1NW7P_W23OIFrMGKVvvQpaj2CbaXZfmxBFcgQU92i-08/edit#gid=0) currently on production as well as our [list of 2020 states w/ 2019 ACS data](https://docs.google.com/spreadsheets/d/1khiNAQp4UnfkgfvRSbfjDU9CU2zJrJ0pMRUeF5a4cuM/edit#gid=0), using a region configured w/ '10 data
- Using `scripts/dbshell`, set `ARCHIVED = TRUE` for that region, and create a new '20 region (I used DE for this, but it would be good to test some other states)
- There should be "Convert to 2020" button on your plan, clicking it should open a modal, which upon confirmation should create a copy of your map converted to work w/ 2020 block data

Closes #815 
