### PR TITLE
Hide minority majority evaluate layer when not on detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add evaluate mode metric view for competitiveness [#824](https://github.com/PublicMapping/districtbuilder/pull/824)
 - Add expandable metrics viewer with ability to pin metrics to sidebar [#827](https://github.com/PublicMapping/districtbuilder/pull/827)
 - Add user id and IP address to rollbar server side error logging [#841](https://github.com/PublicMapping/districtbuilder/pull/841)
-- Add majority race metric to project sidebar [#853](https://github.com/PublicMapping/districtbuilder/pull/853)
+- Add majority race metric to project sidebar [#853](https://github.com/PublicMapping/districtbuilder/pull/853) & [#916](https://github.com/PublicMapping/districtbuilder/pull/916)
 - Add additional keyboard shortcuts [#854](https://github.com/PublicMapping/districtbuilder/pull/854)
 - Add configurable slider to increase size of paintbrush selection tool [#835](https://github.com/PublicMapping/districtbuilder/pull/835)
 - Add populationDeviation and chamber to import project screen [#845](https://github.com/PublicMapping/districtbuilder/pull/845)

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -94,6 +94,7 @@ function removeEvaluateMetricLayers(map: MapboxGL.Map) {
   map.setLayoutProperty(DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID, "visibility", "none");
   map.setLayoutProperty(DISTRICTS_COMPETITIVENESS_CHOROPLETH_LAYER_ID, "visibility", "none");
   map.setLayoutProperty(DISTRICTS_EQUAL_POPULATION_CHOROPLETH_LAYER_ID, "visibility", "none");
+  map.setLayoutProperty(DISTRICTS_MAJORITY_RACE_CHOROPLETH_LAYER_ID, "visibility", "none");
   map.setLayoutProperty(TOPMOST_GEOLEVEL_EVALUATE_SPLIT_ID, "visibility", "none");
   map.setLayoutProperty(TOPMOST_GEOLEVEL_EVALUATE_FILL_SPLIT_ID, "visibility", "none");
   map.setLayoutProperty(DISTRICTS_CONTIGUITY_CHLOROPLETH_LAYER_ID, "visibility", "none");


### PR DESCRIPTION
## Overview

Hides the minority majority evaluate layer when not on the majority race detail view

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Toggle evaluate mode, then the majority/minority race view, then leave evaluate mode. On `develop` the map layers will not reset correctly, on this branch they will.

Closes #903 
