### PR TITLE
Create auto scaling group and stand up new app service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add histogram to evaluate mode metric view for competitiveness [#844](https://github.com/PublicMapping/districtbuilder/pull/844)
 - Added button to convert 2010 maps to 2020 [#878](https://github.com/PublicMapping/districtbuilder/pull/878)
 - Add keyboard shortcuts for incrementing and decrementing the paintbrush size [#874](https://github.com/PublicMapping/districtbuilder/pull/874)
+- Create auto scaling group and stand up new app service [#914](https://github.com/PublicMapping/districtbuilder/pull/914)
 
 ### Changed
 

--- a/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
+++ b/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
@@ -1,0 +1,6 @@
+
+#cloud-config
+
+bootcmd:
+  - mkdir -p /etc/ecs
+  - echo 'ECS_CLUSTER=${ecs_cluster_name}' >> /etc/ecs/ecs.config

--- a/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
+++ b/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
@@ -1,4 +1,3 @@
-
 #cloud-config
 
 bootcmd:

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.aws_region
-  version = "~> 3.6.0"
+  version = "~> 3.10.0"
 }
 
 terraform {

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -1,0 +1,187 @@
+#
+# Auto Scaling resources
+#
+data "template_cloudinit_config" "container_instance_cloud_config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-config/base-container-instance.yml.tmpl", {
+      ecs_cluster_name = aws_ecs_cluster.app.name
+    })
+  }
+}
+
+# Pull the image ID for the latest Amazon ECS-optimized Amazon Linux 2 AMI
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#al2ami
+data "aws_ssm_parameter" "ecs_image_id" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+data "aws_ami" "ecs_ami" {
+  owners = ["self", "amazon", "aws-marketplace"]
+
+  filter {
+    name   = "image-id"
+    values = [data.aws_ssm_parameter.ecs_image_id.value]
+  }
+}
+
+resource "aws_launch_template" "container_instance" {
+  block_device_mappings {
+    device_name = data.aws_ami.ecs_ami.root_device_name
+
+    ebs {
+      volume_type = var.container_instance_root_block_device_type
+      volume_size = var.container_instance_root_block_device_size
+    }
+  }
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+
+  disable_api_termination = false
+
+  name_prefix = "lt${title(var.environment)}ContainerInstance-"
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ecs_container_instance_role.name
+  }
+
+  image_id = data.aws_ami.ecs_ami.image_id
+
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_type                        = var.container_instance_type
+  key_name                             = var.aws_key_name
+  vpc_security_group_ids               = [aws_security_group.app.id]
+  user_data                            = data.template_cloudinit_config.container_instance_cloud_config.rendered
+
+  monitoring {
+    enabled = true
+  }
+}
+
+resource "aws_autoscaling_group" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  name = "asg${title(var.environment)}ContainerInstance"
+
+  launch_template {
+    id      = aws_launch_template.container_instance.id
+    version = "$Latest"
+  }
+
+  health_check_grace_period = var.container_instance_asg_health_check_grace_period
+  health_check_type         = "EC2"
+  desired_capacity          = var.container_instance_asg_override_desired_capacity
+  termination_policies      = ["OldestLaunchConfiguration", "Default"]
+  min_size                  = var.container_instance_asg_min_size
+  max_size                  = var.container_instance_asg_max_size
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+  vpc_zone_identifier = module.vpc.private_subnet_ids
+
+  tag {
+    key                 = "Name"
+    value               = "ContainerInstance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = var.project
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+}
+
+#
+# ECS resources
+#
+data "aws_ec2_instance_type" "container_instance" {
+  instance_type = var.container_instance_type
+}
+
+locals {
+  container_instance_app_memory = min(
+    # It is estimated that some larger states could use up to a gig. This math
+    # will add an additional 1024MiB for every state.
+    var.container_instance_app_base_memory + var.districtbuilder_state_count * 1024,
+    # This ensures no configuration exceeds the upper bound of available memory
+    # on a container instance.
+    data.aws_ec2_instance_type.container_instance.memory_size
+  )
+}
+
+resource "aws_ecs_task_definition" "app_container_instance" {
+  family       = "${var.environment}App_EC2LaunchType"
+  network_mode = "awsvpc"
+  # These are hard limits of CPU units and memory, specified at the task level.
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+  cpu    = var.container_instance_app_cpu
+  memory = local.container_instance_app_memory
+
+  container_definitions = templatefile("${path.module}/task-definitions/app.json.tmpl", merge(
+    local.shared_app_task_def_template_vars,
+    {
+      max_old_space_size = local.container_instance_app_memory * 0.75
+    }
+  ))
+
+  tags = {
+    Name        = "${var.environment}App_EC2LaunchType",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_service" "app_container_instance" {
+  name            = "${var.environment}App_EC2LaunchType"
+  cluster         = aws_ecs_cluster.app.name
+  task_definition = aws_ecs_task_definition.app.arn
+
+  desired_count                      = var.container_instance_app_desired_count
+  deployment_minimum_healthy_percent = var.container_instance_app_deployment_min_percent
+  deployment_maximum_percent         = var.container_instance_app_deployment_max_percent
+
+  health_check_grace_period_seconds = var.districtbuilder_state_count * var.health_check_grace_period_per_state
+
+  launch_type = "EC2"
+
+  network_configuration {
+    security_groups = [aws_security_group.app.id]
+    subnets         = module.vpc.private_subnet_ids
+  }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = var.app_port
+  }
+
+  depends_on = [
+    aws_lb_listener.app,
+  ]
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -227,6 +227,66 @@ variable "image_tag" {
   type = string
 }
 
+variable "container_instance_type" {
+  default = "r5.2xlarge"
+  type    = string
+}
+
+variable "container_instance_root_block_device_type" {
+  default = "gp2"
+  type    = string
+}
+
+variable "container_instance_root_block_device_size" {
+  default = 64
+  type    = number
+}
+
+variable "container_instance_asg_health_check_grace_period" {
+  default = 600
+  type    = number
+}
+
+variable "container_instance_asg_override_desired_capacity" {
+  default = null
+  type    = number
+}
+
+variable "container_instance_asg_min_size" {
+  default = 1
+  type    = number
+}
+
+variable "container_instance_asg_max_size" {
+  default = 1
+  type    = number
+}
+
+variable "container_instance_app_desired_count" {
+  default = 1
+  type    = number
+}
+
+variable "container_instance_app_deployment_min_percent" {
+  default = 100
+  type    = number
+}
+
+variable "container_instance_app_deployment_max_percent" {
+  default = 200
+  type    = number
+}
+
+variable "container_instance_app_cpu" {
+  default = 4096
+  type    = number
+}
+
+variable "container_instance_app_base_memory" {
+  default = 2048
+  type    = number
+}
+
 variable "fargate_platform_version" {
   default = "1.4.0"
 }
@@ -297,6 +357,11 @@ variable "app_port" {
 
 variable "aws_ecs_task_execution_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  type    = string
+}
+
+variable "aws_ec2_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
   type    = string
 }
 


