### PR TITLE
Hide archived projects from community maps view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redirect to home screen after successful login [#895](https://github.com/PublicMapping/districtbuilder/pull/895)
 - Improved handling large number of import flags [#888](https://github.com/PublicMapping/districtbuilder/pull/888)
 - Fixed creating districts from project template [#905](https://github.com/PublicMapping/districtbuilder/pull/905)
+- Hide archived projects from community maps page [#927](https://github.com/PublicMapping/districtbuilder/pull/927)
 
 ## [1.6.0] - 2021-05-24
 

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -73,9 +73,11 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
   async findAllPublishedProjectsPaginated(
     options: AllProjectsOptions
   ): Promise<Pagination<Project>> {
-    const builder = this.getProjectsBase().andWhere("project.visibility = :published", {
-      published: ProjectVisibility.Published
-    });
+    const builder = this.getProjectsBase()
+      .andWhere("project.visibility = :published", {
+        published: ProjectVisibility.Published
+      })
+      .andWhere("project.archived = FALSE");
     const builderWithFilter = options.completed
       ? // Completed projects are defined as having no geo units assigned to the unassigned district
         //
@@ -88,6 +90,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
     const builderWithRegion = options.region
       ? builderWithFilter.andWhere("regionConfig.regionCode = :region", { region: options.region })
       : builderWithFilter;
+
     return this.simplifyDistricts(paginate<Project>(builderWithRegion, options));
   }
 


### PR DESCRIPTION
## Overview

Makes archived projects no longer displayed in the community maps view

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible



## Testing Instructions

- Create a completed project and archive it
- Go to the community maps page. It will still show up on `develop`, but should be hidden here

Closes #925 
