### PR TITLE
Fix CSV export for other user's projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed export GeoJSON endpoint cache busting [#940](https://github.com/PublicMapping/districtbuilder/pull/940)
 - Fixed EC2-based ECS setup to use correct container [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
 - Fixed healthcheck when archived regions are loaded [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
+- Fix CSV export for other user's projects [#943](https://github.com/PublicMapping/districtbuilder/pull/943)
 
 ## [1.7.1] - 2021-08-12
 

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -6,8 +6,7 @@ import {
   DistrictProperties,
   DistrictsDefinition,
   IProject,
-  MetricField,
-  GeoUnitHierarchy
+  MetricField
 } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
@@ -17,14 +16,9 @@ import {
   DEFAULT_POPULATION_DEVIATION,
   DEFAULT_PINNED_METRIC_FIELDS
 } from "../../../../shared/constants";
-import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
-import { InternalServerErrorException, Logger } from "@nestjs/common";
-import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.entity";
 
 // TODO #179: Move to shared/entities
 export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
-
-const LOGGER = new Logger("Project");
 
 @Entity()
 export class Project implements IProject {
@@ -120,45 +114,5 @@ export class Project implements IProject {
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {
     return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };
-  }
-
-  exportToCsv(geoCollection: GeoUnitTopology | GeoUnitProperties): [string, number][] {
-    const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
-    const baseGeoUnitProperties = geoCollection.topologyProperties[baseGeoLevel];
-
-    // First column is the base geounit id, second column is the district id
-    const mutableCsvRows: [string, number][] = [];
-
-    // The geounit hierarchy and district definition have the same structure (except the
-    // hierarchy always goes out to the base geounit level). Walk them both at the same time
-    // and collect the information needed for the CSV (base geounit id and district id).
-    const accumulateCsvRows = (
-      defnSubset: number | GeoUnitHierarchy,
-      hierarchySubset: GeoUnitHierarchy
-    ) => {
-      hierarchySubset.forEach((hierarchyNumOrArray, idx) => {
-        const districtOrArray = typeof defnSubset === "number" ? defnSubset : defnSubset[idx];
-        if (typeof districtOrArray === "number" && typeof hierarchyNumOrArray === "number") {
-          // The numbers found in the hierarchy are the base geounit indices of the topology.
-          // Access this item in the topology to find it's base geounit id.
-          const props: any = baseGeoUnitProperties[hierarchyNumOrArray];
-          mutableCsvRows.push([props[baseGeoLevel], districtOrArray]);
-        } else if (typeof hierarchyNumOrArray !== "number") {
-          // Keep recursing into the hierarchy until we reach the end
-          accumulateCsvRows(districtOrArray, hierarchyNumOrArray);
-        } else {
-          // This shouldn't ever happen, and would suggest a district definition/hierarchy mismatch
-          LOGGER.error(
-            "Hierarchy and districts definition mismatch",
-            districtOrArray.toString(),
-            hierarchyNumOrArray.toString()
-          );
-          throw new InternalServerErrorException();
-        }
-      });
-    };
-    accumulateCsvRows(this.districtsDefinition, geoCollection.hierarchyDefinition);
-
-    return mutableCsvRows;
   }
 }


### PR DESCRIPTION
## Overview

Fixes the error identified [https://rollbar.com/Azavea/DistrictBuilder/items/66/?item_page=0&](here): 

```
TypeError: project.exportToCsv is not a function
```

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible


### Notes

I'm not sure entirely what's going on here, aside from that this was changed in #878 as part of a refactor. When I reverted these changes by moving the function back into the controller, the issue appears to have been resolved.

## Testing Instructions

- Go to a project that is created by another user and click export
- Expect export is successful
