### PR TITLE
Revert "Temporarily hide Community Maps page"

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -67,6 +67,7 @@ const App = () => (
           </PrivateRoute>
           <Route path="/projects/:projectId" exact={true} component={ProjectScreen} />
           <Route path="/login" exact={true} component={LoginScreen} />
+          <Route path="/maps" exact={true} component={PublishedMapsListScreen} />
           <Route path="/register" exact={true} component={RegistrationScreen} />
           <Route path="/forgot-password" exact={true} component={ForgotPasswordScreen} />
           <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />

--- a/src/client/components/SiteHeader.tsx
+++ b/src/client/components/SiteHeader.tsx
@@ -204,6 +204,11 @@ const SiteHeader = ({ user }: Props) => {
             {user.resource.organizations.length > 0 && (
               <OrganizationDropdown organizations={user.resource.organizations} />
             )}
+            <span sx={style.linkItem}>
+              <NavLink exact to="/maps">
+                Community maps
+              </NavLink>
+            </span>
             <span
               sx={{
                 svg: { display: "none" },


### PR DESCRIPTION
## Overview

This reverts commit cac25cd1c9f5619c91c8109624b88fa401fe85a1.

We hid the page because it was too slow to load on production, I've created https://github.com/PublicMapping/districtbuilder/issues/934 to track this