### PR TITLE
Parameterize database healthcheck timeout

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -124,10 +124,11 @@ locals {
     postgres_password = var.rds_database_password
     postgres_db       = var.rds_database_name
 
-    default_from_email   = "no-reply@${var.r53_public_hosted_zone}"
-    jwt_secret           = var.jwt_secret
-    jwt_expiration_in_ms = var.jwt_expiration_in_ms
-    client_url           = var.client_url
+    default_from_email     = "no-reply@${var.r53_public_hosted_zone}"
+    jwt_secret             = var.jwt_secret
+    jwt_expiration_in_ms   = var.jwt_expiration_in_ms
+    client_url             = var.client_url
+    healthcheck_db_timeout = var.healthcheck_db_timeout
 
     app_port = var.app_port
 

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -54,6 +54,10 @@
         "value": "${client_url}"
       },
       {
+        "name": "HEALTHCHECK_DB_TIMEOUT",
+        "value": "${healthcheck_db_timeout}"
+      },
+      {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_access_token}"
       },

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -327,6 +327,10 @@ variable "client_url" {
   type = string
 }
 
+variable "healthcheck_db_timeout" {
+  type = string
+}
+
 variable "rollbar_access_token" {
   type = string
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,9 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - JWT_SECRET=insecure
-      - JWT_EXPIRATION_IN_MS=604800000  # 1 week
-      - CLIENT_URL=http://localhost:3003  # TODO: make this configurable per environment
+      - JWT_EXPIRATION_IN_MS=604800000 # 1 week
+      - CLIENT_URL=http://localhost:3003
+      - HEALTHCHECK_DB_TIMEOUT=5000
     build:
       context: ./src/server
       dockerfile: Dockerfile

--- a/src/server/src/healthcheck/healthcheck.controller.ts
+++ b/src/server/src/healthcheck/healthcheck.controller.ts
@@ -19,8 +19,12 @@ export class HealthcheckController {
   @Get()
   @HealthCheck()
   healthCheck(): Promise<HealthCheckResult> {
+    // If timeout is 'undefined' we'll use the default of 1000ms
+    const timeout = process.env.HEALTHCHECK_DB_TIMEOUT
+      ? Number(process.env.HEALTHCHECK_DB_TIMEOUT)
+      : undefined;
     return this.health.check([
-      async () => this.db.pingCheck("database", { timeout: 3000 }),
+      async () => this.db.pingCheck("database", { timeout }),
       () => this.topoLoaded.isHealthy("topology")
     ]);
   }


### PR DESCRIPTION
## Overview

Allows changing the timeout for the database healthcheck via environment / Terraform variables

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/129768043-b7c0a418-7fcb-485d-9b18-d34fa8639979.png)


### Notes

I haven't updated the `.tfvars` files yet for staging / production

## Testing Instructions
 - Running `scripts/infra plan` should request a value for `healthcheck_db_timeout` and the plan should show it threaded through to the container
 - Turning off your local database and then hitting [http://localhost:3005/healthcheck](http://localhost:3005/healthcheck) should timeout based on the passed in environment variable.