### PR TITLE
Hide pagination when only one page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Only show pagination footer is more than one page is available [#915](https://github.com/PublicMapping/districtbuilder/pull/915)
 - Switched race demographic colors to a palette with fewer conflicts to our other color palettes [#795](https://github.com/PublicMapping/districtbuilder/pull/795)
 - Display evaluate mode toggle button in read-only mode [#786](https://github.com/PublicMapping/districtbuilder/pull/786)
 - Disable keyboard shortcuts in evaluate mode [#784](https://github.com/PublicMapping/districtbuilder/pull/784)
@@ -64,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redirect to home screen after successful login [#895](https://github.com/PublicMapping/districtbuilder/pull/895)
 - Improved handling large number of import flags [#888](https://github.com/PublicMapping/districtbuilder/pull/888)
 - Fixed creating districts from project template [#905](https://github.com/PublicMapping/districtbuilder/pull/905)
-
 
 ## [1.6.0] - 2021-05-24
 

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -53,11 +53,11 @@ const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
 
   return (
     <Box>
-      {
+      {totalPages > 1 && (
         <ul id="page-numbers" sx={style.pageList}>
           {renderPageNumbers}
         </ul>
-      }
+      )}
     </Box>
   );
 };


### PR DESCRIPTION

## Overview

To simplify the UI, hides pagination when there is only one page.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-08-11 at 3 49 52 PM](https://user-images.githubusercontent.com/1809908/129094168-60179931-973b-4131-8e8a-4ee2402985ea.png)

## Testing Instructions

- On My Maps, if you have 10 or fewer maps, you should not see the pagination; duplicate maps until you have 11 or more, at which point you should see the pagination
- Alternatively, on My Maps, if you have more than 10 maps: you should see pagination at the bottom of the page; delete maps until you have 10 or fewer, or start a new account; you should no longer see the pagination