### PR TITLE
Reduce copy length when political data unavailable

### DIFF
--- a/src/client/components/PVIDisplay.tsx
+++ b/src/client/components/PVIDisplay.tsx
@@ -54,7 +54,7 @@ const PVIDisplay = ({
       <span>{votingDisplay}</span>
     </Tooltip>
   ) : (
-    <span>No voting data available</span>
+    <span>N/A</span>
   );
 };
 


### PR DESCRIPTION
"No voting data available" is long and makes the sidebar very large when it appears. Reducing to "N/A" shortens it significantly and I think is a good tradeoff.

![Screen Shot 2021-08-27 at 1 59 22 PM](https://user-images.githubusercontent.com/1809908/131169676-d6f889b9-cb4d-4367-9d6c-410212b95e14.png)

