### PR TITLE
Sort region configs by region code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Support extra demographic fields on metrics viewer [#984](https://github.com/PublicMapping/districtbuilder/pull/984)
+- Sort region configs by region code [#1004](https://github.com/PublicMapping/districtbuilder/pull/1004)
+
 ### Fixed
 
 ## [1.9.0] - 2021-08-30

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -246,7 +246,9 @@ export async function fetchRegionConfigs(): Promise<IRegionConfig> {
   return new Promise((resolve, reject) => {
     apiAxios
       .get("/api/region-configs?sort=name,ASC")
-      .then(response => resolve(response.data))
+      .then(response => {
+        resolve(response.data);
+      })
       .catch(error => reject(error.message));
   });
 }

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -84,11 +84,13 @@ const PublishedMapsListScreen = ({
   }, [regionConfigs]);
 
   const regionConfigOptions = regionConfigs
-    ? regionConfigs.map(rc => (
-        <option key={rc.regionCode} value={rc.regionCode}>
-          {capitalizeFirstLetter(rc.regionCode)}
-        </option>
-      ))
+    ? [...regionConfigs]
+        .sort((a, b) => a.regionCode.localeCompare(b.regionCode))
+        .map(rc => (
+          <option key={rc.regionCode} value={rc.regionCode}>
+            {capitalizeFirstLetter(rc.regionCode)}
+          </option>
+        ))
     : [];
   return (
     <Flex sx={{ height: "100%", flexDirection: "column" }}>


### PR DESCRIPTION
## Overview

Updates the region config dropdown in the community maps page by region code

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/133116485-e3e6d81e-5750-4bae-8b6a-f4e0144af155.png)


## Testing Instructions

- `./scripts/server`
- Go to community maps page and click on the dropdown
- Expect regions to be sorted by region code

Closes #993 
