### PR TITLE
Fix CSV import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add levers to tune LB health check configuration [#950](https://github.com/PublicMapping/districtbuilder/pull/950)
+
 ### Changed
 - Parameterize `max_old_space_size` [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
 - Don't define container-level CPU reservation [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scale `vm.max_map_count` with container memory usage [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
 
 ### Fixed
+- Fix CSV import by increasing max JSON payload to 50mb [#951](https://github.com/PublicMapping/districtbuilder/pull/951)
 - Fix CSV export for other user's projects [#943](https://github.com/PublicMapping/districtbuilder/pull/943)
 
 ## [1.7.2] - 2021-08-13

--- a/src/server/src/main.ts
+++ b/src/server/src/main.ts
@@ -4,6 +4,7 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { BadRequestExceptionFilter } from "./common/bad-request-exception.filter";
 import { DEBUG } from "./common/constants";
+import * as bodyParser from "body-parser";
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule, {
@@ -19,6 +20,8 @@ async function bootstrap(): Promise<void> {
   );
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
   app.useGlobalFilters(new BadRequestExceptionFilter());
+  app.use(bodyParser.json({ limit: "25mb" }));
+  app.use(bodyParser.urlencoded({ limit: "25mb", extended: true }));
 
   // Save the output of 'listen' to a variable, which is a Node http.Server
   const server = await app.listen(3005);


### PR DESCRIPTION
## Overview

Fix CSV import by allowing JSON payloads of up to 50mb, instead of the default which was originally 100kb

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible



## Testing Instructions

- `./scripts/server`
- Attempt to upload the attached CSVs and create new projects for them. Note that PA requires 2020 data 

Closes #945 
