### PR TITLE
Reduce tolerance for simplification for small regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Support extra demographic fields on metrics viewer [#984](https://github.com/PublicMapping/districtbuilder/pull/984)
 - Sort region configs by region code [#1004](https://github.com/PublicMapping/districtbuilder/pull/1004)
+- Fix mini-maps for DC and other small regions [#1009](https://github.com/PublicMapping/districtbuilder/pull/1009)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@szhsin/react-menu": "^1.9.1",
     "@theme-ui/color": "0.4.0-rc.1",
     "@tippyjs/react": "^4.1.0",
-    "@turf/bbox": "^6.0.1",
+    "@turf/bbox": "^6.5.0",
     "@turf/boolean-intersects": "^6.4.0",
     "@turf/circle": "^6.4.0",
     "@turf/distance": "^6.4.0",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -39,6 +39,7 @@
     "@nestjsx/crud": "4.6.0",
     "@nestjsx/crud-typeorm": "4.6.0",
     "@turf/area": "6.0.1",
+    "@turf/bbox": "^6.5.0",
     "@turf/length": "6.0.2",
     "@turf/polygon-to-line": "6.0.3",
     "@turf/simplify": "^6.5.0",

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -572,6 +572,14 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
+"@turf/bbox@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.5.0.tgz#bec30a744019eae420dac9ea46fb75caa44d8dc5"
+  integrity sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
 "@turf/clean-coords@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-6.5.0.tgz#6690adf764ec4b649710a8a20dab7005efbea53f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,13 +1892,13 @@
     "@turf/helpers" "^6.4.0"
     "@turf/meta" "^6.4.0"
 
-"@turf/bbox@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
-  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+"@turf/bbox@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.5.0.tgz#bec30a744019eae420dac9ea46fb75caa44d8dc5"
+  integrity sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==
   dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/meta" "6.x"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
 
 "@turf/bearing@^6.4.0":
   version "6.4.0"
@@ -2291,6 +2291,11 @@
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.4.0.tgz#e263d960ab1caed3bfe86a7f2f4b2096dbbf0635"
   integrity sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==
 
+"@turf/helpers@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
+  integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
 "@turf/hex-grid@^6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@turf/hex-grid/-/hex-grid-6.4.0.tgz#acdd87c2f3cc327e3683cd035b74cc9eff048b03"
@@ -2506,6 +2511,13 @@
   integrity sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==
   dependencies:
     "@turf/helpers" "^6.4.0"
+
+"@turf/meta@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.5.0.tgz#b725c3653c9f432133eaa04d3421f7e51e0418ca"
+  integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
 
 "@turf/midpoint@^6.4.0":
   version "6.4.0"


### PR DESCRIPTION
## Overview

Set the tolerance to .001 instead of .005 for small units with an area than less than 1 (?) for the simplification used to improve performance for mini-maps that inadvertently caused rendering issues for DC and other small regions.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/66973361/133512044-76c30f7a-14ef-43f6-a6df-db2aa40a92b2.png)


## Testing Instructions

- Create and complete projects for DC and RI
- Look at them in the community maps viewer; expect the mini-maps to render properly

Closes #994 
