### PR TITLE
Hide copy/convert button for other users maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix PVI calculation to not include third party votes & calc average correctly [#977](https://github.com/PublicMapping/districtbuilder/pull/977)
 - Fix handling of expired authentication tokens [#986](https://github.com/PublicMapping/districtbuilder/pull/986)
 - Don't show political data for regions without it on map tooltip [#987](https://github.com/PublicMapping/districtbuilder/pull/987)
+- Hide convert overlay on map screen for other users projects [#988](https://github.com/PublicMapping/districtbuilder/pull/988)
 
 ## [1.8.0] - 2021-08-19
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -190,6 +190,7 @@ interface Props {
   readonly evaluateMode: boolean;
   readonly isReadOnly: boolean;
   readonly isArchived: boolean;
+  readonly isThisUsersMap: boolean;
   readonly limitSelectionToCounty: boolean;
   readonly findMenuOpen: boolean;
   readonly findTool: FindTool;
@@ -285,6 +286,7 @@ const DistrictsMap = ({
   lockedDistricts,
   isReadOnly,
   isArchived,
+  isThisUsersMap,
   expandedProjectMetrics,
   limitSelectionToCounty,
   findMenuOpen,
@@ -1004,7 +1006,7 @@ const DistrictsMap = ({
           ></circle>
         </svg>
       </div>
-      {!evaluateMode && isArchived && (
+      {!evaluateMode && isThisUsersMap && isArchived && (
         <Box sx={style.archivedMessage}>
           <Icon name="alert-triangle" /> This map is using an archived region for the 2010 Census
           and can no longer be edited.
@@ -1186,7 +1188,11 @@ function mapStateToProps(state: State) {
     findMenuOpen: state.project.findMenuOpen,
     findTool: state.project.findTool,
     electionYear: state.project.electionYear,
-    showKeyboardShortcutsModal: state.project.showKeyboardShortcutsModal
+    showKeyboardShortcutsModal: state.project.showKeyboardShortcutsModal,
+    isThisUsersMap:
+      "resource" in state.user &&
+      "resource" in state.project.projectData &&
+      state.user.resource.id !== state.project.projectData.resource.project.user.id
   };
 }
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -1192,7 +1192,7 @@ function mapStateToProps(state: State) {
     isThisUsersMap:
       "resource" in state.user &&
       "resource" in state.project.projectData &&
-      state.user.resource.id !== state.project.projectData.resource.project.user.id
+      state.user.resource.id === state.project.projectData.resource.project.user.id
   };
 }
 


### PR DESCRIPTION
## Overview

Hides the copy & convert to 2020 overlay / button for archived 2010 maps when  looking at another users map.
The button wouldn't work in this case anyways, so this should silence some Rollbar errors.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Visible in the logged in browser, not visble in the not logged in incognito window:
![image](https://user-images.githubusercontent.com/4432106/131194942-423b1d7c-408c-4a6c-ae5a-d7a39b891604.png)

## Testing Instructions

- Using `scripts/dbshell`, set a region for which you have projects to be `archived`
- If you go to a project of yours for that region, you should the copy / convert overlay (note that unless your archived region was for 2010 & you have a non-archived 2020 region configured for the same state, the convert button won't work)
- Go to that same project as another user, or while logged out. You should not see the overlay.

Closes #982 
