### PR TITLE
Properly handle Projects with a null districts column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.1] - 2021-08-12
 
 ### Fixed
+- Fixed loading mini-maps for Projects w/o cached districts column
 
 ## [1.7.0] - 2021-08-12
 

--- a/src/client/components/map/ProjectDistrictsMap.tsx
+++ b/src/client/components/map/ProjectDistrictsMap.tsx
@@ -45,7 +45,7 @@ const ProjectDistrictsMap = ({
       return;
     }
 
-    districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
+    districts && districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
       // On the main project screen the unassigned district isn't colored in,
       // but for the minimap we need it to be visible to define the state borders
 

--- a/src/client/components/map/ProjectDistrictsMap.tsx
+++ b/src/client/components/map/ProjectDistrictsMap.tsx
@@ -45,13 +45,14 @@ const ProjectDistrictsMap = ({
       return;
     }
 
-    districts && districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
-      // On the main project screen the unassigned district isn't colored in,
-      // but for the minimap we need it to be visible to define the state borders
+    districts &&
+      districts.features.forEach((feature: DistrictGeoJSON, id: number) => {
+        // On the main project screen the unassigned district isn't colored in,
+        // but for the minimap we need it to be visible to define the state borders
 
-      // eslint-disable-next-line functional/immutable-data
-      feature.properties.color = id === 0 ? "#EDEDED" : getDistrictColor(id);
-    });
+        // eslint-disable-next-line functional/immutable-data
+        feature.properties.color = id === 0 ? "#EDEDED" : getDistrictColor(id);
+      });
 
     const bounds = districts && (bbox(districts) as BBox2d);
     const map = new MapboxGL.Map({

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -433,7 +433,7 @@ export class ProjectsController implements CrudController<Project> {
     }
 
     // If the districts are out-of-date, recalculate them and save
-    if (project.regionConfigVersion !== project.regionConfig.version) {
+    if (!project.districts || project.regionConfigVersion !== project.regionConfig.version) {
       const districts = await this.getGeojson({
         regionConfig: project.regionConfig,
         numberOfDistricts: project.numberOfDistricts,

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -66,7 +66,7 @@ export class Project implements IProject {
     name: "districts",
     nullable: true
   })
-  districts: DistrictsGeoJSON;
+  districts?: DistrictsGeoJSON;
 
   @ManyToOne(() => User, { nullable: false, eager: true })
   @JoinColumn({ name: "user_id" })

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -54,28 +54,29 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
   async simplifyDistricts(page: Promise<Pagination<Project>>): Promise<Pagination<Project>> {
     const projects = await page;
     projects.items.forEach(project => {
-      project.districts.features.forEach(districtFeature => {
-        // Some very small holes may collapse to a single point during the merge operation,
-        // and generate invalid polygons that cause simplify to fail
-        //eslint-disable-next-line functional/immutable-data
-        districtFeature.geometry.coordinates = districtFeature.geometry.coordinates
-          .map(polygonCoords =>
-            polygonCoords.flatMap(ringCoords => {
-              if (ringCoords.every(coord => _.isEqual(coord, ringCoords[0]))) {
-                return [];
-              }
-              return [ringCoords];
-            })
-          )
-          .filter(polygonCoords => polygonCoords.length > 0);
-        try {
-          simplify(districtFeature, { mutate: true, tolerance: 0.005 });
-        } catch (e) {
-          this.logger.debug(
-            `Could not simplify district ${districtFeature.id} for project ${project.id}: ${e}`
-          );
-        }
-      });
+      project.districts &&
+        project.districts.features.forEach(districtFeature => {
+          // Some very small holes may collapse to a single point during the merge operation,
+          // and generate invalid polygons that cause simplify to fail
+          //eslint-disable-next-line functional/immutable-data
+          districtFeature.geometry.coordinates = districtFeature.geometry.coordinates
+            .map(polygonCoords =>
+              polygonCoords.flatMap(ringCoords => {
+                if (ringCoords.every(coord => _.isEqual(coord, ringCoords[0]))) {
+                  return [];
+                }
+                return [ringCoords];
+              })
+            )
+            .filter(polygonCoords => polygonCoords.length > 0);
+          try {
+            simplify(districtFeature, { mutate: true, tolerance: 0.005 });
+          } catch (e) {
+            this.logger.debug(
+              `Could not simplify district ${districtFeature.id} for project ${project.id}: ${e}`
+            );
+          }
+        });
     });
     return projects;
   }


### PR DESCRIPTION
## Overview

Some of our projects on production are from before we were caching 'districts', and don't have a precomputed districts column for us to use.

Gracefully handle these cases in by simply not displaying a mini-map in the frontend and skipping simplification in the backend.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_](https://user-images.githubusercontent.com/4432106/129261587-1ef43672-c693-4701-91e1-f735bb66f14d.png)


## Testing Instructions

- Null out the `districts` column of your projects (I simply ran `UPDATE project SET districts = NULL` in a SQL shell).
- On `develop` the Home Screen will crash
- On this branch it should load, but not display the mini-map

