### PR TITLE
Create indexes concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Updated copy on home screen for new users [#985](https://github.com/PublicMapping/districtbuilder/pull/985)
+- Disable migration transactions in order to create project indexes concurrently [#989](https://github.com/PublicMapping/districtbuilder/pull/989)
 ### Fixed
 - Disable Send to Plan Score button for incomplete projects [#957](https://github.com/PublicMapping/districtbuilder/pull/957)
 - Fix Send to Plan Score button for other users projects [#958](https://github.com/PublicMapping/districtbuilder/pull/958)

--- a/scripts/yarn
+++ b/scripts/yarn
@@ -18,7 +18,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         usage
     elif [[ "${1}" == "server" ]]; then
         docker-compose \
-            run --rm --no-deps "${1}" \
+            run --rm "${1}" \
             "${@:2}"
     else
         docker-compose \

--- a/src/server/migrations/1629680461750-project_index.ts
+++ b/src/server/migrations/1629680461750-project_index.ts
@@ -5,10 +5,10 @@ export class projectIndex1629680461750 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX "IDX_110113f7f5d7d3b08d0c12f5b0" ON "project" ("updated_dt", "user_id")`
+      `CREATE INDEX CONCURRENTLY "IDX_110113f7f5d7d3b08d0c12f5b0" ON "project" ("updated_dt", "user_id")`
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_PUBLISHED_PROJECTS" ON "project" ("updated_dt" DESC, jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates'), "region_config_id") WHERE "archived" <> TRUE AND "visibility" = 'PUBLISHED'`
+      `CREATE INDEX CONCURRENTLY "IDX_PUBLISHED_PROJECTS" ON "project" ("updated_dt" DESC, jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates'), "region_config_id") WHERE "archived" <> TRUE AND "visibility" = 'PUBLISHED'`
     );
   }
 

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -21,7 +21,7 @@
     "migration:generate": "yarn run typeorm migration:generate -n",
     "migration:create": "yarn run typeorm migration:create -n",
     "migration:revert": "yarn run typeorm migration:revert",
-    "migration:run": "yarn run typeorm migration:run"
+    "migration:run": "yarn run typeorm migration:run -t=false"
   },
   "dependencies": {
     "@drdgvhbh/postgres-error-codes": "0.0.6",


### PR DESCRIPTION
## Overview

PR #969 added indexes to the `project` table, but in production this table is quite large and we'd prefer not to lock it while building an index. PostgreSQL has support for creating indexes concurrently, but by default we couldn't use that in a migration, as migrations are wrapped in a transaction by TypeORM, and `CREATE INDEX CONCURRENTLY` cannot be run in a transaction.

Due to the above, we had planned to manually create these indexes in production and add a row to the `migration` table ourselves (#975), however a discussion w/ @KlaasH and a more careful reading of the docs showed a more standard option - rather than apply these manually , we're temporarily turning off transactions for migrations until after our next release by passing the `-t=false` option, at which point we'll make these create index statements not concurrent again and re-enable transactions for migrations.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

```shell
$ ./scripts/yarn server run migration:run
Creating districtbuilder_server_run ... done
yarn run v1.22.5
$ yarn run typeorm migration:run -t=false
$ ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -t=false
query: SELECT * FROM "information_schema"."tables" WHERE "table_schema" = current_schema() AND "table_name" = 'migrations'
query: SELECT * FROM "migrations" "migrations"  ORDER BY "id" DESC
42 migrations are already loaded in the database.
43 migrations were found in the source code.
projectVersionDefault1628546956803 is the last executed migration. It was executed on Mon Aug 09 2021 22:09:16 GMT+0000 (Coordinated Universal Time).
1 migrations are new migrations that needs to be executed.
query: CREATE INDEX CONCURRENTLY "IDX_110113f7f5d7d3b08d0c12f5b0" ON "project" ("updated_dt", "user_id")
query: CREATE INDEX CONCURRENTLY "IDX_PUBLISHED_PROJECTS" ON "project" ("updated_dt" DESC, jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates'), "region_config_id") WHERE "archived" <> TRUE AND "visibility" = 'PUBLISHED'
query: INSERT INTO "migrations"("timestamp", "name") VALUES ($1, $2) -- PARAMETERS: [1629680461750,"projectIndex1629680461750"]
Migration projectIndex1629680461750 has been executed successfully.
Done in 1.64s.
```

## Testing Instructions

- `scripts/update`
- Revert the most recent migration `./scripts/yarn server run typeorm migration:revert`
- Attempt to run the migration by calling `typeorm` directly, it should fail: `./scripts/yarn server run typeorm migration:run`
- Run the migration by using the `migration:run` script in `package.json`, it should succeed: `./scripts/yarn server run migration:run` (this is [how we run migrations](https://github.com/PublicMapping/districtbuilder/tree/develop/deployment#migrations) in production)

Closes #975 
