### PR TITLE
Style cleanup for paintbrush size panel

### DIFF
--- a/src/client/components/MapHeader.tsx
+++ b/src/client/components/MapHeader.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React, { useEffect, useState } from "react";
-import { Flex, Box, Label, Button, jsx, Select, Slider, ThemeUIStyleObject } from "theme-ui";
+import { Flex, Box, Label, Button, jsx, Select, Slider, Text, ThemeUIStyleObject } from "theme-ui";
 import { GeoLevelInfo, GeoLevelHierarchy, GeoUnits, IStaticMetadata } from "../../shared/entities";
 import { ElectionYear } from "../types";
 import { toggleFind } from "../actions/districtDrawing";
@@ -72,14 +72,13 @@ const style: ThemeUIStyleObject = {
     position: "absolute",
     display: "flex",
     backgroundColor: "#fff",
-    borderRadius: "2px",
+    borderRadius: "3px",
     border: "1px solid",
     borderColor: "gray.2",
-    padding: "5px",
-    top: "100px",
-    zIndex: 1,
-    justifyContent: "space-evenly",
-    width: "300px"
+    py: 1,
+    px: 2,
+    top: "102px",
+    zIndex: 1
   }
 };
 
@@ -268,7 +267,7 @@ const MapHeader = ({
             </Flex>
             {isPaintBrushSizeSliderVisible ? (
               <Box sx={style.sliderContainer}>
-                <Box sx={{ flexShrink: 0 }}>Brush size</Box>
+                <Text sx={{ fontSize: 1, flexShrink: 0 }}>Brush size</Text>
                 <Slider
                   min={1}
                   max={5}
@@ -278,10 +277,10 @@ const MapHeader = ({
                       setPaintBrushSize(parseInt(e.target.value, 10) as PaintBrushSize)
                     );
                   }}
-                  sx={{ width: "150px" }}
+                  sx={{ width: "110px", position: "relative", top: "2px", mx: 2 }}
                   value={paintBrushSize}
                 />
-                <Box>{paintBrushSize}</Box>
+                <Text sx={{ fontSize: 1, flexShrink: 0 }}>{paintBrushSize}</Text>
               </Box>
             ) : null}
 


### PR DESCRIPTION
## Overview

Minor style cleanup for paintbrush size panel.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-08-12 at 11 57 06 AM](https://user-images.githubusercontent.com/1809908/129229056-1315bf8d-540e-45dd-b4c5-01c1b90dce32.png)

### Notes

To reduce the size of this panel (so it wouldn't cover as much of the map), I made the following changes:

- Used smaller text
- Reduced slider width
- Reduced panel padding


## Testing Instructions

- Switch to paintbrush drawing mode
- The panel should look similar to the attached screenshot