### PR TITLE
Fix creating project from template with existing districts definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix archive not updating list of projects [#892](https://github.com/PublicMapping/districtbuilder/pull/892)
 - Redirect to home screen after successful login [#895](https://github.com/PublicMapping/districtbuilder/pull/895)
 - Improved handling large number of import flags [#888](https://github.com/PublicMapping/districtbuilder/pull/888)
+- Fixed creating districts from project template [#905](https://github.com/PublicMapping/districtbuilder/pull/905)
 
 
 ## [1.6.0] - 2021-05-24

--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -22,7 +22,9 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
     const data = await builder
       .select()
       .leftJoin("organization.users", "users")
+      .addSelect(["users.id", "users.name"])
       .leftJoin("organization.admin", "admin")
+      .addSelect(["admin.id", "admin.name"])
       .leftJoinAndSelect(
         "organization.projectTemplates",
         "projectTemplates",
@@ -30,7 +32,6 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
       )
       .leftJoinAndSelect("projectTemplates.regionConfig", "regionConfig")
       .where("organization.slug = :slug", { slug: slug })
-      .addSelect(["users.id", "users.name", "admin.id", "admin.name"])
       .getOne();
     return data;
   }

--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -20,8 +20,9 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
     // Returns public data for organization screen
     const builder = this.repo.createQueryBuilder("organization");
     const data = await builder
-      .leftJoinAndSelect("organization.users", "users")
-      .leftJoinAndSelect("organization.admin", "admin")
+      .select()
+      .leftJoin("organization.users", "users")
+      .leftJoin("organization.admin", "admin")
       .leftJoinAndSelect(
         "organization.projectTemplates",
         "projectTemplates",
@@ -29,30 +30,7 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
       )
       .leftJoinAndSelect("projectTemplates.regionConfig", "regionConfig")
       .where("organization.slug = :slug", { slug: slug })
-      .select([
-        "organization.id",
-        "organization.slug",
-        "organization.name",
-        "organization.description",
-        "organization.linkUrl",
-        "organization.logoUrl",
-        "organization.municipality",
-        "organization.region",
-        "users.id",
-        "users.name",
-        "admin.id",
-        "admin.name",
-        "projectTemplates.id",
-        "projectTemplates.name",
-        "regionConfig.name",
-        "regionConfig.id",
-        "regionConfig.countryCode",
-        "regionConfig.regionCode",
-        "projectTemplates.numberOfDistricts",
-        "projectTemplates.description",
-        "projectTemplates.details",
-        "projectTemplates.isActive"
-      ])
+      .addSelect(["users.id", "users.name", "admin.id", "admin.name"])
       .getOne();
     return data;
   }


### PR DESCRIPTION
## Overview

We were not returning `districts_definition` as part of Organization project templates, which prevented them from being used when creating projects from them.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

The existing use of `leftJoinAndSelect(...)` wasn't quite right - because the calls to this method came _before_ the later call to `select(...)`, these did not select any fields and functioned the same as `leftJoin(...)`. By switching to use `addSelect(...)` instead of `select(...)` we can omit the fields for all tables that use `leftJoinAndSelect(...)`. Similarly we can omit the `Organization` fields by using `select(...)`.

## Testing Instructions

Add a `districts_definition` to an existing `project_template` row, or construct a `project_template` from an existing project using SQL:
```sql
INSERT INTO project_template
(name, number_of_districts, districts_definition, organization_id, region_config_id, description, details)
SELECT name, number_of_districts, districts_definition, '...', region_config_id, '', ''
FROM project WHERE id = '...';
```

Then try creating a project from that template. You should see the districts when redirected to the project screen.

Closes #882