### PR DESCRIPTION
## Overview

I made the following changes to support allocating over 30 GB of memory to the app server for the updated Census:

- Create an Auto Scaling group and launch template based on the [Terraform 0.12 branch](https://github.com/azavea/terraform-aws-ecs-cluster/tree/feature/jrb%2Fterraform-0.12) of our ECS cluster module.
- Make changes to work with the existing ECS cluster and security group resources.
- Stand up a second ECS service for the application server that uses the [EC2 launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html#launch-type-ec2).
- Make use of the [`awsvpc` network mode](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking-awsvpc.html) to preserve the existing target group, allowing a zero-downtime deployment. 

In previous ECS clusters where we've managed container instances, we've used `bridge` networking. `awsvpc` is the same network mode that we use with Fargate, which makes it less complicated to bridge two launch types, but also means we must have a one-to-one mapping of application servers to container instances.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

Double check that Terraform is up-to-date:

```console
docker-compose -f docker-compose.ci.yml run --rm terraform
export GIT_COMMIT=56dc64e
./scripts/infra plan

. . .

No changes. Infrastructure is up-to-date.
```

See that both ECS services are up and healthy:

<details>

<img width="2000" alt="image" src="https://user-images.githubusercontent.com/1774125/129094631-9d3e57de-7295-4612-b766-f8f0603ad01f.png">

<img width="2000" alt="image" src="https://user-images.githubusercontent.com/1774125/129094699-f92a4a82-8566-406f-ae8c-754518519623.png">

</details>

Verify that, aside from 4198e6c, there are **only additions** in the plan for production:

```console
export DB_SETTINGS_BUCKET=districtbuilder-production-config-us-east-1
export DB_DEPLOYMENT_ENVIRONMENT=production
export GIT_COMMIT=c006344
./scripts/infra plan

. . .

Plan: 9 to add, 1 to change, 1 to destroy.

```

Resolves #879 