### PR TITLE
Show unassigned district on project minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add populationDeviation and chamber to import project screen [#845](https://github.com/PublicMapping/districtbuilder/pull/845)
 - Add filter by state functionality to community maps page [#851](https://github.com/PublicMapping/districtbuilder/pull/851)
 - Add button to upload project to PlanScore via API [#847](https://github.com/PublicMapping/districtbuilder/pull/847)
-- Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850)
+- Add maps to list of user projects on home screen [#850](https://github.com/PublicMapping/districtbuilder/pull/850) & [#893](https://github.com/PublicMapping/districtbuilder/pull/893)
 - Add histogram to evaluate mode metric view for competitiveness [#844](https://github.com/PublicMapping/districtbuilder/pull/844)
 - Added button to convert 2010 maps to 2020 [#878](https://github.com/PublicMapping/districtbuilder/pull/878)
 

--- a/src/client/components/map/ProjectDistrictsMap.tsx
+++ b/src/client/components/map/ProjectDistrictsMap.tsx
@@ -46,8 +46,11 @@ const ProjectDistrictsMap = ({
     }
 
     districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
-      // eslint-disable-next-line
-      feature.properties.color = getDistrictColor(id);
+      // On the main project screen the unassigned district isn't colored in,
+      // but for the minimap we need it to be visible to define the state borders
+
+      // eslint-disable-next-line functional/immutable-data
+      feature.properties.color = id === 0 ? "#EDEDED" : getDistrictColor(id);
     });
 
     const bounds = districts && (bbox(districts) as BBox2d);


### PR DESCRIPTION
## Overview

Show unassigned district on project minimap, in order to ensure state borders are visible.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/128365221-be4ead4e-7765-43cd-afd7-39f2bff8109a.png)


## Testing Instructions

- `scripts/server`

Closes #873
