### PR TITLE
Project template reference layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for uploading reference layers to a project [#902](https://github.com/PublicMapping/districtbuilder/pull/902)
 - Show / delete reference layers for a project [#999](https://github.com/PublicMapping/districtbuilder/pull/999)
+- Copy project template reference layers to project [#1018](https://github.com/PublicMapping/districtbuilder/pull/1018)
 
 ### Changed
 - Support extra demographic fields on metrics viewer [#984](https://github.com/PublicMapping/districtbuilder/pull/984)

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -19,13 +19,13 @@ import {
   DistrictsImportApiResponse,
   PlanScoreAPIResponse,
   IReferenceLayer,
-  ReferenceLayerId
+  ReferenceLayerId,
+  CreateReferenceLayerData
 } from "../shared/entities";
 import {
   DistrictsGeoJSON,
   DynamicProjectData,
   PaginatedResponse,
-  CreateReferenceLayerData,
   ReferenceLayerWithGeojson
 } from "./types";
 import { getJWT, setJWT } from "./jwt";

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -132,26 +132,10 @@ export async function resetPassword(token: string, password: string): Promise<vo
   });
 }
 
-export async function createProject({
-  name,
-  numberOfDistricts,
-  chamber,
-  regionConfig,
-  districtsDefinition,
-  projectTemplate,
-  populationDeviation
-}: CreateProjectData): Promise<IProject> {
+export async function createProject(data: CreateProjectData): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .post("/api/projects", {
-        name,
-        numberOfDistricts,
-        regionConfig,
-        districtsDefinition,
-        chamber,
-        populationDeviation,
-        projectTemplate
-      })
+      .post("/api/projects", data)
       .then(response => resolve(response.data))
       .catch(error => reject(error.response?.data || error));
   });

