### PR TITLE
Style cleanup for Majority-Minority race chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve style for Majority-minor district indicator [#937](https://github.com/PublicMapping/districtbuilder/pull/937)
+
 ### Fixed
 
 ## [1.7.0] - 2021-08-12

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -94,7 +94,7 @@ const DemographicsTooltip = ({
       {isMajorityMinority && (
         <Box>
           <Divider sx={{ my: 1, borderColor: "gray.6" }} />
-          <Box>* Minority majority district</Box>
+          <Box sx={{ borderLeft: "1px dashed", pl: "6px" }}>Majority-minority district</Box>
         </Box>
       )}
     </Box>

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -139,7 +139,9 @@ const style: ThemeUIStyleObject = {
     mr: 2
   },
   deviationIcon: {
-    ml: "15px"
+    ml: "6px",
+    position: "relative",
+    top: "1px"
   },
   unassignedColor: {
     border: "1px solid",
@@ -690,10 +692,17 @@ const SidebarRow = memo(
               }
             >
               <Flex>
-                <span sx={style.chart}>
+                <span
+                  sx={{
+                    borderLeft: "1px dashed",
+                    borderColor: isMajorityMinority(district) ? "gray.8" : "transparent",
+                    pl: "1px",
+                    position: "relative",
+                    left: "-2px"
+                  }}
+                >
                   <DemographicsChart demographics={demographics} />
                 </span>
-                {isMajorityMinority(district) && <span sx={style.minorityMajorityFlag}>*</span>}
               </Flex>
             </Tooltip>
           </Styled.td>


### PR DESCRIPTION
## Overview

Implements approved design for Majority-Minority race chart. This fell off my radar for the larger style pass. 

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-08-12 at 6 42 04 PM](https://user-images.githubusercontent.com/1809908/129279378-4d881897-52af-45c6-a7f0-898d64aa364d.png)

## Testing Instructions

- Create a Majority-Minority district
- You should see a dashed line appear next to the chart in the sidebar
- Upon hovering the chart, you should see a dashed line next to "Majority-minority district"
