### PR TITLE
Clean up Home Screen project handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved padding in the sidebar district rows, which had become unbalanced [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Keyboard shortcuts no longer fire when form elements are focused [#823](https://github.com/PublicMapping/districtbuilder/pull/823)
 - Fix breaking change to routing introduced with QueryParamsProvider [#869](https://github.com/PublicMapping/districtbuilder/pull/869)
-- Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
+- Fix duplicate project button on home screen projects [#872](https://github.com/PublicMapping/districtbuilder/pull/872) & [#892](https://github.com/PublicMapping/districtbuilder/pull/892)
 - Fix find menu button so that it actually opens the find menu [#871](https://github.com/PublicMapping/districtbuilder/pull/871)
 - Show file error when attempting to import a CSV for an unsupported region [#875](https://github.com/PublicMapping/districtbuilder/pull/875)
 - Increased timeout on database healthcheck [#877](https://github.com/PublicMapping/districtbuilder/pull/877)
+- Fix archive not updating list of projects [#892](https://github.com/PublicMapping/districtbuilder/pull/892)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -158,6 +158,15 @@ export async function convertAndCopyProject(id: ProjectId): Promise<IProject> {
   });
 }
 
+export async function copyProject(id: ProjectId): Promise<IProject> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/projects/${id}/duplicate`)
+      .then(response => resolve(response.data))
+      .catch(error => reject(error.response?.data || error));
+  });
+}
+
 async function fetchProject(id: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios

--- a/src/client/components/CopyMapModal.tsx
+++ b/src/client/components/CopyMapModal.tsx
@@ -8,7 +8,7 @@ import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
 import { IProject, IUser } from "../../shared/entities";
 import { showCopyMapModal } from "../actions/districtDrawing";
 import { resetProjectState } from "../actions/root";
-import { createProject } from "../api";
+import { copyProject } from "../api";
 import { showActionFailedToast } from "../functions";
 import { State } from "../reducers";
 import store from "../store";
@@ -77,11 +77,7 @@ const CopyMapModal = ({
               sx={{ flexDirection: "column" }}
               onSubmit={(e: React.FormEvent) => {
                 e.preventDefault();
-                createProject({
-                  ...project,
-                  name: `Copy of ${attributedName}`,
-                  chamber: project.chamber || undefined
-                })
+                copyProject(project.id)
                   .then((project: IProject) => {
                     setCreateProjectResource({ resource: project });
 

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -58,7 +58,8 @@ import {
   fetchProjectData,
   fetchProjectGeoJson,
   createProject,
-  patchProject
+  patchProject,
+  copyProject
 } from "../api";
 import { fetchAllStaticData } from "../s3";
 
@@ -464,13 +465,10 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
           saving: "saving",
           duplicatedProject: null
         },
-        Cmd.run(
-          () => createProject({ ...action.payload, name: `Copy of ${action.payload.name}` }),
-          {
-            successActionCreator: duplicateProjectSuccess,
-            failActionCreator: duplicateProjectFailure
-          }
-        )
+        Cmd.run(() => copyProject(action.payload.id), {
+          successActionCreator: duplicateProjectSuccess,
+          failActionCreator: duplicateProjectFailure
+        })
       );
     }
     case getType(duplicateProjectSuccess):

--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -173,29 +173,16 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
         })
       );
     case getType(projectArchiveSuccess):
-      return {
-        deleteProject: undefined,
-        archiveProjectPending: false,
-        globalProjectsPagination: state.globalProjectsPagination,
-        userProjectsPagination: state.userProjectsPagination,
-        projects:
-          "resource" in state.projects
-            ? {
-                resource: state.projects.resource.map(project =>
-                  project.id !== action.payload.id ? project : action.payload
-                )
-              }
-            : state.projects,
-        globalProjectsRegion: state.globalProjectsRegion,
-        globalProjects:
-          "resource" in state.globalProjects
-            ? {
-                resource: state.globalProjects.resource.map(project =>
-                  project.id !== action.payload.id ? project : action.payload
-                )
-              }
-            : state.globalProjects
-      };
+      return loop(
+        {
+          ...state,
+          deleteProject: undefined,
+          archiveProjectPending: false,
+          globalProjectsPagination: initialState.globalProjectsPagination,
+          globalProjects: initialState.globalProjects
+        },
+        Cmd.action(userProjectsFetchPage(state.userProjectsPagination.currentPage))
+      );
     case getType(projectArchiveFailure):
       return loop({ ...state, archiveProjectPending: false }, Cmd.run(showResourceFailedToast));
     default:

--- a/src/server/migrations/1628170922516-rename_project_fields_to_match_convention.ts
+++ b/src/server/migrations/1628170922516-rename_project_fields_to_match_convention.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class renameProjectFieldsToMatchConvention1628170922516 implements MigrationInterface {
+    name = 'renameProjectFieldsToMatchConvention1628170922516'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" RENAME COLUMN "advancedEditingEnabled" TO "advanced_editing_enabled"`);
+        await queryRunner.query(`ALTER TABLE "project" RENAME COLUMN "isFeatured" TO "is_featured"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" RENAME COLUMN "advanced_editing_enabled" TO "advancedEditingEnabled"`);
+        await queryRunner.query(`ALTER TABLE "project" RENAME COLUMN "is_featured" TO "isFeatured"`);
+    }
+
+}

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -287,8 +287,8 @@ export class ProjectsController implements CrudController<Project> {
     };
   }
 
-  @Override()
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(CrudRequestInterceptor)
   @Post(":id/duplicate")
   async duplicate(@ParsedRequest() req: CrudRequest, @Param("id") id: ProjectId): Promise<Project> {
     try {
@@ -311,8 +311,7 @@ export class ProjectsController implements CrudController<Project> {
         isFeatured: undefined
       };
 
-      return await this.service.createOne(
-        req,
+      return await this.service.save(
         await this.formatCreateProjectDto(dto, geoCollection, project.regionConfig, req)
       );
     } catch (error) {

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -253,23 +253,68 @@ export class ProjectsController implements CrudController<Project> {
         );
       }
 
-      // Districts definition is optional. Use it if supplied, otherwise use all-unassigned.
-      const districtsDefinition =
-        dto.districtsDefinition || new Array(geoCollection.hierarchy.length).fill(0);
-      const lockedDistricts = new Array(dto.numberOfDistricts).fill(false);
-      const districts = await this.getGeojson({
-        numberOfDistricts: dto.numberOfDistricts,
-        districtsDefinition,
-        regionConfig
-      });
+      return await this.service.createOne(
+        req,
+        await this.formatCreateProjectDto(dto, geoCollection, regionConfig, req)
+      );
+    } catch (error) {
+      this.logger.error(`Error creating project: ${error}`);
+      throw new InternalServerErrorException();
+    }
+  }
 
-      return this.service.createOne(req, {
-        ...dto,
-        districtsDefinition,
-        districts,
-        lockedDistricts,
-        user: req.parsed.authPersist.userId
-      });
+  private async formatCreateProjectDto(
+    dto: CreateProjectDto,
+    geoCollection: GeoUnitTopology | GeoUnitProperties,
+    regionConfig: RegionConfig,
+    req: CrudRequest
+  ) {
+    // Districts definition is optional. Use it if supplied, otherwise use all-unassigned.
+    const districtsDefinition =
+      dto.districtsDefinition || new Array(geoCollection.hierarchy.length).fill(0);
+    const lockedDistricts = new Array(dto.numberOfDistricts).fill(false);
+    const districts = await this.getGeojson({
+      numberOfDistricts: dto.numberOfDistricts,
+      districtsDefinition,
+      regionConfig
+    });
+    return {
+      ...dto,
+      districtsDefinition,
+      districts,
+      lockedDistricts,
+      user: req.parsed.authPersist.userId
+    };
+  }
+
+  @Override()
+  @UseGuards(JwtAuthGuard)
+  @Post(":id/duplicate")
+  async duplicate(@ParsedRequest() req: CrudRequest, @Param("id") id: ProjectId): Promise<Project> {
+    try {
+      const project = await this.getProject(req, id);
+      const geoCollection = await this.topologyService.get(project.regionConfig.s3URI);
+      if (!geoCollection) {
+        throw new NotFoundException(
+          `Topology ${project.regionConfig.s3URI} not found`,
+          MakeDistrictsErrors.TOPOLOGY_NOT_FOUND
+        );
+      }
+      // Set any fields we don't want duplicated to be undefined
+      const dto = {
+        ...project,
+        name: `Copy of ${project.name}`,
+        id: undefined,
+        user: undefined,
+        createdDt: undefined,
+        updatedDt: undefined,
+        isFeatured: undefined
+      };
+
+      return await this.service.createOne(
+        req,
+        await this.formatCreateProjectDto(dto, geoCollection, project.regionConfig, req)
+      );
     } catch (error) {
       this.logger.error(`Error creating project: ${error}`);
       throw new InternalServerErrorException();

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -33,7 +33,7 @@ export class CreateProjectDto implements CreateProjectData {
   @Min(0, { message: "Population deviation must be between 0% and 100%" })
   readonly populationDeviation: number;
   @IsOptional()
-  readonly chamber: ChamberIdDto;
+  readonly chamber?: ChamberIdDto;
   @IsOptional()
-  readonly projectTemplate: ProjectTemplateIdDto;
+  readonly projectTemplate?: ProjectTemplateIdDto;
 }

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -77,7 +77,7 @@ export class Project implements IProject {
   })
   updatedDt: Date;
 
-  @Column({ type: "boolean", default: false })
+  @Column({ type: "boolean", default: false, name: "advanced_editing_enabled" })
   advancedEditingEnabled: boolean;
 
   @Column({
@@ -94,7 +94,7 @@ export class Project implements IProject {
   @Column({ type: "boolean", default: false })
   archived: boolean;
 
-  @Column({ type: "boolean", default: false })
+  @Column({ type: "boolean", default: false, name: "is_featured" })
   isFeatured: boolean;
 
   @Column({

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -27,13 +27,13 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
   getProjectsBase(): SelectQueryBuilder<Project> {
     return this.repo
       .createQueryBuilder("project")
-      .innerJoinAndSelect("project.regionConfig", "regionConfig")
-      .innerJoinAndSelect("project.user", "user")
-      .leftJoinAndSelect("project.chamber", "chamber")
+      .innerJoin("project.regionConfig", "regionConfig")
+      .innerJoin("project.user", "user")
+      .leftJoin("project.chamber", "chamber")
       .select([
         "project.id",
-        "project.numberOfDistricts",
         "project.name",
+        "project.numberOfDistricts",
         "project.updatedDt",
         "project.createdDt",
         "project.districts",
@@ -67,9 +67,10 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
     userId: string,
     options: AllProjectsOptions
   ): Promise<Pagination<Project>> {
-    const builder = this.getProjectsBase()
-      .addSelect("project.districtsDefinition")
-      .andWhere("project.archived = FALSE AND user.id = :userId", { userId });
+    const builder = this.getProjectsBase().andWhere(
+      "project.archived = FALSE AND user.id = :userId",
+      { userId }
+    );
 
     return paginate<Project>(builder, options);
   }

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
-import { Repository, SelectQueryBuilder } from "typeorm";
+import { Repository, SelectQueryBuilder, DeepPartial } from "typeorm";
 
 import { Project } from "../entities/project.entity";
 import { ProjectVisibility } from "../../../../shared/constants";
@@ -19,7 +19,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
     super(repo);
   }
 
-  save(project: Partial<Project>): Promise<Project> {
+  save(project: DeepPartial<Project>): Promise<Project> {
     // @ts-ignore
     return this.repo.save(project);
   }


### PR DESCRIPTION
## Overview

In the course of investigating #881 I encountered two issues:
 - Duplicated projects lost their `projectTemplate` reference
 - Archiving a project would cause the page it was on to lose items. Archiving all projects on the page would cause it to revert to the "No projects" state you see when you first join
 
 I fixed the first by creating a new project duplicate endpoint (I explored adding the missing fields to the SQL query in `ProjectsService` but decided this way was less brittle, as we won't need to update it as we add new fields.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- On the Home Screen, duplicate a project that is visible & associated w/ and organization `ProjectTemplate`. The duplicate project should appear on the Organization Admin screen.
- Archive a project from the Home Screen - the list of projects should refresh but maintain your current page

