### PR TITLE
Fix creating projects

### DIFF
--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -290,7 +290,8 @@ export class ProjectsController implements CrudController<Project> {
       districtsDefinition,
       districts,
       lockedDistricts,
-      user: req.parsed.authPersist.userId
+      user: req.parsed.authPersist.userId,
+      regionConfigVersion: regionConfig.version
     };
   }
 


### PR DESCRIPTION
## Overview

Adding `Project.region_config_version` as part of #884 as a not-null field unintentionally broke project creation.

## Testing Instructions

On `develop` you can't create new projects. On this branch you can.