### PR TITLE
Fix PVI calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed map outline ordering [#968](https://github.com/PublicMapping/districtbuilder/pull/968)
 - Fixed pinned metrics for read-only projects [#976](https://github.com/PublicMapping/districtbuilder/pull/976)
 - Fix duplicate button for projects in archived regions [#978](https://github.com/PublicMapping/districtbuilder/pull/978)
+- Fix PVI calculation to not include third party votes & calc average correctly [#977](https://github.com/PublicMapping/districtbuilder/pull/977)
 
 ## [1.8.0] - 2021-08-19
 

--- a/src/client/components/PVIDisplay.tsx
+++ b/src/client/components/PVIDisplay.tsx
@@ -43,7 +43,7 @@ const PVIDisplay = ({
       placement="top-start"
       content={
         pvi !== undefined ? (
-          <VotingSidebarTooltip voting={voting} />
+          <VotingSidebarTooltip voting={voting} excludeOther={true} />
         ) : (
           <em>
             <strong>Empty district.</strong> Add people to this district to view the vote totals

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -566,7 +566,7 @@ const SidebarRow = memo(
     const otherDemographics = "other" in demographics;
 
     function getPartyVoteShareDisplay(party1: number, party2: number, party3: number): string {
-      const percent = calculatePartyVoteShare(party1, party2, party3);
+      const percent = calculatePartyVoteShare(party1, party2 + party3);
       return percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0";
     }
 

--- a/src/client/components/VotingSidebarTooltip.tsx
+++ b/src/client/components/VotingSidebarTooltip.tsx
@@ -72,10 +72,12 @@ const Row = ({
 
 const getRows = ({
   voting,
-  year
+  year,
+  excludeOther
 }: {
   readonly voting: DemographicCounts;
   readonly year?: ElectionYear;
+  readonly excludeOther?: boolean;
 }) => {
   const votesForYear = extractYear(voting, year);
   const total = sum(Object.values(votesForYear));
@@ -86,22 +88,30 @@ const getRows = ({
   ).sort(([a], [b]) => {
     return order.indexOf(b) - order.indexOf(a);
   });
-  const rows = percentages.map(([party, percent]) => (
-    <Row
-      key={party}
-      party={party}
-      votes={votesForYear[party]}
-      percent={percent}
-      color={getPartyColor(party)}
-    />
-  ));
+  const rows = percentages.map(([party, percent]) =>
+    !excludeOther || party !== "other party" ? (
+      <Row
+        key={party}
+        party={party}
+        votes={votesForYear[party]}
+        percent={percent}
+        color={getPartyColor(party)}
+      />
+    ) : null
+  );
   return rows.length > 0 ? rows : null;
 };
 
-const VotingSidebarTooltip = ({ voting }: { readonly voting: DemographicCounts }) => {
-  const rows16 = getRows({ voting, year: "16" });
-  const rows20 = getRows({ voting, year: "20" });
-  const unspecifiedRows = !rows16 && !rows20 && getRows({ voting });
+const VotingSidebarTooltip = ({
+  voting,
+  excludeOther
+}: {
+  readonly voting: DemographicCounts;
+  readonly excludeOther?: boolean;
+}) => {
+  const rows16 = getRows({ voting, year: "16", excludeOther });
+  const rows20 = getRows({ voting, year: "20", excludeOther });
+  const unspecifiedRows = !rows16 && !rows20 && getRows({ voting, excludeOther });
 
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -123,10 +123,9 @@ const nationalDemVoteShareAvg = nationalDemVoteShare16 + nationalDemVoteShare20 
 // Computes share of votes for party1
 export function calculatePartyVoteShare(
   party1Votes: number,
-  party2Votes: number,
   otherVotes: number
 ): number | undefined {
-  const total = party1Votes + party2Votes + otherVotes;
+  const total = party1Votes + otherVotes;
   return total ? (100 * party1Votes) / total : undefined;
 }
 
@@ -161,16 +160,8 @@ export function calculatePVI(voting: DemographicCounts, year?: ElectionYear): nu
     year !== "16" &&
     year !== "20"
   ) {
-    const votes16 = calculatePartyVoteShare(
-      voting.democrat16,
-      voting.republican16,
-      voting["other party16"] || 0
-    );
-    const votes20 = calculatePartyVoteShare(
-      voting.democrat20,
-      voting.republican20,
-      voting["other party20"] || 0
-    );
+    const votes16 = calculatePartyVoteShare(voting.democrat16, voting.republican16);
+    const votes20 = calculatePartyVoteShare(voting.democrat20, voting.republican20);
     if (votes16 !== undefined && votes20 !== undefined) {
       const avgVoteShare = votes16 + votes20 / 2;
       return avgVoteShare - nationalDemVoteShareAvg;
@@ -178,13 +169,9 @@ export function calculatePVI(voting: DemographicCounts, year?: ElectionYear): nu
   } else if (year === "20") {
     const voteShare =
       "democrat20" in voting && "republican20" in voting
-        ? calculatePartyVoteShare(
-            voting.democrat20,
-            voting.republican20,
-            voting["other party20"] || 0
-          )
+        ? calculatePartyVoteShare(voting.democrat20, voting.republican20)
         : "democrat" in voting && "republican" in voting
-        ? calculatePartyVoteShare(voting.democrat, voting.republican, voting["other party"] || 0)
+        ? calculatePartyVoteShare(voting.democrat, voting.republican)
         : undefined;
     if (voteShare !== undefined) {
       return voteShare - nationalDemVoteShare20;
@@ -194,13 +181,9 @@ export function calculatePVI(voting: DemographicCounts, year?: ElectionYear): nu
     // We assume unspecified vote totals are from 2016
     const voteShare =
       "democrat16" in voting && "republican16" in voting
-        ? calculatePartyVoteShare(
-            voting.democrat16,
-            voting.republican16,
-            voting["other party16"] || 0
-          )
+        ? calculatePartyVoteShare(voting.democrat16, voting.republican16)
         : "democrat" in voting && "republican" in voting
-        ? calculatePartyVoteShare(voting.democrat, voting.republican, voting["other party"] || 0)
+        ? calculatePartyVoteShare(voting.democrat, voting.republican)
         : undefined;
     if (voteShare !== undefined) {
       return voteShare - nationalDemVoteShare16;

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -118,7 +118,7 @@ export function computeRowFill(stops: ChoroplethSteps, value?: number, interval?
 // Source: https://cookpolitical.com/analysis/national/pvi/introducing-2021-cook-political-report-partisan-voter-index
 const nationalDemVoteShare16 = 51.1;
 const nationalDemVoteShare20 = 52.3;
-const nationalDemVoteShareAvg = nationalDemVoteShare16 + nationalDemVoteShare20 / 2;
+const nationalDemVoteShareAvg = (nationalDemVoteShare16 + nationalDemVoteShare20) / 2;
 
 // Computes share of votes for party1
 export function calculatePartyVoteShare(
@@ -163,7 +163,7 @@ export function calculatePVI(voting: DemographicCounts, year?: ElectionYear): nu
     const votes16 = calculatePartyVoteShare(voting.democrat16, voting.republican16);
     const votes20 = calculatePartyVoteShare(voting.democrat20, voting.republican20);
     if (votes16 !== undefined && votes20 !== undefined) {
-      const avgVoteShare = votes16 + votes20 / 2;
+      const avgVoteShare = (votes16 + votes20) / 2;
       return avgVoteShare - nationalDemVoteShareAvg;
     }
   } else if (year === "20") {


### PR DESCRIPTION
## Overview

We were incorrectly including other party vote totals in calculating vote share for PVI, which should instead use the two-party vote share to calculate vote totals.

_Edit_ Additionally, we were calculating the 16 / 20 combined averages incorrectly, fixed in https://github.com/PublicMapping/districtbuilder/pull/977/commits/4f9224540feb152a37b97f4f6e19c7513f833ade

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

On `develop` we incorrectly calculate PVI for AZ as R+8 when it should be ~R+4~ R+3.

Fixed PVI calculations, as well as omitting "other party" from the tooltip:
![image](https://user-images.githubusercontent.com/4432106/130852469-557d022d-d938-44f7-825e-91f5c0800fa3.png)


### Notes

Changing the tooltip for PVI means there will be a discrepancy between what we show in the PVI tooltip (two party vote) and what we show on the map tooltip / other voting metric tooltips, where we will include thrid parties when calculating vote total percentage,

## Testing Instructions

- `scripts/server`
- Load / create a project for a region with voting data (see https://docs.google.com/spreadsheets/d/1ugX-ku_rwooZZ5DAI5NuCpQCcVGT67fWYz2V22ICm8w/edit#gid=645349603). The PVI column should now calculate w/o other party votes counted.

Closes #970 
