### PR TITLE
Retry on topology errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve style for Majority-minor district indicator [#937](https://github.com/PublicMapping/districtbuilder/pull/937)
+- Retry regions that fail to load in TopologyService [#944](https://github.com/PublicMapping/districtbuilder/pull/944)
 
 ### Fixed
 - Fixed export GeoJSON endpoint cache busting [#940](https://github.com/PublicMapping/districtbuilder/pull/940)

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -77,7 +77,8 @@ export class TopologyService {
 
   private async fetchLayer(
     s3URI: S3URI,
-    archived: boolean
+    archived: boolean,
+    numRetries = 0
   ): Promise<GeoUnitTopology | GeoUnitProperties | void> {
     try {
       const [topojsonResponse, staticMetadataResponse] = await Promise.all([
@@ -116,7 +117,10 @@ export class TopologyService {
         this.logger.error("Invalid TopoJSON or metadata bodies");
       }
     } catch (err) {
-      this.logger.error(`Unable to download static files from for ${s3URI}: ${err}`);
+      this.logger.error(
+        `Failed to load topology for '${s3URI}' ${numRetries + 1} times, err ${err}`
+      );
+      this.fetchLayer(s3URI, archived, numRetries + 1);
     }
   }
 

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -120,7 +120,7 @@ export class TopologyService {
       this.logger.error(
         `Failed to load topology for '${s3URI}' ${numRetries + 1} times, err ${err}`
       );
-      this.fetchLayer(s3URI, archived, numRetries + 1);
+      return this.fetchLayer(s3URI, archived, numRetries + 1);
     }
   }
 


### PR DESCRIPTION
## Overview

On occasion we have encountered issues downloading the required JSON files for the `TopologyService` to load, and adding more states / increasing application resources seems to have increased the frequency of this.

Retrying on errors should enable us to get past any transitory errors w/o having to redownload / parse all the states we have already loaded

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

Closes #XXX
