### PR TITLE
Set custom bbox for projects in Alaska

### DIFF
--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -316,9 +316,11 @@ const DistrictsMap = ({
     panToggled &&
     !selectionInProgress &&
     (selectionTool === SelectionTool.Rectangle || selectionTool === SelectionTool.PaintBrush);
-
   // Conversion from readonly -> mutable to match Mapbox interface
-  const [b0, b1, b2, b3] = staticMetadata.bbox;
+  const [b0, b1, b2, b3] =
+    project.regionConfig.regionCode !== "AK"
+      ? staticMetadata.bbox
+      : [-146.8, 47.175091, -177.999, 73.439786];
 
   const selectedGeolevel = getSelectedGeoLevel(staticMetadata.geoLevelHierarchy, geoLevelIndex);
 


### PR DESCRIPTION
## Overview

Sets a custom bbox for projects in Alaska 

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/130286873-379b43f6-e354-42ac-bb64-de9a962923f4.png)


### Notes

I tested on a few different screen sizes and seems like the current bounding box works pretty well on larger and smaller screens.

## Testing Instructions

- Create a `region_config` for Alaska
- Create a project in Alaska 
- Close and re-open the project - expect project to zoom to Alaska, as opposed to Europe like `develop`

Closes #953 
