### PR TITLE
Update copy on Home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+- Updated copy on home screen for new users [#985](https://github.com/PublicMapping/districtbuilder/pull/985)
 ### Fixed
 - Disable Send to Plan Score button for incomplete projects [#957](https://github.com/PublicMapping/districtbuilder/pull/957)
 - Fix Send to Plan Score button for other users projects [#958](https://github.com/PublicMapping/districtbuilder/pull/958)

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -125,7 +125,15 @@ const HomeScreen = ({ projects, isSaving, duplicatedProject, user, pagination }:
                 >
                   getting started guide
                 </Styled.a>{" "}
-                or see <Styled.a href="/maps">community maps</Styled.a>.
+                or see <Styled.a href="/maps">community maps</Styled.a>. If you want to start
+                mapping for an organization, you&rsquo;ll need to{" "}
+                <Styled.a
+                  href="https://github.com/PublicMapping/districtbuilder/wiki/Join-an-Organization"
+                  target="_blank"
+                >
+                  join the organization
+                </Styled.a>{" "}
+                first.
               </Text>
               <Flex>
                 <Styled.a


### PR DESCRIPTION
## Overview

Updates copy on the home screen shown to users w/o any maps yet.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/131185893-ee11db21-8cdd-4773-94df-9a33cc27aac7.png)

## Testing Instructions

- Create a new user, you should be redirected to the home screen
- Observe the extra sentence. It should link to [this wiki page](https://github.com/PublicMapping/districtbuilder/wiki/Join-an-Organization)

Closes #983 
