### PR TITLE
Clean up import error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased timeout on database healthcheck [#877](https://github.com/PublicMapping/districtbuilder/pull/877)
 - Fix archive not updating list of projects [#892](https://github.com/PublicMapping/districtbuilder/pull/892)
 - Redirect to home screen after successful login [#895](https://github.com/PublicMapping/districtbuilder/pull/895)
+- Improved handling large number of import flags [#888](https://github.com/PublicMapping/districtbuilder/pull/888)
+
 
 ## [1.6.0] - 2021-05-24
 

--- a/src/client/components/ImportFlagsModal.tsx
+++ b/src/client/components/ImportFlagsModal.tsx
@@ -8,6 +8,7 @@ import { setImportFlagsModal } from "../actions/districtDrawing";
 import { State } from "../reducers";
 import store from "../store";
 import { ImportRowFlag } from "../../shared/entities";
+import { MAX_IMPORT_ERRORS } from "../../shared/constants";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -47,11 +48,13 @@ const style: ThemeUIStyleObject = {
 
 const ImportFlagsModal = ({
   importFlags,
+  numFlags,
   showModal,
   onContinue,
   onCancel
 }: {
   readonly importFlags: readonly ImportRowFlag[];
+  readonly numFlags: number;
   readonly showModal: boolean;
   readonly onContinue: () => void;
   readonly onCancel: () => void;
@@ -70,13 +73,19 @@ const ImportFlagsModal = ({
     >
       <Box sx={style.modal}>
         <Heading sx={style.heading}>
-          There are {importFlags.length} rows with flags in your import{" "}
+          There are {numFlags > importFlags.length ? `${MAX_IMPORT_ERRORS}+` : numFlags} rows with
+          flags in your import{" "}
         </Heading>
         <Box>
           We were able to read your block equivalency file, but we ran into a few issues. Please
           review the flags below and decide if you want to continue with this file or start over
           with a new file.
         </Box>
+        {numFlags > importFlags.length && (
+          <Box sx={{ pt: 2 }}>
+            Displaying the first <b>{importFlags.length}</b> of <b>{numFlags}</b> errors
+          </Box>
+        )}
         <Box sx={style.flags}>
           {importFlags.map(flag => (
             <Box key={flag.rowNumber}>

--- a/src/client/components/ImportFlagsModal.tsx
+++ b/src/client/components/ImportFlagsModal.tsx
@@ -41,7 +41,8 @@ const style: ThemeUIStyleObject = {
   },
   button: {
     mr: "3"
-  }
+  },
+  flags: { marginTop: 4, maxHeight: "60vh", overflowY: "scroll" }
 };
 
 const ImportFlagsModal = ({
@@ -76,7 +77,7 @@ const ImportFlagsModal = ({
           review the flags below and decide if you want to continue with this file or start over
           with a new file.
         </Box>
-        <Box style={{ marginTop: 4 }}>
+        <Box sx={style.flags}>
           {importFlags.map(flag => (
             <Box key={flag.rowNumber}>
               <Box>

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -17,13 +17,13 @@ import {
   Radio
 } from "theme-ui";
 
-import { DEFAULT_POPULATION_DEVIATION, FIPS, MaxUploadFileSize } from "../../shared/constants";
+import { DEFAULT_POPULATION_DEVIATION, FIPS, MAX_UPLOAD_FILE_SIZE } from "../../shared/constants";
 import {
   DistrictsDefinition,
-  ImportRowFlag,
   IProject,
   IRegionConfig,
-  IChamber
+  IChamber,
+  DistrictsImportApiSuccess
 } from "../../shared/entities";
 
 import { regionConfigsFetch } from "../actions/regionConfig";
@@ -42,13 +42,11 @@ interface StateProps {
   readonly regionConfigs: Resource<readonly IRegionConfig[]>;
 }
 
-const validate = (
-  form: ConfigurableForm,
-  importResource: ImportResource,
-  maxDistrictId?: number
-): ProjectForm => {
+const validate = (form: ConfigurableForm, importResource: ImportResource): ProjectForm => {
   const regionConfig = importResource.data;
-  const districtsDefinition = "resource" in importResource ? importResource.resource : null;
+  const districtsDefinition =
+    "resource" in importResource ? importResource.resource.districtsDefinition : null;
+  const maxDistrictId = "resource" in importResource ? importResource.resource.maxDistrictId : null;
   const numberOfDistricts = form.numberOfDistricts;
   const populationDeviation = form.populationDeviation;
   const chamber = form.chamber;
@@ -79,7 +77,7 @@ const validate = (
       };
 };
 
-type ImportResource = WriteResource<IRegionConfig | null, DistrictsDefinition>;
+type ImportResource = WriteResource<IRegionConfig | null, DistrictsImportApiSuccess>;
 
 interface ConfigurableForm {
   readonly numberOfDistricts: number | null;
@@ -238,8 +236,10 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
   const [importResource, setImportResource] = useState<ImportResource>({
     data: null
   });
-  const [rowFlags, setRowFlags] = useState<readonly ImportRowFlag[] | undefined>(undefined);
-  const [maxDistrictId, setMaxDistrictId] = useState<number | undefined>(undefined);
+  const rowFlags = "resource" in importResource && importResource.resource.rowFlags;
+  const maxDistrictId = "resource" in importResource && importResource.resource.maxDistrictId;
+  const numFlags = "resource" in importResource && importResource.resource.numFlags;
+
   const [createProjectResource, setCreateProjectResource] = useState<
     WriteResource<ConfigurableForm, IProject>
   >({
@@ -272,8 +272,8 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
     (file: File) => {
       async function setConfigFromFile() {
         if (file && "resource" in regionConfigs) {
-          // Check file size (must be less than MaxUploadFileSize)
-          if (file.size > MaxUploadFileSize) {
+          // Check file size (must be less than MAX_UPLOAD_FILE_SIZE)
+          if (file.size > MAX_UPLOAD_FILE_SIZE) {
             setFileError("File must be less than 25mb");
             return;
           }
@@ -318,10 +318,8 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
             } else {
               setImportResource({
                 data: regionConfig,
-                resource: importResponse.districtsDefinition
+                resource: importResponse
               });
-              importResponse.rowFlags && setRowFlags(importResponse.rowFlags);
-              importResponse.maxDistrictId && setMaxDistrictId(importResponse.maxDistrictId);
             }
           }
         }
@@ -363,10 +361,8 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
       data: null
     });
     setImportFlagsModal(false);
-    setRowFlags(undefined);
     setFileError(undefined);
     setCreateProjectResource({ data: blankForm });
-    setMaxDistrictId(undefined);
   }
 
   return "resource" in createProjectResource ? (
@@ -405,7 +401,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
             sx={{ flexDirection: "column" }}
             onSubmit={(e: React.FormEvent) => {
               e.preventDefault();
-              const validatedForm = validate(formData, importResource, maxDistrictId);
+              const validatedForm = validate(formData, importResource);
               if (validatedForm.valid === true) {
                 setCreateProjectResource({ data: formData, isPending: true });
                 createProject({
@@ -448,16 +444,16 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                       : style.uploadSuccessWithFlags
                   }
                 >
-                  {"resource" in importResource && !rowFlags && !fileError ? (
+                  {"resource" in importResource && !numFlags && !fileError ? (
                     <b>Upload success</b>
-                  ) : "resource" in importResource && rowFlags ? (
+                  ) : "resource" in importResource && numFlags ? (
                     <b>
                       Upload success, with
                       <span
                         sx={style.rowFlagsLink}
                         onClick={() => rowFlags && store.dispatch(setImportFlagsModal(true))}
                       >
-                        &nbsp;{rowFlags.length} flags
+                        &nbsp;{numFlags} flags
                       </span>
                     </b>
                   ) : fileError ? (
@@ -636,7 +632,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
                   <Button
                     type="submit"
                     disabled={
-                      !validate(formData, importResource, maxDistrictId).valid &&
+                      !validate(formData, importResource).valid &&
                       !("errorMessage" in createProjectResource)
                     }
                   >
@@ -651,6 +647,7 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
       {rowFlags && (
         <ImportFlagsModal
           importFlags={rowFlags}
+          numFlags={numFlags || 0}
           onContinue={() => store.dispatch(setImportFlagsModal(false))}
           onCancel={() => resetForm()}
         ></ImportFlagsModal>

--- a/src/server/migrations/1628016680955-region_census_year.ts
+++ b/src/server/migrations/1628016680955-region_census_year.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class regionCensusYear1628016680955 implements MigrationInterface {
+    name = 'regionCensusYear1628016680955'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."region_config_census_enum" AS ENUM('2010', '2020')`);
+        await queryRunner.query(`ALTER TABLE "public"."region_config" ADD "census" "public"."region_config_census_enum"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."region_config" DROP COLUMN "census"`);
+        await queryRunner.query(`DROP TYPE "public"."region_config_census_enum"`);
+    }
+
+}

--- a/src/server/migrations/1628016841545-region_census_year_defaults.ts
+++ b/src/server/migrations/1628016841545-region_census_year_defaults.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class regionCensusYear1628016841545 implements MigrationInterface {
+  name = "regionCensusYear1628016841545";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // This is the list of 2020 states that have been processed as-of writing this migration
+    await queryRunner.query(`
+        UPDATE region_config SET census = CASE WHEN s3_uri = ANY('{
+        s3://global-districtbuilder-dev-us-east-1/regions/US/AK/2021-06-18T14:24:11.337Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/AZ/2021-07-01T15:29:22.217Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/CO/2021-06-30T16:20:02.781Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/DC/2021-06-12T00:25:53.517Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/DE/2021-06-11T23:03:36.938Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/GA/2021-06-30T17:12:22.649Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/HI/2021-06-18T15:51:03.204Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/IA/2021-06-12T14:45:27.207Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/ID/2021-06-12T14:48:46.371Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/IL/2021-06-04T15:05:37.089Z,
+s3://global-districtbuilder-dev-us-east-1/regions/US/KS/2021-06-12T14:50:54.971Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/LA/2021-06-12T14:53:58.291Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/ME/2021-06-30T17:27:46.642Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/MI/2021-06-21T20:10:55.297Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/MN/2021-06-12T14:56:57.316Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/MT/2021-06-18T21:11:45.923Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/NV/2021-06-30T18:34:44.920Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/NH/2021-06-12T15:01:01.278Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/NC/2021-06-30T18:13:40.821Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/OH/2021-06-12T15:02:06.107Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/OK/2021-06-12T15:06:56.221Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/RI/2021-06-12T15:10:22.621Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/SC/2021-06-12T15:11:15.083Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/UT/2021-06-30T18:55:51.375Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/VT/2021-06-29T20:38:26.744Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-06-18T17:42:56.629Z/,
+s3://global-districtbuilder-dev-us-east-1/regions/US/WY/2021-06-17T20:44:48.259Z/}'::text[])
+        THEN '2020'::region_config_census_enum ELSE '2010'::region_config_census_enum END
+        `);
+    await queryRunner.query(
+      `ALTER TABLE "public"."region_config" ALTER COLUMN "census" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "public"."region_config" ALTER COLUMN "census" SET DEFAULT '2020'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "public"."region_config" ALTER COLUMN "census" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "public"."region_config" ALTER COLUMN "census" DROP NOT NULL`
+    );
+  }
+}

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -19,7 +19,6 @@ import { FIPS, MAX_IMPORT_ERRORS } from "../../../../shared/constants";
 import { TopologyService } from "../services/topology.service";
 
 import { RegionConfigsService } from "../../region-configs/services/region-configs.service";
-import _ from "lodash";
 
 @Controller("api/districts")
 export class DistrictsController {

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -15,7 +15,7 @@ import {
   DistrictsImportApiResponse,
   DistrictImportField
 } from "../../../../shared/entities";
-import { FIPS } from "../../../../shared/constants";
+import { FIPS, MAX_IMPORT_ERRORS } from "../../../../shared/constants";
 import { TopologyService } from "../services/topology.service";
 
 import { RegionConfigsService } from "../../region-configs/services/region-configs.service";
@@ -126,11 +126,13 @@ export class DistrictsController {
       ...districtsDefinition.flat(geoCollection.staticMetadata.geoLevels.length)
     );
     const rowFlags = flaggedRows.filter(r => !!r);
+    const numFlags = rowFlags.length;
 
     return {
-      districtsDefinition: districtsDefinition,
-      maxDistrictId: maxDistrictId,
-      rowFlags: rowFlags.length > 0 ? rowFlags : undefined
+      districtsDefinition,
+      maxDistrictId,
+      numFlags: numFlags || undefined,
+      rowFlags: numFlags > 0 ? rowFlags.slice(0, MAX_IMPORT_ERRORS) : undefined
     };
   }
 }

--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -10,6 +10,7 @@ import {
 import { IRegionConfig } from "../../../../shared/entities";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
+import { CensusDate } from "../../../../shared/constants";
 
 @Entity()
 @Unique(["name", "countryCode", "regionCode", "version"])
@@ -54,4 +55,7 @@ export class RegionConfig implements IRegionConfig {
   // Archived regions are hidden, and also do not have data loaded and so their projects cannot be edited
   @Column({ type: "boolean", default: false })
   archived: boolean;
+
+  @Column({ type: "enum", enum: CensusDate, default: CensusDate.Census2020 })
+  census: CensusDate;
 }

--- a/src/server/test/districts.controller.e2e-spec.ts
+++ b/src/server/test/districts.controller.e2e-spec.ts
@@ -61,6 +61,8 @@ describe("DistrictsController", () => {
         .expect(200)
         .expect({
           districtsDefinition: [2, 1, 3],
+          maxDistrictId: 3,
+          numFlags: 1,
           rowFlags: [
             {
               rowNumber: 0,
@@ -68,8 +70,7 @@ describe("DistrictsController", () => {
               rowValue: ["100059900000024", "3"],
               field: "BLOCKID"
             }
-          ],
-          maxDistrictId: 3
+          ]
         });
     });
   });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -49,6 +49,11 @@ export enum ProjectVisibility {
   Published = "PUBLISHED"
 }
 
+export enum CensusDate {
+  Census2010 = "2010",
+  Census2020 = "2020"
+}
+
 export const DEFAULT_POPULATION_DEVIATION = 5;
 
 export const DEFAULT_PINNED_METRIC_FIELDS = [

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -124,6 +124,8 @@ export const REGION_TO_FIPS = Object.fromEntries(
 );
 
 // Maximum allowable upload size, in bytes
-export const MaxUploadFileSize = 25_000_000;
+export const MAX_UPLOAD_FILE_SIZE = 25_000_000;
+
+export const MAX_IMPORT_ERRORS = 1_000;
 
 export const REGION_LABELS = ["election"] as const;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -306,6 +306,7 @@ export interface ImportRowFlag {
 export interface DistrictsImportApiResponse {
   readonly districtsDefinition?: DistrictsDefinition;
   readonly rowFlags?: readonly ImportRowFlag[];
+  readonly numFlags?: number;
   readonly maxDistrictId: number;
 }
 

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -303,12 +303,18 @@ export interface ImportRowFlag {
   readonly rowValue: readonly string[];
 }
 
-export interface DistrictsImportApiResponse {
-  readonly districtsDefinition?: DistrictsDefinition;
+export interface DistrictsImportApiError {
+  readonly error: string;
+}
+
+export interface DistrictsImportApiSuccess {
+  readonly districtsDefinition: DistrictsDefinition;
   readonly rowFlags?: readonly ImportRowFlag[];
   readonly numFlags?: number;
   readonly maxDistrictId: number;
 }
+
+export type DistrictsImportApiResponse = DistrictsImportApiSuccess | DistrictsImportApiError;
 
 export interface PlanScoreAPIResponse {
   readonly index_url: string;


### PR DESCRIPTION
## Overview

Imports were returning such large numbers of errors that it was generating `PayloadTooLargeError` errors. It seems this was _mostly_ due to invalid block IDs from using 2020 block equivalency files for (likely exported from another tool, such as Dave's Redistricting) for a state for which we have 2010 data.

I addressed this specific case by marking an excessive number of invalid block IDs w/ the correct state FIPs as file-level error and include the expected census year in returned error.

In addition to that, I _also_ added a cut-off for the number of flags, displaying only the first 1000, and I cleaned up the flags modal to correctly scroll when there are  large number of flags.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_import-project](https://user-images.githubusercontent.com/4432106/128085007-c2853ad6-1f1b-41b8-8e56-d7cb46247b9a.png)

![localhost_3003_import-project (1)](https://user-images.githubusercontent.com/4432106/128085016-30872878-aeb7-4649-b373-b425472ca8e1.png)

## Testing Instructions

- Set up a NJ region using 2010 data (`s3://global-districtbuilder-dev-us-east-1/regions/US/NJ/2020-09-09T14:19:50.625Z/`)
- Attempt to upload this file https://github.com/PublicMapping/districtbuilder/files/6804154/nj_congress_bef.zip

To test the cut-off flags, I commented out the new check for invalid blocks over certain size

Closes #846 
