### PR TITLE
Fix communty maps region filter

### DIFF
--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -138,7 +138,11 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
         ? loop(
             {
               ...state,
-              globalProjectsRegion: action.payload || null
+              globalProjectsRegion: action.payload || null,
+              globalProjectsPagination: {
+                ...state.globalProjectsPagination,
+                currentPage: 1
+              }
             },
             Cmd.action(globalProjectsFetch())
           )

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -68,12 +68,16 @@ const PublishedMapsListScreen = ({
   const [regionCode, setRegionCode] = useQueryParam("region", StringParam);
 
   useEffect(() => {
-    store.dispatch(globalProjectsSetRegion(regionCode || null));
-  }, [regionCode]);
+    if (regionCode) {
+      store.dispatch(globalProjectsSetRegion(regionCode));
+    } else {
+      store.dispatch(globalProjectsFetch());
+    }
+  }, []);
 
   useEffect(() => {
-    store.dispatch(globalProjectsFetch());
-  }, []);
+    store.dispatch(globalProjectsSetRegion(regionCode || null));
+  }, [regionCode]);
 
   useEffect(() => {
     !regionConfigs && store.dispatch(regionConfigsFetch());


### PR DESCRIPTION
## Overview

 - Prevents showing "No results" incorrectly when setting the region filter
 - Eliminates duplicate API query when loading the page with a region filter

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Load the community maps page, and navigate to page 2, then change the region filter to a state with only 1 page worth of results
- Refresh the page and check the network tab to see the `globalProjects` endpoint isn't called twice

Closes #922 
