### PR TITLE
Fix map CSV import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
 ### Changed
+
 ### Fixed
+- Fixed project import [#1029](https://github.com/PublicMapping/districtbuilder/pull/1029)
 
 ## [1.10.0] - 2021-09-28
 ### Added

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -404,8 +404,10 @@ const ImportProjectScreen = ({ regionConfigs }: StateProps) => {
               const validatedForm = validate(formData, importResource);
               if (validatedForm.valid === true) {
                 setCreateProjectResource({ data: formData, isPending: true });
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { isCustom, valid, ...validatedData } = validatedForm;
                 createProject({
-                  ...validatedForm,
+                  ...validatedData,
                   name: validatedForm.regionConfig.name
                 })
                   .then((project: IProject) =>


### PR DESCRIPTION
## Overview

This regression was caused by the refactor in a13ff4 - by no longer explicitly listing fields we allowed extra fields to be included in the POST data.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Export one of your maps, and attempt to import it. On `develop` the import will fail, on this branch it should succeed

Fixes #1027
