### PR TITLE
Fix community maps page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update display logic for political data in expandable metrics viewer [#864](https://github.com/PublicMapping/districtbuilder/pull/864)
 - Update UX for duplication, showing a spinner when duplication is pending and redirecting when it completes [#872](https://github.com/PublicMapping/districtbuilder/pull/872)
 - Added cache-busting to 'districts' column [#897](https://github.com/PublicMapping/districtbuilder/pull/897)
-- Simplify districts used to display mini-map [#894](https://github.com/PublicMapping/districtbuilder/pull/894)
+- Simplify districts used to display mini-map [#894](https://github.com/PublicMapping/districtbuilder/pull/894) & [#911](https://github.com/PublicMapping/districtbuilder/pull/911)
 
 ### Fixed
 


### PR DESCRIPTION
## Overview

It seems like some of our NJ data has invalid polygon data in it due to rounding points of a very small hole such that all corners are exactly equal.

This tripped up the simplification library, which caused the page to not load.

We probably can't find/fix every such data issue like this, so I made the simplification a bit more granular and have it just skip past any polygons it has issues with (and return them unsimplified).

Hopefully all the problematic polygons are similarly small, so it won't be an issue that we don't simplify them.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

The specific MultiPolygon throwing off `simplify`:
```
{
  "id":9,
  "type":"Feature",
  "geometry":{
    "type":"MultiPolygon",
    "coordinates":[
     [
        ...
     ],
      [
        [
          [
            -74.33104881808818,
            41.186675416504166
          ],
          [
            -74.33104881808818,
            41.186675416504166
          ],
          [
            -74.33104881808818,
            41.186675416504166
          ],
          [
            -74.33104881808818,
            41.186675416504166
          ]
        ]
      ]
    ]
  },
  "properties":{
    "voting":{},
    "contiguity":"non-contiguous",
    "compactness":0,
    "demographics":{
      "asian":32440,
      "black":73973,
      "other":8070,
      "white":359628,
      "hispanic":195294,
      "population":650491
    }
  }
}
```

## Testing Instructions

Create a new map for NJ using the region set up on staging (`s3://global-districtbuilder-dev-us-east-1/regions/US/PA/2020-09-09T19:03:58.174Z/`). I simply assigned every county to the first district.

On `develop`, loading the mini-map for this project will fail.
On this branch, it will succeed and log a debug message to the console.

Closes #910 
