### PR TITLE
Districts cache busting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update population deviation helper text [#848](https://github.com/PublicMapping/districtbuilder/pull/848)
 - Update display logic for political data in expandable metrics viewer [#864](https://github.com/PublicMapping/districtbuilder/pull/864)
 - Update UX for duplication, showing a spinner when duplication is pending and redirecting when it completes [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
+- Added cache-busting to 'districts' column [#897](https://github.com/PublicMapping/districtbuilder/pull/897)
 
 ### Fixed
 

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -57,7 +57,6 @@ import {
   exportProjectShp,
   fetchProjectData,
   fetchProjectGeoJson,
-  createProject,
   patchProject,
   copyProject
 } from "../api";

--- a/src/server/migrations/1628182840067-project_version.ts
+++ b/src/server/migrations/1628182840067-project_version.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class projectVersion1628182840067 implements MigrationInterface {
+  name = "projectVersion1628182840067";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "project" ADD "region_config_version" TIMESTAMP WITH TIME ZONE`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "region_config_version"`);
+  }
+}

--- a/src/server/migrations/1628546956803-project_version_default.ts
+++ b/src/server/migrations/1628546956803-project_version_default.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class projectVersionDefault1628546956803 implements MigrationInterface {
+    name = 'projectVersionDefault1628546956803'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE project SET region_config_version = region_config.version FROM region_config WHERE project.region_config_id = region_config.id`);
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "region_config_version" SET NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "region_config_version" DROP NOT NULL`);
+    }
+
+}

--- a/src/server/src/project-templates/controllers/project-templates.controller.ts
+++ b/src/server/src/project-templates/controllers/project-templates.controller.ts
@@ -102,6 +102,9 @@ export class ProjectTemplatesController {
         `User does not have admin privileges for organization: ${org.id}`
       );
     }
+    // The associated 'districts' column may be out-of-date if the RegionConfig has been updated
+    // We don't make an attempt to regenerate those here, and accept that we will return whatever data was
+    // available when the user last updated their project
     const projectRows = await this.service.findAdminOrgProjectsWithDistrictProperties(slug);
     const regionURIs = new Set(projectRows.map(row => row.regionS3URI));
     const topoLayers: { [s3uri: string]: GeoUnitTopology | GeoUnitProperties } = {};

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -431,6 +431,24 @@ export class ProjectsController implements CrudController<Project> {
       );
     }
 
+    // If the districts are out-of-date, recalculate them and save
+    if (project.regionConfigVersion !== project.regionConfig.version) {
+      const districts = await this.getGeojson({
+        regionConfig: project.regionConfig,
+        numberOfDistricts: project.numberOfDistricts,
+        districtsDefinition: project.districtsDefinition
+      });
+
+      // Note we don't wait for save to return, and we throw away it's result
+      void this.service.save({
+        ...project,
+        districts,
+        regionConfigVersion: project.regionConfig.version
+      });
+
+      return districts;
+    }
+
     return project.districts;
   }
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -633,7 +633,11 @@ export class ProjectsController implements CrudController<Project> {
     @Param("id") projectId: ProjectId
   ): Promise<Project> {
     const planScoreToken = process.env.PLAN_SCORE_API_TOKEN || "";
-    const geojson = await this.exportGeoJSON(req, projectId);
+    const districts = await this.exportGeoJSON(req, projectId);
+    const geojson = districts && {
+      ...districts,
+      features: districts.features.filter(f => f.id !== 0)
+    };
 
     return new Promise((resolve, reject) => {
       axios({

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -202,11 +202,12 @@ export class ProjectsController implements CrudController<Project> {
       } as Errors<UpdateProjectDto>);
     }
 
-    // Update districts GeoJSON if the definition has changed or there is no cached value yet
+    // Update districts GeoJSON if the definition has changed, the version is out-of-date, or there is no cached value yet
     const dataWithDefinitions =
       existingProject &&
       dto.districtsDefinition &&
       (!existingProject.districts ||
+        existingProject.regionConfigVersion !== existingProject.regionConfig.version ||
         !_.isEqual(dto.districtsDefinition, existingProject.districtsDefinition))
         ? {
             ...dto,
@@ -214,7 +215,8 @@ export class ProjectsController implements CrudController<Project> {
               regionConfig: existingProject.regionConfig,
               numberOfDistricts: existingProject.numberOfDistricts,
               districtsDefinition: dto.districtsDefinition
-            })
+            }),
+            regionConfigVersion: existingProject.regionConfig.version
           }
         : dto;
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -70,6 +70,7 @@ import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.
     }
   },
   query: {
+    exclude: ["districts"],
     join: {
       projectTemplate: {
         exclude: ["districtsDefinition"],

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -40,11 +40,7 @@ export class Project implements IProject {
 
   // The version of Project.regionConfig at the time of last update,
   // used to bust cache for districts column
-  @Column({
-    type: "timestamp with time zone",
-    name: "region_config_version",
-    nullable: true
-  })
+  @Column({ type: "timestamp with time zone", name: "region_config_version" })
   regionConfigVersion: Date;
 
   @ManyToOne(() => Chamber, { nullable: true })

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -38,6 +38,15 @@ export class Project implements IProject {
   @JoinColumn({ name: "region_config_id" })
   regionConfig: RegionConfig;
 
+  // The version of Project.regionConfig at the time of last update,
+  // used to bust cache for districts column
+  @Column({
+    type: "timestamp with time zone",
+    name: "region_config_version",
+    nullable: true
+  })
+  regionConfigVersion: Date;
+
   @ManyToOne(() => Chamber, { nullable: true })
   @JoinColumn({ name: "chamber_id" })
   chamber?: Chamber;

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -52,9 +52,12 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
       published: ProjectVisibility.Published
     });
     const builderWithFilter = options.completed
-      ? // Completed projects are defined as having no population in the unassigned district
+      ? // Completed projects are defined as having no geo units assigned to the unassigned district
+        //
+        // Note: while data updates might change what population is assigned, we don't expect them to
+        // change geometries, so this should be safe even with a stale 'districts' colum
         builder.andWhere(
-          "(project.districts->'features'->0->'properties'->'demographics'->'population')::integer = 0"
+          "jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates')::integer = 0"
         )
       : builder;
     const builderWithRegion = options.region


### PR DESCRIPTION
## Overview

Adds cache-busting to the `districts` column by tracking the `version` of `RegionConfig` on the new `Project.regionConfigVersion` field, and regenerating the column when they are out-of-sync.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

We only make use of district feature geometries outside the project screen for the most part, so it was relatively easy to contain needing to regenerate the `districts` column to the use of the GeoJSON export endpoint, with a few exceptions:
 - I changed the definition of "completed" on the Community from having no population in the unassigned district to having no features in the unassigned district (you could have only blocks w/ no population left before and we'd consider it "complete").
 - The organization admin CSV map export won't recalculate districts; if this is desired I'll open a follow-on issue to tackle this separately

## Testing Instructions

I created a PA region w/o political data (`'s3://global-districtbuilder-dev-us-east-1/regions/US/PA/2021-02-08T18:07:18.957Z/'`) and created a map / assigned some districts.

_Then_ I updated my PA `region_config` row to point to updated data w/ political data (`'s3://global-districtbuilder-dev-us-east-1/regions/US/PA/2020-09-09T19:03:58.174Z/'`) and updated the `version` of the region_config.

Subsequently, loading the map you created previously should regenerate the `districts` column & show political data.

Closes #884 
