### PR TITLE
Allow retrieving the PlanScore for another users project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Disable Send to Plan Score button for incomplete projects [#957](https://github.com/PublicMapping/districtbuilder/pull/957)
+- Fix Send to Plan Score button for other users projects [#958](https://github.com/PublicMapping/districtbuilder/pull/958)
 
 ## [1.8.0] - 2021-08-19
 


### PR DESCRIPTION
## Overview

Fixes an issue I encountered in the course of testing #957 

Also refactors the `getProjectWithDistricts` method to remove redundant SQL WHERE clauses.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Attempt to submit PlanScore data for another users project. On `develop` this will fail w/ status code 401. On this branch it will return 200 (unless the PlanScore API is still down, in which case it will return 502).