--- a/src/client/components/AddReferenceLayerModal.tsx
+++ b/src/client/components/AddReferenceLayerModal.tsx
@@ -314,7 +314,7 @@ const AddReferenceLayerModal = ({
                 const referenceLayer = {
                   name: validatedForm.name,
                   label_field: validatedForm.label_field,
-                  project: validatedForm.project,
+                  project: { id: validatedForm.project },
                   layer: validatedForm.layer,
                   layer_type: validatedForm.layer_type
                 };

--- a/src/client/components/ConfirmJoinOrganization.tsx
+++ b/src/client/components/ConfirmJoinOrganization.tsx
@@ -38,12 +38,12 @@ const style: ThemeUIStyleObject = {
 const ConfirmJoinOrganization = ({
   organization,
   user,
-  projectTemplate,
+  projectTemplateData,
   onCancel
 }: {
   readonly organization: IOrganization;
   readonly user: Resource<IUser>;
-  readonly projectTemplate?: CreateProjectData;
+  readonly projectTemplateData?: CreateProjectData;
   readonly onCancel: () => void;
 }) => {
   const history = useHistory();
@@ -56,7 +56,7 @@ const ConfirmJoinOrganization = ({
       ) &&
       store.dispatch(showCopyMapModal(false));
 
-    projectTemplate && createProjectFromTemplate();
+    projectTemplateData && createProjectFromTemplate();
   }
 
   function closeModal() {
@@ -65,8 +65,8 @@ const ConfirmJoinOrganization = ({
   }
 
   function createProjectFromTemplate() {
-    projectTemplate &&
-      void createProject(projectTemplate).then((project: IProject) =>
+    projectTemplateData &&
+      void createProject(projectTemplateData).then((project: IProject) =>
         history.push(`/projects/${project.id}`)
       );
   }

--- a/src/client/components/JoinOrganizationModal.tsx
+++ b/src/client/components/JoinOrganizationModal.tsx
@@ -40,13 +40,13 @@ const JoinOrganizationModal = ({
   organization,
   user,
   showModal,
-  projectTemplate,
+  projectTemplateData,
   onCancel
 }: {
   readonly organization: IOrganization;
   readonly showModal: boolean;
   readonly user: Resource<IUser>;
-  readonly projectTemplate?: CreateProjectData;
+  readonly projectTemplateData?: CreateProjectData;
   readonly onCancel: () => void;
 }) => {
   const hideModal = () => {
@@ -66,7 +66,7 @@ const JoinOrganizationModal = ({
         {"resource" in user ? (
           <ConfirmJoinOrganization
             organization={organization}
-            projectTemplate={projectTemplate}
+            projectTemplateData={projectTemplateData}
             onCancel={onCancel}
           />
         ) : (

--- a/src/client/components/OrganizationTemplates.tsx
+++ b/src/client/components/OrganizationTemplates.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { IOrganization, IUser, IProjectTemplate } from "../../shared/entities";
+import { IOrganization, IUser, CreateProjectData } from "../../shared/entities";
 import { Box, Heading, jsx } from "theme-ui";
 import TemplateCard from "./TemplateCard";
 
@@ -9,7 +9,7 @@ interface Props {
 }
 
 interface IProps {
-  readonly setTemplate?: (template: IProjectTemplate) => void;
+  readonly templateSelected?: (templateData: CreateProjectData) => void;
 }
 
 const style = {
@@ -39,7 +39,7 @@ const style = {
   }
 } as const;
 
-const OrganizationTemplates = ({ organization, user, setTemplate }: Props & IProps) => {
+const OrganizationTemplates = ({ organization, user, templateSelected }: Props & IProps) => {
   return (
     <Box sx={style.container}>
       {organization.projectTemplates.length > 0 && (
@@ -53,7 +53,7 @@ const OrganizationTemplates = ({ organization, user, setTemplate }: Props & IPro
               <TemplateCard
                 template={template}
                 key={template.id}
-                setTemplate={setTemplate}
+                templateSelected={templateSelected}
                 organization={organization}
                 user={user}
               />

--- a/src/client/components/OrganizationTemplates.tsx
+++ b/src/client/components/OrganizationTemplates.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { IOrganization, IUser, CreateProjectData } from "../../shared/entities";
+import { IOrganization, IUser, IProjectTemplate } from "../../shared/entities";
 import { Box, Heading, jsx } from "theme-ui";
 import TemplateCard from "./TemplateCard";
 
@@ -9,7 +9,7 @@ interface Props {
 }
 
 interface IProps {
-  readonly setTemplate?: (template: CreateProjectData) => void;
+  readonly setTemplate?: (template: IProjectTemplate) => void;
 }
 
 const style = {

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -1,18 +1,8 @@
 /** @jsx jsx */
-import {
-  IOrganization,
-  IProjectTemplate,
-  IUser,
-  CreateProjectData,
-  IProject
-} from "../../shared/entities";
+import { IOrganization, IProjectTemplate, IUser } from "../../shared/entities";
 import { Box, Button, Flex, Heading, jsx, Text } from "theme-ui";
-import { useHistory } from "react-router-dom";
-import { createProject } from "../api";
 import { isUserLoggedIn } from "../jwt";
 import Tooltip from "./Tooltip";
-import store from "../store";
-import { showCopyMapModal } from "../actions/districtDrawing";
 
 const style = {
   template: {
@@ -44,38 +34,17 @@ const TemplateCard = ({
 }: {
   readonly template: IProjectTemplate;
   readonly organization: IOrganization;
-  readonly user: IUser | undefined;
-  readonly setTemplate: ((template: CreateProjectData) => void) | undefined;
+  readonly user?: IUser;
+  readonly setTemplate?: (template: IProjectTemplate) => void;
 }) => {
   const userIsVerified = user?.isEmailVerified;
   const isLoggedIn = isUserLoggedIn();
   const userInOrg = user && checkIfUserInOrg(organization, user);
-  const history = useHistory();
-
-  function createProjectFromTemplate(template: CreateProjectData) {
-    void createProject(template).then((project: IProject) =>
-      history.push(`/projects/${project.id}`)
-    );
-  }
-
-  function setupProjectFromTemplate(template: IProjectTemplate) {
-    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
-    const currentTemplate: CreateProjectData = {
-      name,
-      regionConfig,
-      numberOfDistricts,
-      districtsDefinition,
-      chamber,
-      projectTemplate: { id }
-    };
-    setTemplate && setTemplate(currentTemplate);
-    userInOrg ? createProjectFromTemplate(currentTemplate) : store.dispatch(showCopyMapModal(true));
-  }
 
   const useButton = (
     <Button
       disabled={isLoggedIn && !userIsVerified}
-      onClick={() => setupProjectFromTemplate(template)}
+      onClick={() => setTemplate && setTemplate(template)}
       sx={style.useTemplateBtn}
     >
       Use this template

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { IOrganization, IProjectTemplate, IUser } from "../../shared/entities";
+import { IOrganization, IProjectTemplate, IUser, CreateProjectData } from "../../shared/entities";
 import { Box, Button, Flex, Heading, jsx, Text } from "theme-ui";
 import { isUserLoggedIn } from "../jwt";
 import Tooltip from "./Tooltip";
@@ -30,12 +30,12 @@ const TemplateCard = ({
   template,
   user,
   organization,
-  setTemplate
+  templateSelected
 }: {
   readonly template: IProjectTemplate;
   readonly organization: IOrganization;
   readonly user?: IUser;
-  readonly setTemplate?: (template: IProjectTemplate) => void;
+  readonly templateSelected?: (templateData: CreateProjectData) => void;
 }) => {
   const userIsVerified = user?.isEmailVerified;
   const isLoggedIn = isUserLoggedIn();
@@ -44,7 +44,13 @@ const TemplateCard = ({
   const useButton = (
     <Button
       disabled={isLoggedIn && !userIsVerified}
-      onClick={() => setTemplate && setTemplate(template)}
+      onClick={() => {
+        if (templateSelected) {
+          const { id } = template;
+          const data: CreateProjectData = { projectTemplate: { id } };
+          templateSelected(data);
+        }
+      }}
       sx={style.useTemplateBtn}
     >
       Use this template

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -323,8 +323,10 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                 // eslint-disable-next-line
                 if (validatedForm.valid === true) {
                   setCreateProjectResource({ data, isPending: true });
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  const { isCustom, valid, ...validatedData } = validatedForm;
                   createProject({
-                    ...validatedForm,
+                    ...validatedData,
                     chamber: validatedForm.chamber || undefined,
                     populationDeviation: validatedForm.populationDeviation,
                     numberOfDistricts: validatedForm.numberOfDistricts

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -19,7 +19,13 @@ import {
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
-import { IProject, IRegionConfig, IChamber, OrganizationSlug } from "../../shared/entities";
+import {
+  IProject,
+  IRegionConfig,
+  IChamber,
+  OrganizationSlug,
+  IProjectTemplate
+} from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
 import { organizationFetch } from "../actions/organization";
 import { createProject } from "../api";
@@ -66,11 +72,99 @@ interface InvalidForm extends ProjectForm {
   readonly valid: false;
 }
 
+const style: ThemeUIStyleObject = {
+  header: {
+    py: 3,
+    px: 5,
+    alignItems: "center",
+    bg: "blue.8",
+    borderBottom: "1px solid",
+    borderColor: "blue.7",
+    boxShadow: "bright"
+  },
+  formContainer: {
+    width: "100%",
+    maxWidth: "640px",
+    my: 7,
+    mx: "auto",
+    display: "block",
+    flexDirection: "column",
+    "@media screen and (max-width: 770px)": {
+      width: "95%",
+      my: 2
+    }
+  },
+  cardLabel: {
+    textTransform: "none",
+    variant: "text.h5",
+    display: "block",
+    mb: 1
+  },
+  cardHint: {
+    display: "block",
+    textTransform: "none",
+    fontWeight: "500",
+    fontSize: 1,
+    mt: 2,
+    mb: 3
+  },
+  radioHeading: {
+    textTransform: "none",
+    variant: "text.body",
+    fontSize: 2,
+    lineHeight: "heading",
+    letterSpacing: "0",
+    mb: "0",
+    color: "heading",
+    fontWeight: "body"
+  },
+  radioSubHeading: {
+    fontSize: 1,
+    letterSpacing: "0",
+    textTransform: "none",
+    fontWeight: "500"
+  },
+  customInputContainer: {
+    mt: 2,
+    width: "100%",
+    pt: 4,
+    borderTop: "1px solid",
+    borderColor: "gray.2"
+  },
+  legend: {
+    paddingInlineStart: "0",
+    paddingInlineEnd: "0"
+  },
+  fieldset: {
+    border: "none",
+    marginInlineStart: "0",
+    marginInlineEnd: "0",
+    paddingInlineStart: "0",
+    paddingInlineEnd: "0",
+    paddingBlockEnd: "0"
+  },
+  orgCardLabel: {
+    mt: "5px"
+  },
+  orgCardSubtitle: {
+    mb: "10px"
+  },
+  orgTemplates: {
+    display: "block",
+    minHeight: "100px",
+    pl: "5px",
+    "> *": {
+      mx: 5
+    },
+    mx: "auto",
+    width: "100%",
+    maxWidth: "large",
+    borderTop: "1px solid lightgray",
+    my: 8
+  }
+};
+
 const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) => {
-  useEffect(() => {
-    store.dispatch(regionConfigsFetch());
-    store.dispatch(userFetch());
-  }, []);
   const [createProjectResource, setCreateProjectResource] = useState<
     WriteResource<ProjectForm, IProject>
   >({
@@ -85,9 +179,6 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
   });
   const { data } = createProjectResource;
   const [organizationSlug, setOrganizationSlug] = useState<OrganizationSlug | undefined>(undefined);
-  useEffect(() => {
-    organizationSlug && store.dispatch(organizationFetch(organizationSlug));
-  }, [organizationSlug]);
 
   const onDistrictChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     const chamber =
@@ -108,102 +199,20 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     });
   };
 
-  const style: ThemeUIStyleObject = {
-    header: {
-      py: 3,
-      px: 5,
-      alignItems: "center",
-      bg: "blue.8",
-      borderBottom: "1px solid",
-      borderColor: "blue.7",
-      boxShadow: "bright"
-    },
-    formContainer: {
-      width: "100%",
-      maxWidth: "640px",
-      my: 7,
-      mx: "auto",
-      display: "block",
-      flexDirection: "column",
-      "@media screen and (max-width: 770px)": {
-        width: "95%",
-        my: 2
-      }
-    },
-    cardLabel: {
-      textTransform: "none",
-      variant: "text.h5",
-      display: "block",
-      mb: 1
-    },
-    cardHint: {
-      display: "block",
-      textTransform: "none",
-      fontWeight: "500",
-      fontSize: 1,
-      mt: 2,
-      mb: 3
-    },
-    radioHeading: {
-      textTransform: "none",
-      variant: "text.body",
-      fontSize: 2,
-      lineHeight: "heading",
-      letterSpacing: "0",
-      mb: "0",
-      color: "heading",
-      fontWeight: "body"
-    },
-    radioSubHeading: {
-      fontSize: 1,
-      letterSpacing: "0",
-      textTransform: "none",
-      fontWeight: "500"
-    },
-    customInputContainer: {
-      mt: 2,
-      width: "100%",
-      pt: 4,
-      borderTop: "1px solid",
-      borderColor: "gray.2"
-    },
-    legend: {
-      paddingInlineStart: "0",
-      paddingInlineEnd: "0"
-    },
-    fieldset: {
-      border: "none",
-      marginInlineStart: "0",
-      marginInlineEnd: "0",
-      paddingInlineStart: "0",
-      paddingInlineEnd: "0",
-      paddingBlockEnd: "0"
-    },
-    orgCardLabel: {
-      mt: "5px"
-    },
-    orgCardSubtitle: {
-      mb: "10px"
-    },
-    orgTemplates: {
-      display: "block",
-      minHeight: "100px",
-      pl: "5px",
-      "> *": {
-        mx: 5
-      },
-      mx: "auto",
-      width: "100%",
-      maxWidth: "large",
-      borderTop: "1px solid lightgray",
-      my: 8
-    }
-  };
 
   const onOrgChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.currentTarget.value !== "" && setOrganizationSlug(e.currentTarget.value);
     e.currentTarget.value === "" && setOrganizationSlug(undefined);
   };
+
+  useEffect(() => {
+    store.dispatch(regionConfigsFetch());
+    store.dispatch(userFetch());
+  }, []);
+
+  useEffect(() => {
+    organizationSlug && store.dispatch(organizationFetch(organizationSlug));
+  }, [organizationSlug]);
 
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import { userFetch } from "../actions/user";
 import { DEFAULT_POPULATION_DEVIATION } from "../../shared/constants";
 import {
@@ -165,6 +165,7 @@ const style: ThemeUIStyleObject = {
 };
 
 const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) => {
+  const history = useHistory();
   const [createProjectResource, setCreateProjectResource] = useState<
     WriteResource<ProjectForm, IProject>
   >({
@@ -199,6 +200,19 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     });
   };
 
+  function setupProjectFromTemplate(template: IProjectTemplate) {
+    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
+    const data = {
+      name,
+      regionConfig,
+      numberOfDistricts,
+      districtsDefinition,
+      chamber,
+      projectTemplate: { id }
+    };
+
+    void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
+  }
 
   const onOrgChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.currentTarget.value !== "" && setOrganizationSlug(e.currentTarget.value);
@@ -299,7 +313,11 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
         </Flex>
         {"resource" in organization && "resource" in user && organizationSlug && (
           <Box sx={style.orgTemplates}>
-            <OrganizationTemplates user={user.resource} organization={organization.resource} />
+            <OrganizationTemplates
+              user={user.resource}
+              organization={organization.resource}
+              setTemplate={setupProjectFromTemplate}
+            />
           </Box>
         )}
         {!organizationSlug && (

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -24,7 +24,7 @@ import {
   IRegionConfig,
   IChamber,
   OrganizationSlug,
-  IProjectTemplate
+  CreateProjectData
 } from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
 import { organizationFetch } from "../actions/organization";
@@ -200,17 +200,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     });
   };
 
-  function setupProjectFromTemplate(template: IProjectTemplate) {
-    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
-    const data = {
-      name,
-      regionConfig,
-      numberOfDistricts,
-      districtsDefinition,
-      chamber,
-      projectTemplate: { id }
-    };
-
+  function setupProjectFromTemplate(data: CreateProjectData) {
     void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
   }
 
@@ -316,7 +306,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
             <OrganizationTemplates
               user={user.resource}
               organization={organization.resource}
-              setTemplate={setupProjectFromTemplate}
+              templateSelected={setupProjectFromTemplate}
             />
           </Box>
         )}

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -22,7 +22,6 @@ import {
   IOrganization,
   IUser,
   ProjectNest,
-  IProjectTemplate,
   IProject
 } from "../../shared/entities";
 
@@ -157,16 +156,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
     void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
   }
 
-  function setupProjectFromTemplate(template: IProjectTemplate) {
-    const { id, name, regionConfig, numberOfDistricts, districtsDefinition, chamber } = template;
-    const data: CreateProjectData = {
-      name,
-      regionConfig,
-      numberOfDistricts,
-      districtsDefinition,
-      chamber,
-      projectTemplate: { id }
-    };
+  function setupProjectFromTemplate(data: CreateProjectData) {
     if (userInOrg) {
       createProjectFromTemplate(data);
     } else {
@@ -340,7 +330,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
                 <OrganizationTemplates
                   user={"resource" in user ? user.resource : undefined}
                   organization={organization.resource}
-                  setTemplate={setupProjectFromTemplate}
+                  templateSelected={setupProjectFromTemplate}
                 />
               )}
             </Box>

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -138,7 +138,9 @@ const style = {
 
 const OrganizationScreen = ({ organization, organizationProjects, user }: StateProps) => {
   const { organizationSlug } = useParams();
-  const [projectTemplate, setProjectTemplate] = useState<CreateProjectData | undefined>(undefined);
+  const [projectTemplateData, setProjectTemplateData] = useState<CreateProjectData | undefined>(
+    undefined
+  );
   const isLoggedIn = isUserLoggedIn();
   const userInOrg =
     "resource" in user &&
@@ -168,7 +170,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
     if (userInOrg) {
       createProjectFromTemplate(data);
     } else {
-      setProjectTemplate(data);
+      setProjectTemplateData(data);
       store.dispatch(showCopyMapModal(true));
     }
   }
@@ -225,7 +227,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
   }
 
   function handleCancelModal() {
-    setProjectTemplate(undefined);
+    setProjectTemplateData(undefined);
   }
 
   const joinButton = (
@@ -393,7 +395,7 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
       {"resource" in organization && organization.resource && (
         <JoinOrganizationModal
           organization={organization.resource}
-          projectTemplate={projectTemplate}
+          projectTemplateData={projectTemplateData}
           onCancel={handleCancelModal}
         />
       )}

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -109,13 +109,6 @@ export interface ReferenceLayerImportResponse {
   readonly fields?: readonly string[];
 }
 
-export interface CreateReferenceLayerData {
-  readonly layer: ReferenceLayerGeojson;
-  readonly name: string;
-  readonly label_field?: string;
-  readonly project: ProjectId;
-}
-
 export interface ReferenceLayerWithGeojson extends IReferenceLayer {
   readonly layer: ReferenceLayerGeojson;
 }

--- a/src/manage/src/lib/dbUtils.ts
+++ b/src/manage/src/lib/dbUtils.ts
@@ -2,6 +2,7 @@ import { ConnectionOptions } from "typeorm";
 import { Chamber } from "../../../server/src/chambers/entities/chamber.entity";
 import { Organization } from "../../../server/src/organizations/entities/organization.entity";
 import { ProjectTemplate } from "../../../server/src/project-templates/entities/project-template.entity";
+import { ReferenceLayer } from "../../../server/src/reference-layers/entities/reference-layer.entity";
 import { RegionConfig } from "../../../server/src/region-configs/entities/region-config.entity";
 import { User } from "../../../server/src/users/entities/user.entity";
 import { Project } from "../../../server/src/projects/entities/project.entity";
@@ -13,7 +14,7 @@ export const connectionOptions: ConnectionOptions = {
   username: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
-  entities: [Chamber, Organization, ProjectTemplate, RegionConfig, User, Project],
+  entities: [Chamber, Organization, ProjectTemplate, RegionConfig, ReferenceLayer, User, Project],
   logging: true,
   synchronize: false
 };

--- a/src/server/migrations/1632492690026-reference_layers_template_column.ts
+++ b/src/server/migrations/1632492690026-reference_layers_template_column.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class referenceLayersTemplateColumn1632492690026 implements MigrationInterface {
+    name = 'referenceLayersTemplateColumn1632492690026'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reference_layer" ADD "project_template_id" uuid`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ADD CONSTRAINT "FK_53e790b817e1ef2709b41c128d9" FOREIGN KEY ("project_template_id") REFERENCES "project_template"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reference_layer" DROP CONSTRAINT "FK_53e790b817e1ef2709b41c128d9"`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" DROP COLUMN "project_template_id"`);
+    }
+
+}

--- a/src/server/migrations/1632512688121-reference_layers_constraint.ts
+++ b/src/server/migrations/1632512688121-reference_layers_constraint.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class referenceLayersConstraint1632512688121 implements MigrationInterface {
+    name = 'referenceLayersConstraint1632512688121'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reference_layer" DROP CONSTRAINT "FK_e6141b3c1854a523a0755406ec4"`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ALTER COLUMN "project_id" DROP NOT NULL`);
+        await queryRunner.query(`COMMENT ON COLUMN "reference_layer"."project_id" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ADD CONSTRAINT "CHK_4e77a0b7d0479ef3d32e7cc98d" CHECK ("project_id" IS NOT NULL OR "project_template_id" IS NOT NULL)`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ADD CONSTRAINT "FK_e6141b3c1854a523a0755406ec4" FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reference_layer" DROP CONSTRAINT "FK_e6141b3c1854a523a0755406ec4"`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" DROP CONSTRAINT "CHK_4e77a0b7d0479ef3d32e7cc98d"`);
+        await queryRunner.query(`COMMENT ON COLUMN "reference_layer"."project_id" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ALTER COLUMN "project_id" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "reference_layer" ADD CONSTRAINT "FK_e6141b3c1854a523a0755406ec4" FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -25,11 +25,18 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
       .addSelect(["users.id", "users.name"])
       .leftJoin("organization.admin", "admin")
       .addSelect(["admin.id", "admin.name"])
-      .leftJoinAndSelect(
+      .leftJoin(
         "organization.projectTemplates",
         "projectTemplates",
         "projectTemplates.isActive = TRUE"
       )
+      .addSelect([
+        "projectTemplates.id",
+        "projectTemplates.name",
+        "projectTemplates.numberOfDistricts",
+        "projectTemplates.description",
+        "projectTemplates.details"
+      ])
       .leftJoinAndSelect("projectTemplates.regionConfig", "regionConfig")
       .where("organization.slug = :slug", { slug: slug })
       .getOne();

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_POPULATION_DEVIATION,
   DEFAULT_PINNED_METRIC_FIELDS
 } from "../../../../shared/constants";
+import { ReferenceLayer } from "../../reference-layers/entities/reference-layer.entity";
 
 @Entity()
 export class ProjectTemplate implements IProjectTemplateWithProjects {
@@ -39,6 +40,12 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
     project => project.projectTemplate
   )
   projects: Project[];
+
+  @OneToMany(
+    () => ReferenceLayer,
+    layer => layer.projectTemplate
+  )
+  referenceLayers: ReferenceLayer[];
 
   @Column({ name: "number_of_districts", type: "integer" })
   numberOfDistricts: number;

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -47,9 +47,7 @@ import {
   PublicUserProperties,
   GeoUnitHierarchy,
   UserId,
-  ProjectTemplateId,
-  ProjectTemplateFields,
-  IProjectTemplate
+  ProjectTemplateId
 } from "../../../../shared/entities";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
@@ -347,6 +345,7 @@ export class ProjectsController implements CrudController<Project> {
       const project = await this.service.createOne(req, { ...data, districts });
       // Copy any reference layers associated with the template to the project
       if (template) {
+        // eslint-disable-next-line functional/no-loop-statement
         for (const refLayer of template.referenceLayers) {
           // We need to wait for reference layers to be copied, but then we don't
           // actually need to do anything with the result

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -73,6 +73,7 @@ import { GeoUnitProperties } from "../../districts/entities/geo-unit-properties.
 import { Brackets } from "typeorm";
 import { getDemographicsMetricFields, getVotingMetricFields } from "../../../../shared/functions";
 import { ProjectTemplatesService } from "../../project-templates/services/project-templates.service";
+import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
 
 @Crud({
   model: {
@@ -287,7 +288,7 @@ export class ProjectsController implements CrudController<Project> {
     // This is in a lambda bc prettier kept moving my @ts-ignore
     const findTemplate = (id: ProjectTemplateId) =>
       // @ts-ignore
-      this.templateService.findOne({ id }, { relations: ["regionConfig"] });
+      this.templateService.findOne({ id }, { relations: ["regionConfig", "referenceLayers"] });
     const projectTemplate = dto.projectTemplate
       ? await findTemplate(dto.projectTemplate.id)
       : undefined;
@@ -314,12 +315,24 @@ export class ProjectsController implements CrudController<Project> {
 
     // Pulls out the fields on ProjectTemplate common to it & Project
     const templateFields = ({
-      id,
-      organization,
-      details,
-      description,
-      ...templateFields
-    }: IProjectTemplate): ProjectTemplateFields => templateFields;
+      name,
+      regionConfig,
+      chamber,
+      numberOfDistricts,
+      populationDeviation,
+      pinnedMetricFields,
+      districtsDefinition,
+      referenceLayers
+    }: ProjectTemplate) => ({
+      name,
+      regionConfig,
+      chamber,
+      numberOfDistricts,
+      populationDeviation,
+      pinnedMetricFields,
+      districtsDefinition,
+      referenceLayers
+    });
     const formdata = projectTemplate ? { ...dto, ...templateFields(projectTemplate) } : dto;
     if (!formdata.numberOfDistricts) {
       throw new InternalServerErrorException();

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -331,6 +331,7 @@ export class ProjectsController implements CrudController<Project> {
     });
     const formdata = template ? { ...dto, ...templateFields(template) } : dto;
     if (!formdata.numberOfDistricts) {
+      // The validation in the DTO should prevent this
       throw new InternalServerErrorException();
     }
 

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -7,7 +7,8 @@ import {
   IsPositive,
   IsNumber,
   Max,
-  Min
+  Min,
+  ValidateIf
 } from "class-validator";
 
 import { CreateProjectData, DistrictsDefinition } from "../../../../shared/entities";
@@ -16,24 +17,33 @@ import { ProjectTemplateIdDto } from "../../project-templates/entities/project-t
 import { RegionConfigIdDto } from "../../region-configs/entities/region-config-id.dto";
 
 export class CreateProjectDto implements CreateProjectData {
+  @ValidateIf(o => o.projectTemplate?.id === undefined)
   @IsNotEmpty({ message: "Please enter a name for your project" })
-  readonly name: string;
+  readonly name?: string;
+
+  @ValidateIf(o => o.projectTemplate?.id === undefined)
   @IsInt({ message: "Number of districts must be an integer" })
   @IsPositive({ message: "Number of districts must be a positive number" })
-  readonly numberOfDistricts: number;
+  readonly numberOfDistricts?: number;
+
+  @ValidateIf(o => o.projectTemplate?.id === undefined)
   @IsNotEmpty({ message: "Need to supply a region configuration" })
-  readonly regionConfig: RegionConfigIdDto;
+  readonly regionConfig?: RegionConfigIdDto;
+
   @IsArray()
   @ArrayNotEmpty()
   @IsOptional()
-  readonly districtsDefinition: DistrictsDefinition;
+  readonly districtsDefinition?: DistrictsDefinition;
+
   @IsOptional()
   @IsNumber()
   @Max(100, { message: "Population deviation must be between 0% and 100%" })
   @Min(0, { message: "Population deviation must be between 0% and 100%" })
-  readonly populationDeviation: number;
+  readonly populationDeviation?: number;
+
   @IsOptional()
   readonly chamber?: ChamberIdDto;
+
   @IsOptional()
   readonly projectTemplate?: ProjectTemplateIdDto;
 }

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -12,6 +12,7 @@ import { ProjectsController } from "./controllers/projects.controller";
 import { Project } from "./entities/project.entity";
 import { ProjectsService } from "./services/projects.service";
 import { CrosswalkService } from "./services/crosswalk.service";
+import { ProjectTemplatesModule } from "../project-templates/project-templates.module";
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { CrosswalkService } from "./services/crosswalk.service";
     RegionConfigsModule,
     ChambersModule,
     OrganizationsModule,
+    ProjectTemplatesModule,
     UsersModule
   ],
   controllers: [ProjectsController, GlobalProjectsController],

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { ChambersModule } from "../chambers/chambers.module";
@@ -13,6 +13,7 @@ import { Project } from "./entities/project.entity";
 import { ProjectsService } from "./services/projects.service";
 import { CrosswalkService } from "./services/crosswalk.service";
 import { ProjectTemplatesModule } from "../project-templates/project-templates.module";
+import { ReferenceLayersModule } from "../reference-layers/reference-layers.module";
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ProjectTemplatesModule } from "../project-templates/project-templates.m
     ChambersModule,
     OrganizationsModule,
     ProjectTemplatesModule,
+    forwardRef(() => ReferenceLayersModule),
     UsersModule
   ],
   controllers: [ProjectsController, GlobalProjectsController],

--- a/src/server/src/reference-layers/entities/reference-layer.entity.ts
+++ b/src/server/src/reference-layers/entities/reference-layer.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Check } from "typeorm";
 import { FeatureCollection, MultiPolygon, Point } from "geojson";
 import { IReferenceLayer, ReferenceLayerProperties } from "../../../../shared/entities";
 import { Project } from "../../projects/entities/project.entity";
@@ -10,6 +10,7 @@ export type ReferenceLayerGeojson =
   | FeatureCollection<MultiPolygon, ReferenceLayerProperties>;
 
 @Entity()
+@Check(`"project_id" IS NOT NULL OR "project_template_id" IS NOT NULL`)
 export class ReferenceLayer implements IReferenceLayer {
   @PrimaryGeneratedColumn("uuid")
   id: string;
@@ -17,7 +18,7 @@ export class ReferenceLayer implements IReferenceLayer {
   @Column({ type: "character varying" })
   name: string;
 
-  @ManyToOne(() => Project, { nullable: false, eager: true })
+  @ManyToOne(() => Project, { nullable: true, eager: true })
   @JoinColumn({ name: "project_id" })
   project: Project;
 

--- a/src/server/src/reference-layers/entities/reference-layer.entity.ts
+++ b/src/server/src/reference-layers/entities/reference-layer.entity.ts
@@ -3,6 +3,7 @@ import { FeatureCollection, MultiPolygon, Point } from "geojson";
 import { IReferenceLayer, ReferenceLayerProperties } from "../../../../shared/entities";
 import { Project } from "../../projects/entities/project.entity";
 import { ReferenceLayerTypes } from "../../../../shared/constants";
+import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
 
 export type ReferenceLayerGeojson =
   | FeatureCollection<Point, ReferenceLayerProperties>
@@ -19,6 +20,10 @@ export class ReferenceLayer implements IReferenceLayer {
   @ManyToOne(() => Project, { nullable: false, eager: true })
   @JoinColumn({ name: "project_id" })
   project: Project;
+
+  @ManyToOne(() => ProjectTemplate, { nullable: true })
+  @JoinColumn({ name: "project_template_id" })
+  projectTemplate: ProjectTemplate;
 
   @Column({ type: "enum", enum: ReferenceLayerTypes, default: ReferenceLayerTypes.Point })
   layer_type: ReferenceLayerTypes;

--- a/src/server/src/reference-layers/reference-layers.module.ts
+++ b/src/server/src/reference-layers/reference-layers.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ReferenceLayersController } from "./controllers/reference-layers.controller";
 import { ReferenceLayer } from "./entities/reference-layer.entity";
@@ -6,7 +6,7 @@ import { ReferenceLayersService } from "./services/reference-layers.service";
 import { ProjectsModule } from "../projects/projects.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ReferenceLayer]), ProjectsModule],
+  imports: [TypeOrmModule.forFeature([ReferenceLayer]), forwardRef(() => ProjectsModule)],
   controllers: [ReferenceLayersController],
   providers: [ReferenceLayersService],
   exports: [ReferenceLayersService, TypeOrmModule]

--- a/src/server/src/reference-layers/services/reference-layers.service.ts
+++ b/src/server/src/reference-layers/services/reference-layers.service.ts
@@ -14,6 +14,10 @@ export class ReferenceLayersService extends TypeOrmCrudService<ReferenceLayer> {
     super(repo);
   }
 
+  async create(layer: Partial<ReferenceLayer>): Promise<ReferenceLayer> {
+    return this.repo.save(layer);
+  }
+
   async getProjectReferenceLayers(projectId: string, userId?: UserId): Promise<IReferenceLayer[]> {
     // Returns public data for organization screen
     const builder = this.repo.createQueryBuilder("referenceLayer");

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -174,7 +174,7 @@ export type VotingMetricField = "dem16" | "rep16" | "other16" | "dem20" | "rep20
 export type MetricsList = readonly (readonly [string, string])[];
 export type VotingMetricsList = readonly (readonly [string, VotingMetricField])[];
 
-interface ProjectTemplateFields {
+export interface ProjectTemplateFields {
   readonly name: string;
   readonly regionConfig: IRegionConfig;
   readonly numberOfDistricts: number;
@@ -216,9 +216,9 @@ export type ProjectNest = Pick<
 };
 
 export interface CreateProjectData {
-  readonly name: string;
-  readonly numberOfDistricts: number;
-  readonly regionConfig: Pick<IRegionConfig, "id">;
+  readonly name?: string;
+  readonly numberOfDistricts?: number;
+  readonly regionConfig?: Pick<IRegionConfig, "id">;
   readonly chamber?: Pick<IChamber, "id"> | null;
   readonly districtsDefinition?: DistrictsDefinition;
   readonly populationDeviation?: number;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -225,6 +225,10 @@ export interface CreateProjectData {
   readonly projectTemplate?: Pick<IProjectTemplate, "id">;
 }
 
+export interface UpdateReferenceLayerData {
+  readonly projects: ReadonlyArray<Pick<IProject, "id">>;
+}
+
 export interface CreateReferenceLayerData {
   readonly name: string;
   readonly project: Pick<IProject, "id">;
@@ -250,6 +254,7 @@ export type IProjectTemplate = ProjectTemplateFields & {
   readonly organization: IOrganization;
   readonly description: string;
   readonly details: string;
+  readonly referenceLayers?: readonly IReferenceLayer[];
 };
 
 export type IProjectTemplateWithProjects = IProjectTemplate & {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -225,10 +225,6 @@ export interface CreateProjectData {
   readonly projectTemplate?: Pick<IProjectTemplate, "id">;
 }
 
-export interface UpdateReferenceLayerData {
-  readonly projects: ReadonlyArray<Pick<IProject, "id">>;
-}
-
 export interface CreateReferenceLayerData {
   readonly name: string;
   readonly project: Pick<IProject, "id">;


### PR DESCRIPTION
## Overview

Adds an option to associate a project template with a reference layer, and then copies that that reference layer to the project when creating a project from that template.

Part of this includes a larger refactor to how creating templates from projects works (https://github.com/PublicMapping/districtbuilder/commit/85618ae611be4c9625279b88d9eabf39506ee631), moving most of the logic for copying fields from template -> project from the client to the server.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![ref-layers](https://user-images.githubusercontent.com/4432106/134918615-6b9958dd-ef8d-4dff-8178-1bde3e99927f.gif)


### Notes

I considered instead of copying reference layers, changing the ManyToOne relation to a ManyToMany and 

## Testing Instructions

 - `scripts/update`
- Add a reference layer to an existing project, then update it to instead point to a project template:
  `UPDATE reference_layer SET project_id = NULL, project_template_id = '<uuid_here>';`
- Create a project using the project template you just set your reference layer to point to
  - The newly created project should start with that reference layer by default
- There should be no regressions in creating a project from a template on either the organization or create project screens

Closes #955 
