### PR TITLE
Disable Send to Plan Score button for incomplete projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix CSV export for other user's projects [#943](https://github.com/PublicMapping/districtbuilder/pull/943)
+- Disable Send to Plan Score button for incomplete projects [#957](https://github.com/PublicMapping/districtbuilder/pull/957)
 
 
 ## [1.7.2] - 2021-08-13

--- a/src/client/components/evaluate/detail/Competitiveness.tsx
+++ b/src/client/components/evaluate/detail/Competitiveness.tsx
@@ -8,6 +8,7 @@ import { formatPvi, computeRowFill, calculatePVI } from "../../../functions";
 import { checkPlanScoreAPI } from "../../../api";
 import { IProject, PlanScoreAPIResponse } from "../../../../shared/entities";
 import CompetitivenessChart from "./CompetitivenessChart";
+import Tooltip from "../../Tooltip";
 
 const style: ThemeUIStyleObject = {
   table: {
@@ -75,6 +76,7 @@ const CompetitivenessMetricDetail = ({
   const [planScoreLoaded, setPlanScoreLoaded] = useState<boolean | null>(null);
   const [planScoreLink, setPlanScoreLink] = useState<string | null>(null);
   const choroplethStops = getPviSteps();
+  const projectIsComplete = geojson && geojson.features[0].geometry.coordinates.length === 0;
   function sendToPlanScore() {
     setPlanScoreLoaded(false);
     project &&
@@ -153,11 +155,17 @@ const CompetitivenessMetricDetail = ({
               },
               ...style.menuButton
             }}
-            disabled={planScoreLoaded === false}
+            disabled={planScoreLoaded === false || !projectIsComplete}
             onClick={() => sendToPlanScore()}
           >
             {planScoreLoaded === null ? (
-              <span>Send to PlanScore API</span>
+              projectIsComplete ? (
+                <span>Send to PlanScore API</span>
+              ) : (
+                <Tooltip content={"Complete your project before sending to PlanScore"}>
+                  <span>Send to PlanScore API</span>
+                </Tooltip>
+              )
             ) : (
               <span>
                 Loading&nbsp;


### PR DESCRIPTION
## Overview

Disables the send to plan score button for any projects that have unassigned areas

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/129969800-2664d285-8dc9-4841-98d9-ec519aa357cf.png)



## Testing Instructions

- Create an incomplete project and go to Evaluate Mode -> Competitiveness
- Expect: the Send to Plan Score button is disabled
- Complete the project, then return to Competitiveness page
- Expect: the Send to Plan Score button is now enabled again


Closes #906 
