### PR TITLE
Reset pagination when setting community maps region filter

### DIFF
--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -138,7 +138,11 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
         ? loop(
             {
               ...state,
-              globalProjectsRegion: action.payload || null
+              globalProjectsRegion: action.payload || null,
+              globalProjectsPagination: {
+                ...state.globalProjectsPagination,
+                currentPage: 1
+              }
             },
             Cmd.action(globalProjectsFetch())
           )


### PR DESCRIPTION
## Overview

Without this fix, setting a state filter could show no results incorrectly because there aren't multiple pages of results.


### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

Closes #XXX
