### PR TITLE
Increase ECS memory and fix health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed export GeoJSON endpoint cache busting [#940](https://github.com/PublicMapping/districtbuilder/pull/940)
+- Fixed EC2-based ECS setup to use correct container [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
+- Fixed healthcheck when archived regions are loaded [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
 
 ## [1.7.1] - 2021-08-12
 

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -192,7 +192,7 @@ resource "aws_ecs_task_definition" "app_container_instance" {
 resource "aws_ecs_service" "app_container_instance" {
   name            = "${var.environment}App_EC2LaunchType"
   cluster         = aws_ecs_cluster.app.name
-  task_definition = aws_ecs_task_definition.app.arn
+  task_definition = aws_ecs_task_definition.app_container_instance.arn
 
   desired_count                      = var.container_instance_app_desired_count
   deployment_minimum_healthy_percent = var.container_instance_app_deployment_min_percent

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -56,7 +56,7 @@ export class TopologyService {
   }
 
   public layers(): Readonly<Layers> | undefined {
-    return this._layers && Object.freeze(this._layers);
+    return this._layers && Object.freeze({ ...this._layers });
   }
 
   public async get(s3URI: S3URI): Promise<GeoUnitTopology | GeoUnitProperties | void> {


### PR DESCRIPTION
## Overview

This fixes two separate issues that prevented us from starting to rollout new 2020 data:
 - The new EC2-based deployment strategy was accidentally referencing the old container image, which was limited to 30Gb of memory due to Fargate compatibility. Fixed in https://github.com/PublicMapping/districtbuilder/commit/312ea4c61ce12dfff125ad135f0481da92e165ae
 - We refactored topology service to load archived regions before loading active regions, but this broke in staging, which indirectly ended up calling `Object.freeze` on the `_layers` private member variable of `TopologyService` as part of the health check, which then broke loading topologies. Fixed in https://github.com/PublicMapping/districtbuilder/commit/8b97b0308b551f0213c463a73d34479c8ed3783b

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

This has already been tested on staging, but to test locally https://github.com/PublicMapping/districtbuilder/pull/938/commits/8b97b0308b551f0213c463a73d34479c8ed3783b you could exercise the `healthcheck` endpoint while archived TopoJSON layers are still loading, which on `develop` will prevent non-archived layers from ever loading.
