### PR TITLE
Use JSON configuration to control fields displayed in metrics table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for uploading reference layers to a project [#902](https://github.com/PublicMapping/districtbuilder/pull/902)
 
 ### Changed
+- Support extra demographic fields on metrics viewer [#984](https://github.com/PublicMapping/districtbuilder/pull/984)
 ### Fixed
 
 ## [1.9.0] - 2021-08-30

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -38,7 +38,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 'Dane County',
                 'US',
                 'WI',
-                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-08-25T19:15:41.712Z/',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-09-02T18:57:17.123Z/',
                 DEFAULT,
                 TRUE,
                 DEFAULT

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -38,7 +38,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 'Dane County',
                 'US',
                 'WI',
-                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-02-08T15:19:22.145Z/',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-08-25T19:15:41.712Z/',
                 DEFAULT,
                 TRUE,
                 DEFAULT
@@ -68,7 +68,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-09-09T19:50:10.921Z/',
                 DEFAULT,
                 DEFAULT,
-                FALSE
+                TRUE
               ), (
                 '411c5908-2a83-40e9-863b-303931a1c119',
                 'Delaware',
@@ -77,7 +77,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2021-06-11T23:03:36.938Z/',
                 DEFAULT,
                 DEFAULT,
-                TRUE
+                FALSE
              )
               ON CONFLICT DO NOTHING;
             "

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -5,14 +5,13 @@ import {
   IProject,
   IReferenceLayer,
   LockedDistricts,
-  MetricField,
   ProjectId
 } from "../../shared/entities";
 import { DynamicProjectData, StaticProjectData } from "../types";
 import { ResourceFailure } from "../resource";
 
 interface PinnedMetrics {
-  readonly pinnedMetricFields: readonly MetricField[];
+  readonly pinnedMetricFields: readonly string[];
   readonly isReadOnly: boolean;
 }
 

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -4,6 +4,7 @@ import { Box, jsx, Styled, ThemeUIStyleObject, Divider } from "theme-ui";
 
 import { demographicsColors } from "../constants/colors";
 import { getDemographicLabel } from "../../shared/functions";
+import { DEMOGRAPHIC_FIELDS_ORDER } from "../../shared/constants";
 
 const style: ThemeUIStyleObject = {
   label: {
@@ -74,18 +75,17 @@ const DemographicsTooltip = ({
     (population: number) =>
       (demographics.population ? population / demographics.population : 0) * 100
   );
-  const races = ["white", "black", "asian", "hispanic", "native", "pacific", "other"] as const;
-  const rows = races
-    .filter(race => percentages[race] !== undefined)
-    .map((id: typeof races[number]) => (
-      <Row
-        key={id}
-        id={id}
-        percent={percentages[id]}
-        color={demographicsColors[id]}
-        abbreviate={abbreviate}
-      />
-    ));
+  const rows = DEMOGRAPHIC_FIELDS_ORDER.filter(
+    race => percentages[race] !== undefined
+  ).map((id: typeof DEMOGRAPHIC_FIELDS_ORDER[number]) => (
+    <Row
+      key={id}
+      id={id}
+      percent={percentages[id]}
+      color={demographicsColors[id]}
+      abbreviate={abbreviate}
+    />
+  ));
   return (
     <Box sx={{ width: "100%", minHeight: "100%" }}>
       <Styled.table sx={{ margin: "0", width: "100%" }}>

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -571,8 +571,6 @@ const SidebarRow = memo(
         ? "0"
         : `${intermediateDeviation > 0 ? "+" : ""}${intermediateDeviation.toLocaleString()}`;
 
-    const otherDemographics = "other" in demographics;
-
     function getPartyVoteShareDisplay(party1: number, party2: number, party3: number): string {
       const percent = calculatePartyVoteShare(party1, party2 + party3);
       return percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0";
@@ -594,6 +592,13 @@ const SidebarRow = memo(
       Object.keys(district.properties.voting || {}).length > 0
         ? district.properties.voting
         : undefined;
+
+    const isVisible = (field: MetricField) =>
+      pinnedMetricFields.includes(field) || expandedProjectMetrics;
+    const isDemographicVisible = (field: MetricField, key: string) =>
+      isVisible(field) && key in demographics;
+    const isVotingVisible = (field: MetricField, keys: readonly string[]) =>
+      voting && isVisible(field) && keys.some(key => key in voting);
 
     return (
       <Styled.tr
@@ -626,12 +631,12 @@ const SidebarRow = memo(
             )}
           </Flex>
         </Styled.td>
-        {(pinnedMetricFields.includes("population") || expandedProjectMetrics) && (
+        {isVisible("population") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             {populationDisplay}
           </Styled.td>
         )}
-        {(pinnedMetricFields.includes("populationDeviation") || expandedProjectMetrics) && (
+        {isVisible("populationDeviation") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             <Tooltip
               placement="top-start"
@@ -684,7 +689,7 @@ const SidebarRow = memo(
             </Tooltip>
           </Styled.td>
         )}
-        {(pinnedMetricFields.includes("raceChart") || expandedProjectMetrics) && (
+        {isVisible("raceChart") && (
           <Styled.td sx={style.td}>
             <Tooltip
               placement="top-start"
@@ -718,17 +723,17 @@ const SidebarRow = memo(
             </Tooltip>
           </Styled.td>
         )}
-        {(pinnedMetricFields.includes("whitePopulation") || expandedProjectMetrics) && (
+        {isDemographicVisible("whitePopulation", "white") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             <span>{computeDemographicSplit(demographics.white, intermediatePopulation)}%</span>
           </Styled.td>
         )}
-        {(pinnedMetricFields.includes("blackPopulation") || expandedProjectMetrics) && (
+        {isDemographicVisible("blackPopulation", "black") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             <span>{computeDemographicSplit(demographics.black, intermediatePopulation)}%</span>
           </Styled.td>
         )}
-        {(pinnedMetricFields.includes("asianPopulation") || expandedProjectMetrics) && (
+        {isDemographicVisible("asianPopulation", "asian") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             <span>{computeDemographicSplit(demographics.asian, intermediatePopulation)}%</span>
           </Styled.td>
@@ -738,223 +743,206 @@ const SidebarRow = memo(
             <span>{computeDemographicSplit(demographics.hispanic, intermediatePopulation)}%</span>
           </Styled.td>
         )}
-        {!otherDemographics &&
-          (pinnedMetricFields.includes("nativePopulation") || expandedProjectMetrics) && (
-            <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-              <span>{computeDemographicSplit(demographics.native, intermediatePopulation)}%</span>
-            </Styled.td>
-          )}
-        {!otherDemographics &&
-          (pinnedMetricFields.includes("pacificPopulation") || expandedProjectMetrics) && (
-            <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-              <span>{computeDemographicSplit(demographics.pacific, intermediatePopulation)}%</span>
-            </Styled.td>
-          )}
-        {otherDemographics &&
-          (pinnedMetricFields.includes("otherPopulation") || expandedProjectMetrics) && (
-            <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
-              <span>{computeDemographicSplit(demographics.other, intermediatePopulation)}%</span>
-            </Styled.td>
-          )}
-        {(pinnedMetricFields.includes("majorityRace") || expandedProjectMetrics) && (
+        {isDemographicVisible("nativePopulation", "native") && (
+          <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
+            <span>{computeDemographicSplit(demographics.native, intermediatePopulation)}%</span>
+          </Styled.td>
+        )}
+        {isDemographicVisible("pacificPopulation", "pacific") && (
+          <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
+            <span>{computeDemographicSplit(demographics.pacific, intermediatePopulation)}%</span>
+          </Styled.td>
+        )}
+        {isDemographicVisible("otherPopulation", "other") && (
+          <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
+            <span>{computeDemographicSplit(demographics.other, intermediatePopulation)}%</span>
+          </Styled.td>
+        )}
+        {isVisible("majorityRace") && (
           <Styled.td sx={{ ...style.td, ...style.number, ...{ color: textColor } }}>
             <span>{getMajorityRaceDisplay(district)}</span>
           </Styled.td>
         )}
-        {hasElectionData
-          ? (pinnedMetricFields.includes("pvi") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <PVIDisplay properties={district.properties} />
-              </Styled.td>
-            )
-          : null}
-        {voting && ("democrat16" in voting || "democrat" in voting)
-          ? (pinnedMetricFields.includes("dem16") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
+        {hasElectionData && isVisible("pvi") && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <PVIDisplay properties={district.properties} />
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("dem16", ["democrat16", "democrat"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {"democrat16" in voting
+                  ? getPartyVoteShareDisplay(
+                      voting.democrat16,
+                      voting.republican16,
+                      voting["other party16"]
                     )
-                  }
-                >
-                  <span>
-                    {"democrat16" in voting
-                      ? getPartyVoteShareDisplay(
-                          voting.democrat16,
-                          voting.republican16,
-                          voting["other party16"]
-                        )
-                      : getPartyVoteShareDisplay(
-                          voting.democrat,
-                          voting.republican,
-                          voting["other party"]
-                        )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {voting && ("republican16" in voting || "republican" in voting)
-          ? (pinnedMetricFields.includes("rep16") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
-                    )
-                  }
-                >
-                  <span>
-                    {"republican16" in voting
-                      ? getPartyVoteShareDisplay(
-                          voting.republican16,
-                          voting.democrat16,
-                          voting["other party16"]
-                        )
-                      : getPartyVoteShareDisplay(
-                          voting.republican,
-                          voting.democrat,
-                          voting["other party"]
-                        )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {voting && ("other party16" in voting || "other party" in voting)
-          ? (pinnedMetricFields.includes("other16") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
-                    )
-                  }
-                >
-                  <span>
-                    {"other party16" in voting
-                      ? getPartyVoteShareDisplay(
-                          voting["other party16"],
-                          voting.republican16,
-                          voting.democrat16
-                        )
-                      : getPartyVoteShareDisplay(
-                          voting["other party"],
-                          voting.republican,
-                          voting.democrat
-                        )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {voting && "democrat20" in voting
-          ? (pinnedMetricFields.includes("dem20") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
-                    )
-                  }
-                >
-                  <span>
-                    {getPartyVoteShareDisplay(
-                      voting.democrat20,
-                      voting.republican20,
-                      voting["other party20"]
+                  : getPartyVoteShareDisplay(
+                      voting.democrat,
+                      voting.republican,
+                      voting["other party"]
                     )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {voting && "republican20" in voting
-          ? (pinnedMetricFields.includes("rep20") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("rep16", ["republican16", "republican"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {"republican16" in voting
+                  ? getPartyVoteShareDisplay(
+                      voting.republican16,
+                      voting.democrat16,
+                      voting["other party16"]
                     )
-                  }
-                >
-                  <span>
-                    {getPartyVoteShareDisplay(
-                      voting.republican20,
-                      voting.democrat20,
-                      voting["other party20"]
+                  : getPartyVoteShareDisplay(
+                      voting.republican,
+                      voting.democrat,
+                      voting["other party"]
                     )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {voting && "other party20" in voting
-          ? (pinnedMetricFields.includes("other20") || expandedProjectMetrics) && (
-              <Styled.td sx={{ ...style.td, ...style.number }}>
-                <Tooltip
-                  placement="top-start"
-                  content={
-                    demographics.population > 0 ? (
-                      <VotingSidebarTooltip voting={voting} />
-                    ) : (
-                      <em>
-                        <strong>Empty district.</strong> Add people to this district to view the
-                        vote totals
-                      </em>
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("other16", ["other party16", "other party"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {"other party16" in voting
+                  ? getPartyVoteShareDisplay(
+                      voting["other party16"],
+                      voting.republican16,
+                      voting.democrat16
                     )
-                  }
-                >
-                  <span>
-                    {getPartyVoteShareDisplay(
-                      voting["other party20"],
-                      voting.republican20,
-                      voting.democrat20
+                  : getPartyVoteShareDisplay(
+                      voting["other party"],
+                      voting.republican,
+                      voting.democrat
                     )}
-                    %
-                  </span>
-                </Tooltip>
-              </Styled.td>
-            )
-          : null}
-        {(pinnedMetricFields.includes("compactness") || expandedProjectMetrics) && (
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("dem20", ["democrat20"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {getPartyVoteShareDisplay(
+                  voting.democrat20,
+                  voting.republican20,
+                  voting["other party20"]
+                )}
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("rep20", ["republican20"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {getPartyVoteShareDisplay(
+                  voting.republican20,
+                  voting.democrat20,
+                  voting["other party20"]
+                )}
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {voting && isVotingVisible("other20", ["other party20"]) && (
+          <Styled.td sx={{ ...style.td, ...style.number }}>
+            <Tooltip
+              placement="top-start"
+              content={
+                demographics.population > 0 ? (
+                  <VotingSidebarTooltip voting={voting} />
+                ) : (
+                  <em>
+                    <strong>Empty district.</strong> Add people to this district to view the vote
+                    totals
+                  </em>
+                )
+              }
+            >
+              <span>
+                {getPartyVoteShareDisplay(
+                  voting["other party20"],
+                  voting.republican20,
+                  voting.democrat20
+                )}
+                %
+              </span>
+            </Tooltip>
+          </Styled.td>
+        )}
+        {isVisible("compactness") && (
           <Styled.td sx={{ ...style.td, ...style.number }}>{compactnessDisplay}</Styled.td>
         )}
         {!expandedProjectMetrics && (

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -9,9 +9,8 @@ import {
   GeoUnits,
   IProject,
   IStaticMetadata,
-  LockedDistricts,
   IReferenceLayer,
-  MetricField
+  LockedDistricts
 } from "../../shared/entities";
 
 import {
@@ -62,7 +61,7 @@ interface LoadingProps {
 }
 
 interface MetricHeader {
-  readonly metric: MetricField;
+  readonly metric: string;
   readonly text: string;
   readonly tooltip: string;
 }
@@ -170,8 +169,8 @@ const MetricPinButton = ({
   pinnedMetrics,
   isReadOnly
 }: {
-  readonly metric: MetricField;
-  readonly pinnedMetrics: readonly MetricField[];
+  readonly metric: string;
+  readonly pinnedMetrics: readonly string[];
   readonly isReadOnly: boolean;
 }) => {
   const metricIsPinned = pinnedMetrics.includes(metric);
@@ -213,8 +212,8 @@ const PinnableMetricHeader = ({
   expandedProjectMetrics,
   isReadOnly
 }: {
-  readonly metric: MetricField;
-  readonly pinnedMetrics: readonly MetricField[];
+  readonly metric: string;
+  readonly pinnedMetrics: readonly string[];
   readonly text: string;
   readonly tooltip: string;
   readonly expandedProjectMetrics: boolean;
@@ -262,7 +261,7 @@ const ProjectSidebar = ({
   readonly hoveredDistrictId: number | null;
   readonly saving: SavingState;
   readonly isReadOnly: boolean;
-  readonly pinnedMetrics?: readonly MetricField[];
+  readonly pinnedMetrics?: readonly string[];
 } & LoadingProps) => {
   const multElections = hasMultipleElections(staticMetadata);
   const has2016Election = has16Election(staticMetadata);
@@ -411,6 +410,7 @@ const ProjectSidebar = ({
       tooltip: "Compactness score (Polsby-Popper)"
     }
   ];
+
   return (
     <Flex
       sx={expandedProjectMetrics ? style.sidebarExpanded : style.sidebar}
@@ -541,7 +541,7 @@ const SidebarRow = memo(
     popDeviationThreshold
   }: {
     readonly district: DistrictGeoJSON;
-    readonly pinnedMetricFields: readonly MetricField[];
+    readonly pinnedMetricFields: readonly string[];
     readonly selected: boolean;
     readonly selectedPopulationDifference?: number;
     readonly expandedProjectMetrics: boolean;
@@ -593,11 +593,11 @@ const SidebarRow = memo(
         ? district.properties.voting
         : undefined;
 
-    const isVisible = (field: MetricField) =>
+    const isVisible = (field: string) =>
       pinnedMetricFields.includes(field) || expandedProjectMetrics;
-    const isDemographicVisible = (field: MetricField, key: string) =>
+    const isDemographicVisible = (field: string, key: string) =>
       isVisible(field) && key in demographics;
-    const isVotingVisible = (field: MetricField, keys: readonly string[]) =>
+    const isVotingVisible = (field: string, keys: readonly string[]) =>
       voting && isVisible(field) && keys.some(key => key in voting);
 
     return (
@@ -991,7 +991,7 @@ interface SidebarRowsProps {
   readonly hoveredDistrictId: number | null;
   readonly selectedGeounits: GeoUnits;
   readonly expandedProjectMetrics: boolean;
-  readonly pinnedMetrics: readonly MetricField[];
+  readonly pinnedMetrics: readonly string[];
   readonly highlightedGeounits: GeoUnits;
   readonly lockedDistricts: LockedDistricts;
   readonly hasElectionData: boolean;

--- a/src/client/constants/colors.ts
+++ b/src/client/constants/colors.ts
@@ -440,5 +440,6 @@ export const demographicsColors = {
   hispanic: "#BEBADA",
   native: "#FB8071",
   pacific: "#B3DE69",
-  other: "#B3DE69"
+  multiracial: "#D77EFF",
+  other: "#5A563E"
 };

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -208,15 +208,13 @@ export const has16Election = (staticMetadata?: IStaticMetadata) => {
     staticMetadata?.voting?.some(file => file.id.endsWith("16")) ||
     (staticMetadata?.voting &&
       Object.keys(staticMetadata?.voting || {}).length > 0 &&
-      !has20Election(staticMetadata))
+      !has20Election(staticMetadata)) ||
+    false
   );
 };
 
-export const demographicsHasOther = (staticMetadata?: IStaticMetadata) =>
-  staticMetadata?.demographics?.some(file => file.id === "other");
-
 export const has20Election = (staticMetadata?: IStaticMetadata) =>
-  staticMetadata?.voting?.some(file => file.id.endsWith("20"));
+  staticMetadata?.voting?.some(file => file.id.endsWith("20")) || false;
 
 export function extractYear(voting: DemographicCounts, year?: ElectionYear): DemographicCounts {
   return year

--- a/src/client/reducers/undoRedo.ts
+++ b/src/client/reducers/undoRedo.ts
@@ -1,7 +1,7 @@
 import { CmdType } from "redux-loop";
 
 import { Action } from "../actions";
-import { DistrictsDefinition, GeoUnits, LockedDistricts, MetricField } from "../../shared/entities";
+import { DistrictsDefinition, GeoUnits, LockedDistricts } from "../../shared/entities";
 import { ProjectState } from "./project";
 
 const UNDO_HISTORY_MAX_LENGTH = 100;
@@ -12,7 +12,7 @@ export interface UndoableState {
   readonly geoLevelVisibility: ReadonlyArray<boolean>; // Visibility values at indices corresponding to `geoLevelIndex`
   readonly lockedDistricts: LockedDistricts;
   readonly districtsDefinition: DistrictsDefinition;
-  readonly pinnedMetricFields?: readonly MetricField[];
+  readonly pinnedMetricFields?: readonly string[];
 }
 
 // Accompanying effect builder for state update when undone/redone (eg. saving districts definition)

--- a/src/manage/dev-data/azavea.yaml
+++ b/src/manage/dev-data/azavea.yaml
@@ -7,6 +7,15 @@ municipality: Philadelphia
 region: PA
 
 projectTemplates:
+  - id: 3a506cad-6531-40aa-8009-95b221bd46c3
+    name: Dane County
+    regionConfig: 4a48268f-ddcf-4ae9-b41f-23cda93c3eba
+    numberOfDistricts: 18
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    details:
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+      Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
   - id: 34711584-2e4c-427d-91cf-706a14b5ddde
     name: House of Representatives
     regionConfig: 96bca832-99b3-4c4d-8913-ab4ca82ec442

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -1,10 +1,6 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 
-import {
-  DistrictsDefinition,
-  IProjectTemplateWithProjects,
-  MetricField
-} from "../../../../shared/entities";
+import { DistrictsDefinition, IProjectTemplateWithProjects } from "../../../../shared/entities";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { Organization } from "../../organizations/entities/organization.entity";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
@@ -73,7 +69,7 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
     name: "pinned_metric_fields",
     default: () => `ARRAY[${DEFAULT_PINNED_METRIC_FIELDS.map(c => `'${c}'`).join(",")}]`
   })
-  pinnedMetricFields: MetricField[];
+  pinnedMetricFields: string[];
 
   @Column({ name: "is_active", type: "boolean", default: true })
   isActive: boolean;

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -36,7 +36,11 @@ import * as _ from "lodash";
 import isUUID from "validator/lib/isUUID";
 import { Pagination } from "nestjs-typeorm-paginate";
 
-import { MakeDistrictsErrors, ConvertProjectErrors } from "../../../../shared/constants";
+import {
+  MakeDistrictsErrors,
+  ConvertProjectErrors,
+  CORE_METRIC_FIELDS
+} from "../../../../shared/constants";
 import {
   DistrictsDefinition,
   ProjectId,
@@ -65,16 +69,6 @@ import { CrosswalkService } from "../services/crosswalk.service";
 import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.entity";
 import { Brackets } from "typeorm";
 import { getDemographicsMetricFields, getVotingMetricFields } from "../../../../shared/functions";
-
-const CORE_METRIC_FIELDS = [
-  "population",
-  "populationDeviation",
-  "raceChart",
-  "majorityRace",
-  "pvi",
-  "compactness",
-  "contiguity"
-];
 
 @Crud({
   model: {

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -64,6 +64,17 @@ import axios from "axios";
 import { CrosswalkService } from "../services/crosswalk.service";
 import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.entity";
 import { Brackets } from "typeorm";
+import { getDemographicsMetricFields, getVotingMetricFields } from "../../../../shared/functions";
+
+const CORE_METRIC_FIELDS = [
+  "population",
+  "populationDeviation",
+  "raceChart",
+  "majorityRace",
+  "pvi",
+  "compactness",
+  "contiguity"
+];
 
 @Crud({
   model: {
@@ -201,11 +212,36 @@ export class ProjectsController implements CrudController<Project> {
     @ParsedRequest() req: CrudRequest,
     @ParsedBody() dto: UpdateProjectDto
   ) {
+    // Start off with some validations that can't be handled easily at the DTO layer
     const existingProject = await this.getProjectWithDistricts(id, req.parsed.authPersist.userId);
     if (dto.lockedDistricts && existingProject?.numberOfDistricts !== dto.lockedDistricts.length) {
       throw new BadRequestException({
         error: "Bad Request",
-        message: { lockedDistricts: [`Length of array does not match "number_of_districts"`] }
+        message: { lockedDistricts: [`Length of array does not match "numberOfDistricts"`] }
+      } as Errors<UpdateProjectDto>);
+    }
+
+    const staticMetadata = (await this.getGeoUnitProperties(existingProject.regionConfig.s3URI))
+      .staticMetadata;
+    const allowedDemographicFields = getDemographicsMetricFields(staticMetadata).map(
+      ([, field]) => field
+    );
+    const allowedVotingFields: readonly string[] =
+      getVotingMetricFields(staticMetadata).map(([, field]) => field) || [];
+    if (
+      dto.pinnedMetricFields &&
+      dto.pinnedMetricFields.some(
+        field =>
+          !(
+            CORE_METRIC_FIELDS.includes(field) ||
+            allowedDemographicFields.includes(field) ||
+            allowedVotingFields.includes(field)
+          )
+      )
+    ) {
+      throw new BadRequestException({
+        error: "Bad Request",
+        message: { pinnedMetricFields: [`Field not allowed in "pinnedMetricFields"`] }
       } as Errors<UpdateProjectDto>);
     }
 

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -2,12 +2,7 @@ import { FeatureCollection, MultiPolygon } from "geojson";
 import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
 import { ProjectVisibility } from "../../../../shared/constants";
-import {
-  DistrictProperties,
-  DistrictsDefinition,
-  IProject,
-  MetricField
-} from "../../../../shared/entities";
+import { DistrictProperties, DistrictsDefinition, IProject } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
@@ -111,7 +106,7 @@ export class Project implements IProject {
     name: "pinned_metric_fields",
     default: () => `ARRAY[${DEFAULT_PINNED_METRIC_FIELDS.map(c => `'${c}'`).join(",")}]`
   })
-  pinnedMetricFields: MetricField[];
+  pinnedMetricFields: string[];
 
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {

--- a/src/server/src/projects/entities/update-project.dto.ts
+++ b/src/server/src/projects/entities/update-project.dto.ts
@@ -11,7 +11,7 @@ import {
 } from "class-validator";
 
 import { ProjectVisibility } from "../../../../shared/constants";
-import { DistrictsDefinition, UpdateProjectData, MetricField } from "../../../../shared/entities";
+import { DistrictsDefinition, UpdateProjectData } from "../../../../shared/entities";
 
 export class UpdateProjectDto implements UpdateProjectData {
   @IsNotEmpty({ message: "Please enter a name for your project" })
@@ -39,7 +39,7 @@ export class UpdateProjectDto implements UpdateProjectData {
   @IsOptional()
   @IsArray()
   @ArrayNotEmpty()
-  readonly pinnedMetricFields: MetricField[];
+  readonly pinnedMetricFields: string[];
   @IsBoolean()
   @IsOptional()
   readonly archived: boolean;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,3 @@
-import { MetricField } from "./entities";
-
 export enum ForgotPasswordResponse {
   SUCCESS = "SUCCESS",
   NOT_FOUND = "NOT_FOUND"
@@ -63,7 +61,7 @@ export enum ReferenceLayerTypes {
 
 export const DEFAULT_POPULATION_DEVIATION = 5;
 
-export const DEFAULT_PINNED_METRIC_FIELDS: readonly MetricField[] = [
+export const DEFAULT_PINNED_METRIC_FIELDS = [
   "population",
   "populationDeviation",
   "raceChart",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -86,6 +86,7 @@ export const DEMOGRAPHIC_FIELDS_ORDER = [
   "hispanic",
   "native",
   "pacific",
+  "multiracial",
   "other"
 ] as const;
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -69,6 +69,26 @@ export const DEFAULT_PINNED_METRIC_FIELDS = [
   "compactness"
 ];
 
+export const CORE_METRIC_FIELDS = [
+  "population",
+  "populationDeviation",
+  "raceChart",
+  "majorityRace",
+  "pvi",
+  "compactness",
+  "contiguity"
+];
+
+export const DEMOGRAPHIC_FIELDS_ORDER = [
+  "white",
+  "black",
+  "asian",
+  "hispanic",
+  "native",
+  "pacific",
+  "other"
+] as const;
+
 export const FIPS: { readonly [fips: string]: string } = {
   "10": "DE",
   "11": "DC",

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -13,28 +13,6 @@ export type PaginationMetadata = {
 
 export type OrganizationNest = Pick<IOrganization, "slug" | "id" | "name" | "logoUrl">;
 
-export type MetricField =
-  | "population"
-  | "populationDeviation"
-  | "raceChart"
-  | "whitePopulation"
-  | "blackPopulation"
-  | "asianPopulation"
-  | "hispanicPopulation"
-  | "otherPopulation"
-  | "nativePopulation"
-  | "pacificPopulation"
-  | "majorityRace"
-  | "dem16"
-  | "rep16"
-  | "other16"
-  | "dem20"
-  | "rep20"
-  | "other20"
-  | "pvi"
-  | "compactness"
-  | "contiguity";
-
 export interface IUser {
   readonly id: UserId;
   readonly email: string;
@@ -197,7 +175,7 @@ interface ProjectTemplateFields {
   readonly numberOfDistricts: number;
   readonly chamber?: IChamber;
   readonly populationDeviation: number;
-  readonly pinnedMetricFields: readonly MetricField[];
+  readonly pinnedMetricFields: readonly string[];
   readonly districtsDefinition: DistrictsDefinition;
 }
 

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -169,6 +169,11 @@ export interface ReferenceLayerProperties {
   readonly [id: string]: number | string;
 }
 
+export type VotingMetricField = "dem16" | "rep16" | "other16" | "dem20" | "rep20" | "other20";
+
+export type MetricsList = readonly (readonly [string, string])[];
+export type VotingMetricsList = readonly (readonly [string, VotingMetricField])[];
+
 interface ProjectTemplateFields {
   readonly name: string;
   readonly regionConfig: IRegionConfig;

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -104,7 +104,7 @@ export function getDemographicsMetricFields(staticMetadata: IStaticMetadata): Me
   // Need to loosen up the types here
   const order: readonly string[] = DEMOGRAPHIC_FIELDS_ORDER;
   // eslint-disable-next-line functional/immutable-data
-  data.sort(([, a], [, b]) => order.indexOf(a) - order.indexOf(b));
+  data.sort(([a,], [b,]) => order.indexOf(a) - order.indexOf(b));
   return data;
 }
 

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -1,4 +1,13 @@
-import { UintArray, DemographicCounts, IStaticMetadata, IStaticFile } from "../shared/entities";
+import {
+  UintArray,
+  DemographicCounts,
+  IStaticMetadata,
+  IStaticFile,
+  MetricsList,
+  VotingMetricsList,
+  VotingMetricField
+} from "../shared/entities";
+import { CORE_METRIC_FIELDS, DEMOGRAPHIC_FIELDS_ORDER } from "./constants";
 
 // Helper for finding all indices in an array buffer matching a value.
 // Note: mutation is used, because the union type of array buffers proved
@@ -82,28 +91,45 @@ export function getDemographicLabel(id: string) {
     : id.split(/(?=[A-Z])/).join(" ");
 }
 
-export function getDemographicsMetricFields(staticMetadata: IStaticMetadata) {
-  return staticMetadata.demographics.map(file =>
-    file.id === "population" ? file.id : `${file.id}Population`
+export const getMetricFieldForDemographicsId = (id: string) =>
+  id === "population" ? id : `${id}Population`;
+
+export function getDemographicsMetricFields(staticMetadata: IStaticMetadata): MetricsList {
+  // eslint-disable-next-line functional/prefer-readonly-type
+  const data: (readonly [string, string])[] = staticMetadata.demographics.flatMap(file =>
+    CORE_METRIC_FIELDS.includes(file.id)
+      ? []
+      : [[file.id, getMetricFieldForDemographicsId(file.id)]]
   );
+  // Need to loosen up the types here
+  const order: readonly string[] = DEMOGRAPHIC_FIELDS_ORDER;
+  // eslint-disable-next-line functional/immutable-data
+  data.sort(([, a], [, b]) => order.indexOf(a) - order.indexOf(b));
+  return data;
 }
 
-export function getVotingMetricFields(staticMetadata: IStaticMetadata) {
-  return staticMetadata.voting
-    ?.map(file =>
-      file.id === "democrat" || file.id === "democrat16"
-        ? "dem16"
-        : file.id === "republican" || file.id === "republican16"
-        ? "rep16"
-        : file.id === "other party" || file.id === "other party16"
-        ? "other16"
-        : file.id === "democrat20"
-        ? "dem20"
-        : file.id === "republican20"
-        ? "rep20"
-        : file.id === "other party20"
-        ? "other party20"
-        : undefined
-    )
-    .filter(field => !field);
+export function getVotingMetricFields(staticMetadata: IStaticMetadata): VotingMetricsList {
+  // eslint-disable-next-line functional/prefer-readonly-type
+  const data: (readonly [string, VotingMetricField])[] =
+    staticMetadata.voting?.flatMap(file => {
+      const field =
+        file.id === "democrat" || file.id === "democrat16"
+          ? "dem16"
+          : file.id === "republican" || file.id === "republican16"
+          ? "rep16"
+          : file.id === "other party" || file.id === "other party16"
+          ? "other16"
+          : file.id === "democrat20"
+          ? "dem20"
+          : file.id === "republican20"
+          ? "rep20"
+          : file.id === "other party20"
+          ? "other20"
+          : undefined;
+      return field !== undefined ? [[file.id, field]] : [];
+    }) || [];
+  const order = ["dem16", "rep16", "other16", "dem20", "rep20", "other20"];
+  // eslint-disable-next-line functional/immutable-data
+  data.sort(([, a], [, b]) => order.indexOf(a) - order.indexOf(b));
+  return data;
 }

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -81,3 +81,29 @@ export function getDemographicLabel(id: string) {
     ? "Pacific Islander"
     : id.split(/(?=[A-Z])/).join(" ");
 }
+
+export function getDemographicsMetricFields(staticMetadata: IStaticMetadata) {
+  return staticMetadata.demographics.map(file =>
+    file.id === "population" ? file.id : `${file.id}Population`
+  );
+}
+
+export function getVotingMetricFields(staticMetadata: IStaticMetadata) {
+  return staticMetadata.voting
+    ?.map(file =>
+      file.id === "democrat" || file.id === "democrat16"
+        ? "dem16"
+        : file.id === "republican" || file.id === "republican16"
+        ? "rep16"
+        : file.id === "other party" || file.id === "other party16"
+        ? "other16"
+        : file.id === "democrat20"
+        ? "dem20"
+        : file.id === "republican20"
+        ? "rep20"
+        : file.id === "other party20"
+        ? "other party20"
+        : undefined
+    )
+    .filter(field => !field);
+}


### PR DESCRIPTION
## Overview

In the first of what we anticipate to be a number of such requests, Dane County has asked to support both "Other" and "Multiracial" as demographics, in addition to the demographics we already have for WI.

To support this, I've removed our hardcoded list of fields we support to instead be based on what is configured in the `static-metadata.json` configuration file we create when preprocessing data.

We still have a hard-coded list that we use for sorting though, instead of relying solely on the sort order in `static-metadata.json` (any fields not on the hard-coded list, like "Multiracial", will sort to the end of the grouping).

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Note the "Other" and "Multiracial" columns:
![Capture](https://user-images.githubusercontent.com/4432106/131183270-b3ef0057-0f12-477d-9333-fbf92112bbe2.PNG)
Pinning works for the new column:
![Capture2](https://user-images.githubusercontent.com/4432106/131183271-5ac92409-a6fd-4906-aa4b-3cb83efc84b7.PNG)
Existing region still working as expected:
![Capture3](https://user-images.githubusercontent.com/4432106/131183272-d05105b2-0ef5-4222-9f2a-0a51ec0fbc14.PNG)


## Testing Instructions

 - Using `scripts/dbshell`, run `TRUNCATE region_config CASCADE` to delete your regions / projects, then run `scripts/load/dev-data` to load new testing data
- Go to the testing organization http://localhost:3003/o/azavea and create a map for the Dane County template
- Use the double-arrow button in the sidebar to expand the metrics viewer
  - You should see columns for Native, Pacific, Other, and Multiracial
  - You should _not_ see a row for Multiracial in the map / sidebar tooltips

Closes #973 
