### PR TITLE
Fix export geojson endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed export GeoJSON endpoint cache busting [#940](https://github.com/PublicMapping/districtbuilder/pull/940)
 
 ## [1.7.1] - 2021-08-12
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -433,7 +433,10 @@ export class ProjectsController implements CrudController<Project> {
     }
 
     // If the districts are out-of-date, recalculate them and save
-    if (!project.districts || project.regionConfigVersion !== project.regionConfig.version) {
+    if (
+      !project.districts ||
+      project.regionConfigVersion.getTime() !== project.regionConfig.version.getTime()
+    ) {
       const districts = await this.getGeojson({
         regionConfig: project.regionConfig,
         numberOfDistricts: project.numberOfDistricts,

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -577,6 +577,7 @@ export class ProjectsController implements CrudController<Project> {
       return this.service.save({
         name: `${project.name} (2020)`,
         regionConfig: newRegion,
+        regionConfigVersion: newRegion.version,
         chamber: project.chamber,
         projectTemplate: project.projectTemplate,
         numberOfDistricts: project.numberOfDistricts,


### PR DESCRIPTION
## Overview

This is a regression introduced by #897 

Date objects are never equal to each other, so we were always recreating the geojson, which made it impossible to load projects for archived regions

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_ (3)](https://user-images.githubusercontent.com/4432106/129299117-28980af8-9699-43b3-b8bc-804a09894061.png)


## Testing Instructions

- Create a project for a 2010 region
- Archive the region and add a new 2020 region for the same state. You should be able to convert your project to use the new 2020 region.

