### PR TITLE
Don't show voting data in map tooltip for regions w/o it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix duplicate button for projects in archived regions [#978](https://github.com/PublicMapping/districtbuilder/pull/978)
 - Fix PVI calculation to not include third party votes & calc average correctly [#977](https://github.com/PublicMapping/districtbuilder/pull/977)
 - Fix handling of expired authentication tokens [#986](https://github.com/PublicMapping/districtbuilder/pull/986)
+- Don't show political data for regions without it on map tooltip [#987](https://github.com/PublicMapping/districtbuilder/pull/987)
 
 ## [1.8.0] - 2021-08-19
 

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -201,7 +201,11 @@ const MapTooltip = ({
     const votingForYear =
       electionYear && data.voting ? extractYear(data.voting, electionYear) : data.voting;
     const voting =
-      votingForYear && Object.keys(votingForYear).length > 0 ? votingForYear : data.voting;
+      votingForYear && Object.keys(votingForYear).length > 0
+        ? votingForYear
+        : data.voting && Object.keys(data.voting).length > 0
+        ? data.voting
+        : undefined;
 
     return (
       <Box


### PR DESCRIPTION
## Overview

Don't show political data for regions w/o it (like the Dane County hidden region)

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/131187950-0da7fe83-14ce-4cdf-acea-94569e565dc0.png)


## Testing Instructions

- Create a map for a region w/o political data, like Dane County
  - Hover over a blockgroup on the map - the tooltip should not show poltical data
- Maps for regions with political data, such as DE 2020, should continue to show it in the tooltip

Closes #972
