### PR TITLE
Revert "Reset pagination when setting community maps region filter"

### DIFF
--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -138,11 +138,7 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
         ? loop(
             {
               ...state,
-              globalProjectsRegion: action.payload || null,
-              globalProjectsPagination: {
-                ...state.globalProjectsPagination,
-                currentPage: 1
-              }
+              globalProjectsRegion: action.payload || null
             },
             Cmd.action(globalProjectsFetch())
           )


### PR DESCRIPTION
Turns out it wasn't trivial - this caused the bug in #885 of duplicate requests on page load to return.

Reverts PublicMapping/districtbuilder#920