### PR TITLE
Fix simplification regresssion

### DIFF
--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -54,17 +54,23 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
     const projects = await page;
     projects.items.forEach(project => {
       project.districts.features.forEach(districtFeature => {
-        districtFeature.geometry.coordinates.forEach(coordinates => {
-          // Simplify each polygon of the multipolygon separately, and skip past any invalid geometries
-          // Some very small holes may collapse to a single point during the merge operation and cause simplify to fail
-          try {
-            simplify({ type: "Polygon", coordinates }, { mutate: true, tolerance: 0.005 });
-          } catch (e) {
-            this.logger.debug(
-              `Could not simplify district ${districtFeature.id} for project ${project.id}: ${e}`
-            );
+        // Some very small holes may collapse to a single point during the merge operation,
+        // and generate invalid polygons that cause simplify to fail
+        districtFeature.geometry.coordinates = districtFeature.geometry.coordinates.flatMap(
+          coordinates => {
+            if (coordinates.every(coord => coord === coordinates[0])) {
+              return [];
+            }
+            return [coordinates];
           }
-        });
+        );
+        try {
+          simplify(districtFeature, { mutate: true, tolerance: 0.005 });
+        } catch (e) {
+          this.logger.debug(
+            `Could not simplify district ${districtFeature.id} for project ${project.id}: ${e}`
+          );
+        }
       });
     });
     return projects;

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -56,6 +56,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
       project.districts.features.forEach(districtFeature => {
         // Some very small holes may collapse to a single point during the merge operation,
         // and generate invalid polygons that cause simplify to fail
+        //eslint-disable-next-line functional/immutable-data
         districtFeature.geometry.coordinates = districtFeature.geometry.coordinates.flatMap(
           coordinates => {
             if (coordinates.every(coord => coord === coordinates[0])) {


### PR DESCRIPTION
## Overview

The previous fix to simplification in #911 caused a regression in performance

Instead of simplifying on a polygon-by-polygon basis, it seems we weren't actually returning simplified data at all anymore

Cleaning the data fixed the one case we knew of invalid polygon data, though I left the try/catch in place in case new data causes a similar issue.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- On `develop`, look at response size of the `globalProjects` endpoint in network tab of the developer tools, and compare it to this branch. You should see a reduction in size.
