### PR TITLE
Add levers to tune LB health check configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+Add levers to tune LB health check configuration [#950](https://github.com/PublicMapping/districtbuilder/pull/950)
 ### Changed
 
 ### Fixed
-
 
 ## [1.7.2] - 2021-08-13
 

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -54,13 +54,13 @@ resource "aws_lb_target_group" "app" {
   name = "tg${var.environment}App"
 
   health_check {
-    healthy_threshold   = "3"
-    interval            = "30"
+    healthy_threshold   = var.target_group_health_check_healthy_threshold
+    interval            = var.target_group_health_check_interval
     matcher             = "200"
     protocol            = "HTTP"
-    timeout             = "3"
+    timeout             = var.target_group_health_check_timeout
     path                = "/healthcheck"
-    unhealthy_threshold = "2"
+    unhealthy_threshold = var.target_group_health_check_unhealthy_threshold
   }
 
   port     = "80"
@@ -124,11 +124,15 @@ locals {
     postgres_password = var.rds_database_password
     postgres_db       = var.rds_database_name
 
-    default_from_email     = "no-reply@${var.r53_public_hosted_zone}"
-    jwt_secret             = var.jwt_secret
-    jwt_expiration_in_ms   = var.jwt_expiration_in_ms
-    client_url             = var.client_url
-    health_check_db_timeout = var.health_check_db_timeout
+    # The database health check is wrapped within a promise that will reject in
+    # the specified number of milliseconds.
+    # https://github.com/nestjs/terminus/blob/d5226a9334abfe1112c523c3b92cdc7214a26025/lib/health-indicator/database/typeorm.health.ts#L90-L114
+    typeorm_health_check_timeout = var.typeorm_health_check_timeout * 1000
+
+    default_from_email   = "no-reply@${var.r53_public_hosted_zone}"
+    jwt_secret           = var.jwt_secret
+    jwt_expiration_in_ms = var.jwt_expiration_in_ms
+    client_url           = var.client_url
 
     app_port = var.app_port
 

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -26,6 +26,10 @@
         "value": "${postgres_db}"
       },
       {
+        "name": "TYPEORM_HEALTH_CHECK_TIMEOUT",
+        "value": "${typeorm_health_check_timeout}"
+      },
+      {
         "name": "NODE_ENV",
         "value": "${environment}"
       },
@@ -52,10 +56,6 @@
       {
         "name": "CLIENT_URL",
         "value": "${client_url}"
-      },
-      {
-        "name": "HEALTH_CHECK_DB_TIMEOUT",
-        "value": "${health_check_db_timeout}"
       },
       {
         "name": "ROLLBAR_ACCESS_TOKEN",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -315,6 +315,31 @@ variable "fargate_app_cli_memory" {
   type = number
 }
 
+variable "target_group_health_check_healthy_threshold" {
+  default = 3
+  type    = number
+}
+
+variable "target_group_health_check_interval" {
+  default = 30
+  type    = number
+}
+
+variable "target_group_health_check_timeout" {
+  default = 3
+  type    = number
+}
+
+variable "target_group_health_check_unhealthy_threshold" {
+  default = 2
+  type    = number
+}
+
+variable "typeorm_health_check_timeout" {
+  default = 3
+  type    = number
+}
+
 variable "jwt_secret" {
   type = string
 }
@@ -324,10 +349,6 @@ variable "jwt_expiration_in_ms" {
 }
 
 variable "client_url" {
-  type = string
-}
-
-variable "health_check_db_timeout" {
   type = string
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder
       - POSTGRES_DB=districtbuilder
+      - TYPEORM_HEALTH_CHECK_TIMEOUT=3000
       - NODE_ENV=Development
       - NODE_OPTIONS=--max-old-space-size=16384
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
@@ -27,7 +28,6 @@ services:
       - JWT_SECRET=insecure
       - JWT_EXPIRATION_IN_MS=604800000 # 1 week
       - CLIENT_URL=http://localhost:3003
-      - HEALTH_CHECK_DB_TIMEOUT=5000
     build:
       context: ./src/server
       dockerfile: Dockerfile

--- a/src/server/src/healthcheck/healthcheck.controller.ts
+++ b/src/server/src/healthcheck/healthcheck.controller.ts
@@ -20,8 +20,8 @@ export class HealthcheckController {
   @HealthCheck()
   healthCheck(): Promise<HealthCheckResult> {
     // If timeout is 'undefined' we'll use the default of 1000ms
-    const timeout = process.env.HEALTH_CHECK_DB_TIMEOUT
-      ? Number(process.env.HEALTH_CHECK_DB_TIMEOUT)
+    const timeout = process.env.TYPEORM_HEALTH_CHECK_TIMEOUT
+      ? Number(process.env.TYPEORM_HEALTH_CHECK_TIMEOUT)
       : undefined;
     return this.health.check([
       async () => this.db.pingCheck("database", { timeout }),


### PR DESCRIPTION
## Overview

I made the following changes in order to make it easier to tune different aspects of our health checks:

- Parameterized health check timing at the [target group level](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html).
- Refactored `HEALTH_CHECK_DB_TIMEOUT` → `TYPEORM_HEALTH_CHECK_TIMEOUT`.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

See that Terraform is up-to-date.

```console
docker-compose -f docker-compose.ci.yml run --rm terraform
export GIT_COMMIT=96ec7f1
./scripts/infra plan

. . .

No changes. Infrastructure is up-to-date.
```

See that health checks in the EC2 and ECS console match what is codified in the .tfvars file:

<details>

<img width="2000" alt="image" src="https://user-images.githubusercontent.com/1774125/129792410-5f80a595-23aa-4071-a5c1-d41adc16f3a1.png">

</details>

<details>

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/1774125/129792775-08c95855-e34c-4bb4-ba25-99720e1fc644.png">

</details>

