### PR TITLE
Hide competitiveness summary when there's no voting info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Display evaluate mode toggle button in read-only mode [#786](https://github.com/PublicMapping/districtbuilder/pull/786)
 - Disable keyboard shortcuts in evaluate mode [#784](https://github.com/PublicMapping/districtbuilder/pull/784)
+- Only show competitiveness summary in evaluate sidebar if elections data is available [#896](https://github.com/PublicMapping/districtbuilder/pull/896)
 - Ignore unassigned districts when computing flag for Contiguity and Equal Population [#797](https://github.com/PublicMapping/districtbuilder/pull/797)
 - Rename Support menu to Resources [#787](https://github.com/PublicMapping/districtbuilder/pull/787)
 - Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)

--- a/src/client/actions/districtDrawing.ts
+++ b/src/client/actions/districtDrawing.ts
@@ -1,6 +1,6 @@
 import { createAction } from "typesafe-actions";
 import { DistrictId, GeoUnits } from "../../shared/entities";
-import { SavingState, ElectionYear, EvaluateMetric } from "../types";
+import { SavingState, ElectionYear, EvaluateMetricWithValue } from "../types";
 
 export enum SelectionTool {
   Default = "DEFAULT",
@@ -76,7 +76,7 @@ export const setFindIndex = createAction("Set find menu polygon index")<number |
 export const toggleEvaluate = createAction("Toggle evaluate mode")<boolean>();
 export const toggleExpandedMetrics = createAction("Toggle expanded metrics")<boolean>();
 export const selectEvaluationMetric = createAction("Select evaluation metric")<
-  EvaluateMetric | undefined
+  EvaluateMetricWithValue | undefined
 >();
 
 export const saveDistrictsDefinition = createAction("Save districts definition")();

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -2,7 +2,7 @@
 import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading, Text, Select } from "theme-ui";
 import { IProject, IStaticMetadata, RegionLookupProperties } from "../../../shared/entities";
 import Icon from "../Icon";
-import { DistrictsGeoJSON, EvaluateMetric, ElectionYear } from "../../types";
+import { DistrictsGeoJSON, ElectionYear, EvaluateMetricWithValue } from "../../types";
 import store from "../../store";
 import { selectEvaluationMetric } from "../../actions/districtDrawing";
 import ContiguityMetricDetail from "./detail/Contiguity";
@@ -40,7 +40,7 @@ const ProjectEvaluateMetricDetail = ({
   staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
-  readonly metric: EvaluateMetric;
+  readonly metric: EvaluateMetricWithValue;
   readonly project?: IProject;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly geoLevel: string;

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -170,6 +170,7 @@ const ProjectEvaluateSidebar = ({
             popThreshold
           )}%) above or below that target.`) ||
         "",
+      showInSummary: true,
       avgPopulation: avgPopulation,
       popThreshold: popThreshold,
       type: "fraction",
@@ -187,6 +188,7 @@ const ProjectEvaluateSidebar = ({
         "Each district should be contiguous, meaning it must be a single, unbroken shape. Some exceptions are allowed, such as the inclusion of islands in a coastal district. Two areas connected only by a single point (touching just their corners) are not considered contiguous.",
       shortText:
         "All parts of a district must be in physical contact with some other part of the district, to the extent possible.",
+      showInSummary: true,
       type: "fraction",
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
       value:
@@ -194,7 +196,7 @@ const ProjectEvaluateSidebar = ({
           .length || 0
     }
   ];
-  const optionalMetrics: readonly EvaluateMetric[] = [
+  const optionalMetrics: readonly EvaluateMetricWithValue[] = [
     {
       key: "competitiveness",
       name: "Competitiveness",
@@ -204,6 +206,7 @@ const ProjectEvaluateSidebar = ({
         "A competitiveness metric evaluates the plan based on the average partisan lean of each district.",
       longText:
         "A competitiveness metric evaluates the plan based on the average partisan lean of each district, calculated using the Partisan Voting Index (PVI). A partisan lean of the district plan which deviates from the overall lean of the state can be indicative of gerrymandering.",
+      showInSummary: !!(staticMetadata && staticMetadata.voting),
       party: party,
       value: avgCompetitiveness,
       hasMultipleElections: multipleElections,
@@ -217,6 +220,7 @@ const ProjectEvaluateSidebar = ({
         "A district that efficiently groups constituents together has higher compactness. Low compactness or districts that branch out to different areas can be indicators of gerrymandering. Compactness is calculated using the Polsby-Popper method. Higher numbers are better.",
       shortText:
         "A district that is more spread out has a lower compactness. Low compactness can be an indicator of gerrymandering.",
+      showInSummary: true,
       description: "are compact",
       value: avgCompactness
     },
@@ -229,6 +233,7 @@ const ProjectEvaluateSidebar = ({
         "A majority-minority district is a district in which a racial minority group or groups comprise a majority of the district's total population.",
       longText:
         'A majority-minority district is a district in which a racial minority group or groups comprise a majority of the district\'s total population. The display indicates districts where a minority race has a simple majority (Black, Hispanic, etc.), or where the sum of multiple minority races combine to a majority (called "Coalition" districts).',
+      showInSummary: true,
       total: geojson?.features.filter(f => f.id !== 0).length || 0,
       value: geojson?.features.filter(f => isMajorityMinority(f)).length || 0
     },
@@ -241,6 +246,7 @@ const ProjectEvaluateSidebar = ({
         "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
       longText:
         "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
+      showInSummary: true,
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,
       splitCounties: project?.districtsDefinition.map(c => {

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -2,13 +2,7 @@
 import { jsx, ThemeUIStyleObject, Container, Box } from "theme-ui";
 
 import { IProject, IStaticMetadata, RegionLookupProperties } from "../../../shared/entities";
-import {
-  DistrictsGeoJSON,
-  EvaluateMetric,
-  EvaluateMetricWithValue,
-  ElectionYear,
-  Party
-} from "../../types";
+import { DistrictsGeoJSON, EvaluateMetricWithValue, ElectionYear, Party } from "../../types";
 import store from "../../store";
 import { hasMultipleElections, isMajorityMinority } from "../../functions";
 import { regionPropertiesFetch } from "../../actions/regionConfig";
@@ -45,7 +39,7 @@ const ProjectEvaluateSidebar = ({
   staticMetadata
 }: {
   readonly geojson?: DistrictsGeoJSON;
-  readonly metric: EvaluateMetric | undefined;
+  readonly metric: EvaluateMetricWithValue | undefined;
   readonly project?: IProject;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly staticMetadata?: IStaticMetadata;
@@ -249,13 +243,7 @@ const ProjectEvaluateSidebar = ({
       showInSummary: true,
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,
-      splitCounties: project?.districtsDefinition.map(c => {
-        if (Array.isArray(c)) {
-          return c;
-        } else {
-          return undefined;
-        }
-      })
+      splitCounties: project?.districtsDefinition.map(c => Array.isArray(c))
     }
   ];
   return (

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -3,7 +3,7 @@ import { Box, IconButton, Flex, jsx, ThemeUIStyleObject, Heading, Text } from "t
 
 import Icon from "../Icon";
 import store from "../../store";
-import { EvaluateMetric, EvaluateMetricWithValue } from "../../types";
+import { EvaluateMetricWithValue } from "../../types";
 import { formatPvi } from "../../functions";
 import { selectEvaluationMetric, toggleEvaluate } from "../../actions/districtDrawing";
 
@@ -57,9 +57,8 @@ const ProjectEvaluateView = ({
   requiredMetrics,
   optionalMetrics
 }: {
-  // Still working out what the type should be here
-  readonly requiredMetrics: readonly EvaluateMetric[];
-  readonly optionalMetrics: readonly EvaluateMetric[];
+  readonly requiredMetrics: readonly EvaluateMetricWithValue[];
+  readonly optionalMetrics: readonly EvaluateMetricWithValue[];
 }) => {
   function formatMetricValue(metric: EvaluateMetricWithValue): string {
     switch (metric.type) {

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -94,67 +94,71 @@ const ProjectEvaluateView = ({
           <Heading as="h3" sx={{ variant: "text.h5", mt: 2 }}>
             Required
           </Heading>
-          {requiredMetrics.map(metric => (
-            <Box
-              as="article"
-              sx={style.metricRow}
-              onClick={() => store.dispatch(selectEvaluationMetric(metric))}
-              key={metric.key}
-              tabIndex={0}
-            >
-              <Flex>
-                <Flex sx={{ alignItems: "center" }}>
-                  {"status" in metric ? (
-                    metric.status ? (
-                      <Box sx={{ lineHeight: "body", mr: 2 }}>
-                        <Icon name={"check-circle-solid"} color="success.3" />
-                      </Box>
+          {requiredMetrics
+            .filter(metric => metric.showInSummary)
+            .map(metric => (
+              <Box
+                as="article"
+                sx={style.metricRow}
+                onClick={() => store.dispatch(selectEvaluationMetric(metric))}
+                key={metric.key}
+                tabIndex={0}
+              >
+                <Flex>
+                  <Flex sx={{ alignItems: "center" }}>
+                    {"status" in metric ? (
+                      metric.status ? (
+                        <Box sx={{ lineHeight: "body", mr: 2 }}>
+                          <Icon name={"check-circle-solid"} color="success.3" />
+                        </Box>
+                      ) : (
+                        <Box sx={{ lineHeight: "body", mr: 2 }}>
+                          <Icon name={"times-circle-solid"} color="error" />
+                        </Box>
+                      )
                     ) : (
-                      <Box sx={{ lineHeight: "body", mr: 2 }}>
-                        <Icon name={"times-circle-solid"} color="error" />
-                      </Box>
-                    )
-                  ) : (
-                    <Box></Box>
-                  )}
-                  <Heading as="h4" sx={{ ...style.metricTitle, mb: 0 }}>
-                    {metric.name}
-                  </Heading>
+                      <Box></Box>
+                    )}
+                    <Heading as="h4" sx={{ ...style.metricTitle, mb: 0 }}>
+                      {metric.name}
+                    </Heading>
+                  </Flex>
+                  <Box sx={style.metricValue}>
+                    {"type" in metric ? formatMetricValue(metric) : ""}
+                  </Box>
                 </Flex>
-                <Box sx={style.metricValue}>
-                  {"type" in metric ? formatMetricValue(metric) : ""}
-                </Box>
-              </Flex>
-              <Text as="p" sx={style.metricText}>
-                {metric.shortText}
-              </Text>
-            </Box>
-          ))}
+                <Text as="p" sx={style.metricText}>
+                  {metric.shortText}
+                </Text>
+              </Box>
+            ))}
         </Box>
         <Box sx={style.evaluateMetricsList}>
           <Heading as="h3" sx={{ variant: "text.h5", mt: 2 }}>
             Optional
           </Heading>
-          {optionalMetrics.map(metric => (
-            <Flex key={metric.key}>
-              <Box
-                as="article"
-                sx={style.metricRow}
-                onClick={() => store.dispatch(selectEvaluationMetric(metric))}
-                tabIndex={0}
-              >
-                <Flex>
-                  <Heading as="h4" sx={{ ...style.metricTitle, textTransform: "capitalize" }}>
-                    {metric.name}
-                  </Heading>
-                  <Box sx={style.metricValue}>
-                    {"type" in metric ? formatMetricValue(metric) : ""}
-                  </Box>
-                </Flex>
-                <Text sx={style.metricText}>{metric.shortText || "Lorem ipsum lorem ipsum"}</Text>
-              </Box>
-            </Flex>
-          ))}
+          {optionalMetrics
+            .filter(metric => metric.showInSummary)
+            .map(metric => (
+              <Flex key={metric.key}>
+                <Box
+                  as="article"
+                  sx={style.metricRow}
+                  onClick={() => store.dispatch(selectEvaluationMetric(metric))}
+                  tabIndex={0}
+                >
+                  <Flex>
+                    <Heading as="h4" sx={{ ...style.metricTitle, textTransform: "capitalize" }}>
+                      {metric.name}
+                    </Heading>
+                    <Box sx={style.metricValue}>
+                      {"type" in metric ? formatMetricValue(metric) : ""}
+                    </Box>
+                  </Flex>
+                  <Text sx={style.metricText}>{metric.shortText || "Lorem ipsum lorem ipsum"}</Text>
+                </Box>
+              </Flex>
+            ))}
         </Box>
       </Box>
     </Flex>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -29,7 +29,6 @@ import {
 import {
   DistrictsGeoJSON,
   DistrictGeoJSON,
-  EvaluateMetric,
   ElectionYear,
   EvaluateMetricWithValue
 } from "../../types";
@@ -198,7 +197,7 @@ interface Props {
   readonly geoLevelIndex: number;
   readonly lockedDistricts: LockedDistricts;
   readonly expandedProjectMetrics: boolean;
-  readonly evaluateMetric?: EvaluateMetric | EvaluateMetricWithValue;
+  readonly evaluateMetric?: EvaluateMetricWithValue;
   readonly evaluateMode: boolean;
   readonly isReadOnly: boolean;
   readonly isArchived: boolean;

--- a/src/client/reducers/districtDrawing.ts
+++ b/src/client/reducers/districtDrawing.ts
@@ -2,7 +2,7 @@ import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
 import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
-import { SavingState, EvaluateMetric, ElectionYear } from "../types";
+import { SavingState, EvaluateMetricWithValue, ElectionYear } from "../types";
 
 import {
   addSelectedGeounits,
@@ -121,7 +121,7 @@ export interface DistrictDrawingState {
   readonly findMenuOpen: boolean;
   readonly expandedProjectMetrics: boolean;
   readonly evaluateMode: boolean;
-  readonly evaluateMetric: EvaluateMetric | undefined;
+  readonly evaluateMetric: EvaluateMetricWithValue | undefined;
   readonly findIndex?: number;
   readonly findTool: FindTool;
   readonly limitSelectionToCounty: boolean;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -15,7 +15,7 @@ import {
   IUser,
   UintArrays
 } from "../../shared/entities";
-import { ElectionYear, EvaluateMetric } from "../types";
+import { ElectionYear, EvaluateMetricWithValue } from "../types";
 
 import { projectDataFetch, clearDuplicationState } from "../actions/projectData";
 import { DistrictDrawingState } from "../reducers/districtDrawing";
@@ -50,7 +50,7 @@ interface StateProps {
   readonly findMenuOpen: boolean;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly evaluateMode: boolean;
-  readonly evaluateMetric: EvaluateMetric | undefined;
+  readonly evaluateMetric: EvaluateMetricWithValue | undefined;
   readonly geoUnitHierarchy?: GeoUnitHierarchy;
   readonly expandedProjectMetrics?: boolean;
   readonly districtDrawing: DistrictDrawingState;

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -95,6 +95,4 @@ export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
   readonly [key: string]: any;
 }
 
-export type EvaluateMetric = BaseEvaluateMetric | EvaluateMetricWithValue;
-
 export type ChoroplethSteps = readonly (readonly [number, string])[];

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -64,6 +64,7 @@ export interface BaseEvaluateMetric {
   readonly description: string;
   readonly longText?: string;
   readonly shortText?: string;
+  readonly showInSummary: boolean;
 }
 
 export type ElectionYear = "16" | "20" | "combined";


### PR DESCRIPTION
## Overview

Hides the competitiveness summary in the Evaluate sidebar when political data is missing for the region. Accomplishes this by adding a "showInSummary" attribute to the EvaluateMetrics so that they can be toggled on and off in the sidebar.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screenshot_2021-08-05_15-31-47](https://user-images.githubusercontent.com/447977/128409916-1e0221ec-bf52-48e2-beef-76b8e8103e9f.png)

### Notes

- Putting in a special-purpose check for competitiveness would have been very slightly easier, but the approach I took seemed like it would pay off in the long run if we need to toggle metric summaries for other reasons (e.g. on a per-organization basis), so I opted for the more general approach.
- I put the formatting in a separate commit because there was a lot of it relative to the substantive changes. I'm planning to squash before merging to keep the commit history uncluttered, but I would also be happy to leave them separate, which might make it easier to parse what this commit is doing later on, if necessary.

## Testing Instructions

- Find a region that has voting data, and one that doesn't. The defaults that come from `/scripts/load-dev-data` seem to lack it, and I was able to use the proxy setup to view some regions that _do_ have data on staging.
- Create projects with both regions, if you don't have them already.
- Enable Evaluate mode in both projects. Confirm that the Competitiveness metric only shows up in the Evaluate sidebar if the Region has election data.
- If you want, switch a different metric's `showInSummary` attribute to `false` and confirm it disappears.
- If you want, test projects with no assigned districts and confirm that the behavior remains the same.

Closes #866 
