### PR TITLE
Import w/ project template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for demographic groups, to support VAP / CVAP fields [#1034](https://github.com/PublicMapping/districtbuilder/pull/1034)
 - Added bulk-reprocess-regions command [#1022](https://github.com/PublicMapping/districtbuilder/pull/1022)
+- Import using a project template [#1033](https://github.com/PublicMapping/districtbuilder/pull/1033)
 
 ### Changed
 - Don't require AWS credentials to load public S3 assets [#1036](https://github.com/PublicMapping/districtbuilder/pull/1036)

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -41,8 +41,21 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-09-02T18:57:17.123Z/',
                 DEFAULT,
                 TRUE,
-                DEFAULT
-              ), (
+                DEFAULT,
+                '2020'
+              ),
+              (
+                'e8f66491-4a6d-45a9-b606-7aabdf91fb76',
+                'Wisconsin',
+                'US',
+                'WI',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/WI/2021-08-13T01:25:55.432Z/',
+                DEFAULT,
+                DEFAULT,
+                DEFAULT,
+                '2020'
+              ),
+              (
                 '96bca832-99b3-4c4d-8913-ab4ca82ec442',
                 'Pennsylvania',
                 'US',
@@ -50,7 +63,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/PA/2020-09-09T19:03:58.174Z/',
                 DEFAULT,
                 DEFAULT,
-                DEFAULT
+                DEFAULT,
+                '2010'
               ), (
                 '6c440b8d-c26e-4bae-850f-dbff37fe0209',
                 'Illinois',
@@ -59,25 +73,28 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 's3://global-districtbuilder-dev-us-east-1/regions/US/IL/2021-06-04T15:05:37.089Z/',
                 DEFAULT,
                 DEFAULT,
-                DEFAULT
+                DEFAULT,
+                '2010'
               ), (
                 '852fa086-de7c-4edd-b666-004b6ff8dc6c',
                 'Delaware',
                 'US',
                 'DE',
                 's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2020-09-09T19:50:10.921Z/',
-                DEFAULT,
-                DEFAULT,
-                TRUE
+                '2020-09-09 19:50:10.921',
+                TRUE,
+                TRUE,
+                '2010'
               ), (
                 '411c5908-2a83-40e9-863b-303931a1c119',
                 'Delaware',
                 'US',
                 'DE',
                 's3://global-districtbuilder-dev-us-east-1/regions/US/DE/2021-06-11T23:03:36.938Z/',
-                DEFAULT,
-                DEFAULT,
-                FALSE
+                '2021-06-11 23:03:36.938',
+                FALSE,
+                FALSE,
+                '2020'
              )
               ON CONFLICT DO NOTHING;
             "

--- a/src/client/actions/organization.ts
+++ b/src/client/actions/organization.ts
@@ -8,6 +8,8 @@ export const organizationFetchFailure = createAction("Organization fetch failure
   ResourceFailure
 >();
 
+export const organizationReset = createAction("Clear organization details")();
+
 export const exportProjects = createAction("Export organization projects CSV")<OrganizationSlug>();
 export const exportProjectsFailure = createAction("Export organization projects CSV failure")<
   string

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -309,14 +309,21 @@ export async function exportProjectShp(project: IProject): Promise<void> {
   });
 }
 
-export async function importCsv(file: Blob): Promise<DistrictsImportApiResponse> {
+export async function importCsv(
+  file: Blob,
+  regionConfigId?: RegionConfigId
+): Promise<DistrictsImportApiResponse> {
   const formData = new FormData();
   formData.append("file", file);
   return new Promise((resolve, reject) => {
     apiAxios
-      .post(`/api/districts/import/csv`, formData, {
-        headers: { "Content-Type": "multipart/form-data" }
-      })
+      .post(
+        `/api/districts/import/csv${regionConfigId ? `?regionConfigId=${regionConfigId}` : ""}`,
+        formData,
+        {
+          headers: { "Content-Type": "multipart/form-data" }
+        }
+      )
       .then(response => {
         return resolve(response.data);
       })

--- a/src/client/components/OrganizationTemplateForm.tsx
+++ b/src/client/components/OrganizationTemplateForm.tsx
@@ -75,7 +75,7 @@ interface Props {
 }
 
 interface IProps {
-  readonly templateSelected: (templateData: CreateProjectData) => void;
+  readonly templateSelected: (templateData: CreateProjectData) => Promise<void>;
 }
 
 const OrganizationTemplateForm = ({

--- a/src/client/components/OrganizationTemplateForm.tsx
+++ b/src/client/components/OrganizationTemplateForm.tsx
@@ -1,0 +1,171 @@
+/** @jsx jsx */
+import {
+  IOrganization,
+  IUser,
+  CreateProjectData,
+  OrganizationSlug,
+  OrganizationNest
+} from "../../shared/entities";
+import { Box, jsx, Card, Label, Radio, Flex, Spinner } from "theme-ui";
+import OrganizationTemplates from "./OrganizationTemplates";
+import { useState, useEffect } from "react";
+import { organizationFetch, organizationReset } from "../actions/organization";
+import store from "../store";
+import React from "react";
+import { Resource } from "../resource";
+
+const style = {
+  formContainer: {
+    width: "100%",
+    display: "block",
+    flexDirection: "column"
+  },
+  orgTemplates: {
+    display: "block",
+    minHeight: "100px",
+    pl: "5px",
+    "> *": {
+      mx: 5
+    },
+    mx: "auto",
+    width: "100%",
+    maxWidth: "large",
+    borderTop: "1px solid lightgray",
+    my: 5
+  },
+  legend: {
+    paddingInlineStart: "0",
+    paddingInlineEnd: "0"
+  },
+  cardLabel: {
+    textTransform: "none",
+    variant: "text.h5",
+    display: "block",
+    mb: 1
+  },
+  cardHint: {
+    display: "block",
+    textTransform: "none",
+    fontWeight: "500",
+    fontSize: 1,
+    mt: 2,
+    mb: 3
+  },
+  radioHeading: {
+    textTransform: "none",
+    variant: "text.body",
+    fontSize: 2,
+    lineHeight: "heading",
+    letterSpacing: "0",
+    mb: "0",
+    color: "heading",
+    fontWeight: "body"
+  },
+  radioSubHeading: {
+    fontSize: 1,
+    letterSpacing: "0",
+    textTransform: "none",
+    fontWeight: "500"
+  }
+} as const;
+
+interface Props {
+  readonly organization?: IOrganization;
+  readonly organizations: readonly OrganizationNest[];
+  readonly user: IUser | undefined;
+}
+
+interface IProps {
+  readonly templateSelected: (templateData: CreateProjectData) => void;
+}
+
+const OrganizationTemplateForm = ({
+  organization,
+  organizations,
+  user,
+  templateSelected
+}: Props & IProps) => {
+  const [organizationSlug, setOrganizationSlug] = useState<OrganizationSlug | undefined>(undefined);
+
+  const onOrgChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.currentTarget.value !== "" && setOrganizationSlug(e.currentTarget.value);
+    e.currentTarget.value === "" && setOrganizationSlug(undefined);
+  };
+
+  useEffect(() => {
+    organizationSlug
+      ? store.dispatch(organizationFetch(organizationSlug))
+      : store.dispatch(organizationReset());
+  }, [organizationSlug]);
+
+  return organizations.length > 0 ? (
+    <React.Fragment>
+      <Flex sx={{ ...style.formContainer }}>
+        <Card sx={{ variant: "card.flat" }}>
+          <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
+            Organization
+          </legend>
+          <Box sx={style.cardHint}>
+            Are you making a new map with an organization you&apos;ve joined?
+          </Box>
+          <div
+            sx={{
+              flex: "0 0 50%",
+              "@media screen and (max-width: 770px)": {
+                flex: "0 0 100%"
+              }
+            }}
+            key="custom"
+          >
+            <Label>
+              <Radio
+                name="organization"
+                value=""
+                onChange={onOrgChanged}
+                checked={organizationSlug === undefined}
+              />
+              <Flex as="span" sx={{ flexDirection: "column" }}>
+                <div sx={style.radioHeading}>No organization</div>
+                <div sx={style.radioSubHeading}>Continue without an organization</div>
+              </Flex>
+            </Label>
+          </div>
+          {organizations.map(org => (
+            <Label
+              key={org.slug}
+              sx={{
+                display: "inline-flex",
+                "@media screen and (min-width: 750px)": {
+                  flex: "0 0 48%",
+                  "&:nth-of-type(even)": {
+                    mr: "2%"
+                  }
+                }
+              }}
+            >
+              <Radio name="organization" value={org.slug} onChange={onOrgChanged} />
+              <Flex as="span" sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}>
+                <div sx={style.radioHeading}>{org.name}</div>
+              </Flex>
+            </Label>
+          ))}
+        </Card>
+      </Flex>
+      {organizationSlug && !organization && (
+        <Flex>
+          <Spinner variant="spinner.large" sx={{ m: "auto" }} />
+        </Flex>
+      )}
+      {organization && user && (
+        <Box sx={style.orgTemplates}>
+          <OrganizationTemplates
+            user={user}
+            organization={organization}
+            templateSelected={templateSelected}
+          />
+        </Box>
+      )}
+    </React.Fragment>
+  ) : null;
+};
+export default OrganizationTemplateForm;

--- a/src/client/components/OrganizationTemplateForm.tsx
+++ b/src/client/components/OrganizationTemplateForm.tsx
@@ -87,8 +87,7 @@ const OrganizationTemplateForm = ({
   const [organizationSlug, setOrganizationSlug] = useState<OrganizationSlug | undefined>(undefined);
 
   const onOrgChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.currentTarget.value !== "" && setOrganizationSlug(e.currentTarget.value);
-    e.currentTarget.value === "" && setOrganizationSlug(undefined);
+    setOrganizationSlug(e.currentTarget.value !== "" ? e.currentTarget.value : undefined);
   };
 
   useEffect(() => {

--- a/src/client/components/OrganizationTemplateForm.tsx
+++ b/src/client/components/OrganizationTemplateForm.tsx
@@ -12,7 +12,6 @@ import { useState, useEffect } from "react";
 import { organizationFetch, organizationReset } from "../actions/organization";
 import store from "../store";
 import React from "react";
-import { Resource } from "../resource";
 
 const style = {
   formContainer: {

--- a/src/client/components/OrganizationTemplates.tsx
+++ b/src/client/components/OrganizationTemplates.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 interface IProps {
-  readonly templateSelected?: (templateData: CreateProjectData) => void;
+  readonly templateSelected: (templateData: CreateProjectData) => Promise<void>;
 }
 
 const style = {

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -1,6 +1,8 @@
 /** @jsx jsx */
+import { useState } from "react";
+import { Box, Button, Flex, Heading, jsx, Text, Spinner } from "theme-ui";
+
 import { IOrganization, IProjectTemplate, IUser, CreateProjectData } from "../../shared/entities";
-import { Box, Button, Flex, Heading, jsx, Text } from "theme-ui";
 import { isUserLoggedIn } from "../jwt";
 import Tooltip from "./Tooltip";
 
@@ -34,27 +36,30 @@ const TemplateCard = ({
 }: {
   readonly template: IProjectTemplate;
   readonly organization: IOrganization;
+  readonly templateSelected: (templateData: CreateProjectData) => Promise<void>;
   readonly user?: IUser;
-  readonly templateSelected?: (templateData: CreateProjectData) => void;
 }) => {
+  const [inProgress, setInProgress] = useState(false);
   const userIsVerified = user?.isEmailVerified;
   const isLoggedIn = isUserLoggedIn();
   const userInOrg = user && checkIfUserInOrg(organization, user);
 
   const useButton = (
     <Button
-      disabled={isLoggedIn && !userIsVerified}
+      disabled={inProgress || (isLoggedIn && !userIsVerified)}
       onClick={() => {
-        if (templateSelected) {
+        if (!inProgress && templateSelected) {
           const data: CreateProjectData = {
             projectTemplate: { id: template.id },
             regionConfig: { id: template.regionConfig.id }
           };
-          templateSelected(data);
+          setInProgress(true);
+          templateSelected(data).then(() => setInProgress(false));
         }
       }}
       sx={style.useTemplateBtn}
     >
+      {inProgress && <Spinner variant="spinner.small" />}
       Use this template
     </Button>
   );

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -46,8 +46,10 @@ const TemplateCard = ({
       disabled={isLoggedIn && !userIsVerified}
       onClick={() => {
         if (templateSelected) {
-          const { id } = template;
-          const data: CreateProjectData = { projectTemplate: { id } };
+          const data: CreateProjectData = {
+            projectTemplate: { id: template.id },
+            regionConfig: { id: template.regionConfig.id }
+          };
           templateSelected(data);
         }
       }}

--- a/src/client/components/TemplateCard.tsx
+++ b/src/client/components/TemplateCard.tsx
@@ -46,6 +46,7 @@ const TemplateCard = ({
 
   const useButton = (
     <Button
+      type="button"
       disabled={inProgress || (isLoggedIn && !userIsVerified)}
       onClick={() => {
         if (!inProgress && templateSelected) {

--- a/src/client/reducers/organization.ts
+++ b/src/client/reducers/organization.ts
@@ -9,7 +9,8 @@ import {
   exportOrgUsers,
   exportOrgUsersFailure,
   exportProjects,
-  exportProjectsFailure
+  exportProjectsFailure,
+  organizationReset
 } from "../actions/organization";
 
 import { IOrganization } from "../../shared/entities";
@@ -34,9 +35,11 @@ const organizationReducer: LoopReducer<OrganizationState, Action> = (
   switch (action.type) {
     case getType(organizationFetch):
       return loop(
-        {
-          isPending: true
-        },
+        "resource" in state
+          ? { resource: state.resource, isPending: true }
+          : {
+              isPending: true
+            },
         Cmd.run(fetchOrganization, {
           successActionCreator: organizationFetchSuccess,
           failActionCreator: organizationFetchFailure,
@@ -56,6 +59,10 @@ const organizationReducer: LoopReducer<OrganizationState, Action> = (
           ? Cmd.run(showResourceFailedToast)
           : Cmd.none
       );
+    case getType(organizationReset):
+      return {
+        isPending: false
+      };
     case getType(exportProjects):
       return loop(
         state,

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -19,15 +19,8 @@ import {
 import { Link } from "react-router-dom";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
-import {
-  IProject,
-  IRegionConfig,
-  IChamber,
-  OrganizationSlug,
-  CreateProjectData
-} from "../../shared/entities";
+import { IProject, IRegionConfig, IChamber, CreateProjectData } from "../../shared/entities";
 import { regionConfigsFetch } from "../actions/regionConfig";
-import { organizationFetch } from "../actions/organization";
 import { createProject } from "../api";
 import { InputField, SelectField } from "../components/Field";
 import FormError from "../components/FormError";
@@ -36,7 +29,7 @@ import { UserState } from "../reducers/user";
 import { WriteResource, Resource } from "../resource";
 import store from "../store";
 import { OrganizationState } from "../reducers/organization";
-import OrganizationTemplates from "../components/OrganizationTemplates";
+import OrganizationTemplateForm from "../components/OrganizationTemplateForm";
 
 interface StateProps {
   readonly regionConfigs: Resource<readonly IRegionConfig[]>;
@@ -85,7 +78,8 @@ const style: ThemeUIStyleObject = {
   formContainer: {
     width: "100%",
     maxWidth: "640px",
-    my: 7,
+    mt: 6,
+    mb: 7,
     mx: "auto",
     display: "block",
     flexDirection: "column",
@@ -148,19 +142,6 @@ const style: ThemeUIStyleObject = {
   },
   orgCardSubtitle: {
     mb: "10px"
-  },
-  orgTemplates: {
-    display: "block",
-    minHeight: "100px",
-    pl: "5px",
-    "> *": {
-      mx: 5
-    },
-    mx: "auto",
-    width: "100%",
-    maxWidth: "large",
-    borderTop: "1px solid lightgray",
-    my: 8
   }
 };
 
@@ -179,7 +160,6 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     }
   });
   const { data } = createProjectResource;
-  const [organizationSlug, setOrganizationSlug] = useState<OrganizationSlug | undefined>(undefined);
 
   const onDistrictChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     const chamber =
@@ -204,19 +184,10 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
   }
 
-  const onOrgChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.currentTarget.value !== "" && setOrganizationSlug(e.currentTarget.value);
-    e.currentTarget.value === "" && setOrganizationSlug(undefined);
-  };
-
   useEffect(() => {
     store.dispatch(regionConfigsFetch());
     store.dispatch(userFetch());
   }, []);
-
-  useEffect(() => {
-    organizationSlug && store.dispatch(organizationFetch(organizationSlug));
-  }, [organizationSlug]);
 
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />
@@ -248,324 +219,274 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
         </Heading>
       </Flex>
       <Flex as="main" sx={{ width: "100%", display: "block" }}>
-        <Flex sx={{ ...style.formContainer, ...{ marginBottom: "-36px" } }}>
-          {"resource" in user && user.resource.organizations.length > 0 && (
-            <Card sx={{ variant: "card.flat" }}>
-              <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
-                Organization
-              </legend>
-              <Box sx={style.cardHint}>
-                Are you making a new map with an organization you&apos;ve joined?
-              </Box>
-              <div
-                sx={{
-                  flex: "0 0 50%",
-                  "@media screen and (max-width: 770px)": {
-                    flex: "0 0 100%"
-                  }
-                }}
-                key="custom"
-              >
-                <Label>
-                  <Radio
-                    name="organization"
-                    value=""
-                    onChange={onOrgChanged}
-                    checked={organizationSlug === undefined}
-                  />
-                  <Flex as="span" sx={{ flexDirection: "column" }}>
-                    <div sx={style.radioHeading}>No organization</div>
-                    <div sx={style.radioSubHeading}>Continue without an organization</div>
-                  </Flex>
-                </Label>
-              </div>
-              {user.resource.organizations.map(org => (
-                <Label
-                  key={org.slug}
-                  sx={{
-                    display: "inline-flex",
-                    "@media screen and (min-width: 750px)": {
-                      flex: "0 0 48%",
-                      "&:nth-of-type(even)": {
-                        mr: "2%"
-                      }
+        <Flex sx={style.formContainer}>
+          <Flex
+            as="form"
+            sx={{ flexDirection: "column" }}
+            onSubmit={(e: React.FormEvent) => {
+              e.preventDefault();
+              const validatedForm = validate(data);
+              // Disabling 'functional/no-conditional-statement' without naming it.
+              // See https://github.com/jonaskello/eslint-plugin-functional/issues/105
+              // eslint-disable-next-line
+              if (validatedForm.valid === true) {
+                setCreateProjectResource({ data, isPending: true });
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { isCustom, valid, ...validatedData } = validatedForm;
+                createProject({
+                  ...validatedData,
+                  chamber: validatedForm.chamber || undefined,
+                  populationDeviation: validatedForm.populationDeviation,
+                  numberOfDistricts: validatedForm.numberOfDistricts
+                })
+                  .then((project: IProject) =>
+                    setCreateProjectResource({ data, resource: project })
+                  )
+                  .catch(errors => setCreateProjectResource({ data, errors }));
+              }
+            }}
+          >
+            {"resource" in user && (
+              <OrganizationTemplateForm
+                organization={"resource" in organization ? organization.resource : undefined}
+                templateSelected={setupProjectFromTemplate}
+                organizations={user.resource.organizations}
+                user={user.resource}
+              />
+            )}
+            {!("resource" in organization) && (
+              <React.Fragment>
+                <Card sx={{ variant: "card.flat" }}>
+                  <FormError resource={createProjectResource} />
+                  <InputField
+                    field="name"
+                    label={
+                      <Box as="span" sx={style.cardLabel}>
+                        Map name
+                      </Box>
                     }
-                  }}
-                >
-                  <Radio name="organization" value={org.slug} onChange={onOrgChanged} />
-                  <Flex as="span" sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}>
-                    <div sx={style.radioHeading}>{org.name}</div>
-                  </Flex>
-                </Label>
-              ))}
-            </Card>
-          )}
-        </Flex>
-        {"resource" in organization && "resource" in user && organizationSlug && (
-          <Box sx={style.orgTemplates}>
-            <OrganizationTemplates
-              user={user.resource}
-              organization={organization.resource}
-              templateSelected={setupProjectFromTemplate}
-            />
-          </Box>
-        )}
-        {!organizationSlug && (
-          <Flex sx={style.formContainer}>
-            <Flex
-              as="form"
-              sx={{ flexDirection: "column" }}
-              onSubmit={(e: React.FormEvent) => {
-                e.preventDefault();
-                const validatedForm = validate(data);
-                // Disabling 'functional/no-conditional-statement' without naming it.
-                // See https://github.com/jonaskello/eslint-plugin-functional/issues/105
-                // eslint-disable-next-line
-                if (validatedForm.valid === true) {
-                  setCreateProjectResource({ data, isPending: true });
-                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  const { isCustom, valid, ...validatedData } = validatedForm;
-                  createProject({
-                    ...validatedData,
-                    chamber: validatedForm.chamber || undefined,
-                    populationDeviation: validatedForm.populationDeviation,
-                    numberOfDistricts: validatedForm.numberOfDistricts
-                  })
-                    .then((project: IProject) =>
-                      setCreateProjectResource({ data, resource: project })
-                    )
-                    .catch(errors => setCreateProjectResource({ data, errors }));
-                }
-              }}
-            >
-              <Card sx={{ variant: "card.flat" }}>
-                <FormError resource={createProjectResource} />
-                <InputField
-                  field="name"
-                  label={
-                    <Box as="span" sx={style.cardLabel}>
-                      Map name
-                    </Box>
-                  }
-                  description={
-                    <Box as="span" sx={style.cardHint}>
-                      e.g. ‘Arizona House of Representatives’. Make it specific to help tell your
-                      maps apart.
-                    </Box>
-                  }
-                  resource={createProjectResource}
-                  inputProps={{
-                    onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                      setCreateProjectResource({
-                        data: { ...data, name: e.currentTarget.value }
-                      })
-                  }}
-                />
-              </Card>
-              <Card sx={{ variant: "card.flat" }}>
-                <SelectField
-                  field="regionConfig"
-                  sx={{ width: "1000px" }}
-                  label={
-                    <Box as="span" sx={style.cardLabel}>
-                      State
-                    </Box>
-                  }
-                  description={
-                    <Box as="span" sx={style.cardHint}>
-                      What state do you want to map? If you don’t see it in the list,{" "}
-                      <Styled.a
-                        href="https://districtbuilder.us1.list-manage.com/subscribe?u=61da999c9897859f1c1fff262&id=70fdf1ae35"
-                        target="_blank"
-                      >
-                        sign up for our mailing list
-                      </Styled.a>{" "}
-                      to know when new states are available!
-                    </Box>
-                  }
-                  resource={createProjectResource}
-                  selectProps={{
-                    onChange:
-                      "resource" in regionConfigs
-                        ? (e: React.ChangeEvent<HTMLSelectElement>) => {
-                            const regionConfig = regionConfigs.resource.find(
-                              regionConfig => regionConfig.id === e.currentTarget.value
-                            );
-                            setCreateProjectResource({
-                              data: { ...data, regionConfig: regionConfig || null }
-                            });
-                          }
-                        : undefined
-                  }}
-                >
-                  <option>Select...</option>
-                  {"resource" in regionConfigs
-                    ? regionConfigs.resource
-                        .filter(regionConfig => !regionConfig.hidden)
-                        .map(regionConfig => (
-                          <option key={regionConfig.id} value={regionConfig.id}>
-                            {regionConfig.name}
-                          </option>
-                        ))
-                    : null}
-                </SelectField>
-              </Card>
-              {data.regionConfig ? (
-                <React.Fragment>
-                  <Card sx={{ variant: "card.flat" }}>
-                    <fieldset sx={style.fieldset}>
+                    description={
+                      <Box as="span" sx={style.cardHint}>
+                        e.g. ‘Arizona House of Representatives’. Make it specific to help tell your
+                        maps apart.
+                      </Box>
+                    }
+                    resource={createProjectResource}
+                    inputProps={{
+                      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                        setCreateProjectResource({
+                          data: { ...data, name: e.currentTarget.value }
+                        })
+                    }}
+                  />
+                </Card>
+                <Card sx={{ variant: "card.flat" }}>
+                  <SelectField
+                    field="regionConfig"
+                    sx={{ width: "1000px" }}
+                    label={
+                      <Box as="span" sx={style.cardLabel}>
+                        State
+                      </Box>
+                    }
+                    description={
+                      <Box as="span" sx={style.cardHint}>
+                        What state do you want to map? If you don’t see it in the list,{" "}
+                        <Styled.a
+                          href="https://districtbuilder.us1.list-manage.com/subscribe?u=61da999c9897859f1c1fff262&id=70fdf1ae35"
+                          target="_blank"
+                        >
+                          sign up for our mailing list
+                        </Styled.a>{" "}
+                        to know when new states are available!
+                      </Box>
+                    }
+                    resource={createProjectResource}
+                    selectProps={{
+                      onChange:
+                        "resource" in regionConfigs
+                          ? (e: React.ChangeEvent<HTMLSelectElement>) => {
+                              const regionConfig = regionConfigs.resource.find(
+                                regionConfig => regionConfig.id === e.currentTarget.value
+                              );
+                              setCreateProjectResource({
+                                data: { ...data, regionConfig: regionConfig || null }
+                              });
+                            }
+                          : undefined
+                    }}
+                  >
+                    <option>Select...</option>
+                    {"resource" in regionConfigs
+                      ? regionConfigs.resource
+                          .filter(regionConfig => !regionConfig.hidden)
+                          .map(regionConfig => (
+                            <option key={regionConfig.id} value={regionConfig.id}>
+                              {regionConfig.name}
+                            </option>
+                          ))
+                      : null}
+                  </SelectField>
+                </Card>
+                {data.regionConfig ? (
+                  <React.Fragment>
+                    <Card sx={{ variant: "card.flat" }}>
+                      <fieldset sx={style.fieldset}>
+                        <Flex sx={{ flexWrap: "wrap" }}>
+                          <legend
+                            sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}
+                          >
+                            Districts
+                          </legend>
+                          <Box
+                            id="description-districts"
+                            as="span"
+                            sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
+                          >
+                            How many districts do you want to map? Choose a federal or state
+                            legislative chamber or define your own.
+                          </Box>
+                          {data.regionConfig &&
+                            [...data.regionConfig.chambers]
+                              .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
+                              .map(chamber => (
+                                <Label
+                                  key={chamber.id}
+                                  sx={{
+                                    display: "inline-flex",
+                                    "@media screen and (min-width: 750px)": {
+                                      flex: "0 0 48%",
+                                      "&:nth-of-type(even)": {
+                                        mr: "2%"
+                                      }
+                                    }
+                                  }}
+                                >
+                                  <Radio
+                                    name="project-district"
+                                    value={chamber.id}
+                                    onChange={onDistrictChanged}
+                                    aria-describedby="description-districts"
+                                  />
+                                  <Flex
+                                    as="span"
+                                    sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
+                                  >
+                                    <div sx={style.radioHeading}>{chamber.name}</div>
+                                    <div sx={style.radioSubHeading}>
+                                      {chamber.numberOfDistricts} districts
+                                    </div>
+                                  </Flex>
+                                </Label>
+                              ))
+                              .concat(
+                                <div
+                                  sx={{
+                                    flex: "0 0 50%",
+                                    "@media screen and (max-width: 770px)": {
+                                      flex: "0 0 100%"
+                                    }
+                                  }}
+                                  key="custom"
+                                >
+                                  <Label>
+                                    <Radio
+                                      name="project-district"
+                                      value=""
+                                      onChange={onDistrictChanged}
+                                    />
+                                    <Flex as="span" sx={{ flexDirection: "column" }}>
+                                      <div sx={style.radioHeading}>Custom</div>
+                                      <div sx={style.radioSubHeading}>
+                                        Define a custom number of districts
+                                      </div>
+                                    </Flex>
+                                  </Label>
+                                </div>
+                              )}
+                          {data.isCustom ? (
+                            <Box sx={style.customInputContainer}>
+                              <InputField
+                                field="numberOfDistricts"
+                                label="Number of districts"
+                                resource={createProjectResource}
+                                inputProps={{
+                                  onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                                    const value = parseInt(e.currentTarget.value, 10);
+                                    const numberOfDistricts = isNaN(value) ? null : value;
+                                    setCreateProjectResource({
+                                      data: {
+                                        ...data,
+                                        numberOfDistricts
+                                      }
+                                    });
+                                  }
+                                }}
+                              />
+                            </Box>
+                          ) : null}
+                        </Flex>
+                      </fieldset>
+                    </Card>
+                    <Card sx={{ variant: "card.flat" }}>
                       <Flex sx={{ flexWrap: "wrap" }}>
                         <legend
                           sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}
                         >
-                          Districts
+                          Population deviation tolerance
                         </legend>
                         <Box
                           id="description-districts"
                           as="span"
                           sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
                         >
-                          How many districts do you want to map? Choose a federal or state
-                          legislative chamber or define your own.
+                          How detailed of a map do you want to draw? Setting a lower tolerance means
+                          the population of your districts will need to be more exact. If you
+                          aren&apos;t sure, we think 5% is a good starting point.
                         </Box>
-                        {data.regionConfig &&
-                          [...data.regionConfig.chambers]
-                            .sort((a, b) => a.numberOfDistricts - b.numberOfDistricts)
-                            .map(chamber => (
-                              <Label
-                                key={chamber.id}
-                                sx={{
-                                  display: "inline-flex",
-                                  "@media screen and (min-width: 750px)": {
-                                    flex: "0 0 48%",
-                                    "&:nth-of-type(even)": {
-                                      mr: "2%"
-                                    }
+                        <Box sx={style.customInputContainer}>
+                          <InputField
+                            field="populationDeviation"
+                            label="Population deviation tolerance (%)"
+                            defaultValue={DEFAULT_POPULATION_DEVIATION}
+                            resource={createProjectResource}
+                            inputProps={{
+                              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                                const value = parseFloat(e.currentTarget.value);
+                                const populationDeviation = isNaN(value) ? null : value;
+                                setCreateProjectResource({
+                                  data: {
+                                    ...data,
+                                    populationDeviation
                                   }
-                                }}
-                              >
-                                <Radio
-                                  name="project-district"
-                                  value={chamber.id}
-                                  onChange={onDistrictChanged}
-                                  aria-describedby="description-districts"
-                                />
-                                <Flex
-                                  as="span"
-                                  sx={{ flexDirection: "column", flex: "0 1 calc(100% - 2rem)" }}
-                                >
-                                  <div sx={style.radioHeading}>{chamber.name}</div>
-                                  <div sx={style.radioSubHeading}>
-                                    {chamber.numberOfDistricts} districts
-                                  </div>
-                                </Flex>
-                              </Label>
-                            ))
-                            .concat(
-                              <div
-                                sx={{
-                                  flex: "0 0 50%",
-                                  "@media screen and (max-width: 770px)": {
-                                    flex: "0 0 100%"
-                                  }
-                                }}
-                                key="custom"
-                              >
-                                <Label>
-                                  <Radio
-                                    name="project-district"
-                                    value=""
-                                    onChange={onDistrictChanged}
-                                  />
-                                  <Flex as="span" sx={{ flexDirection: "column" }}>
-                                    <div sx={style.radioHeading}>Custom</div>
-                                    <div sx={style.radioSubHeading}>
-                                      Define a custom number of districts
-                                    </div>
-                                  </Flex>
-                                </Label>
-                              </div>
-                            )}
-                        {data.isCustom ? (
-                          <Box sx={style.customInputContainer}>
-                            <InputField
-                              field="numberOfDistricts"
-                              label="Number of districts"
-                              resource={createProjectResource}
-                              inputProps={{
-                                onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                                  const value = parseInt(e.currentTarget.value, 10);
-                                  const numberOfDistricts = isNaN(value) ? null : value;
-                                  setCreateProjectResource({
-                                    data: {
-                                      ...data,
-                                      numberOfDistricts
-                                    }
-                                  });
-                                }
-                              }}
-                            />
-                          </Box>
-                        ) : null}
+                                });
+                              }
+                            }}
+                          />
+                        </Box>
                       </Flex>
-                    </fieldset>
-                  </Card>
-                  <Card sx={{ variant: "card.flat" }}>
-                    <Flex sx={{ flexWrap: "wrap" }}>
-                      <legend sx={{ ...style.cardLabel, ...style.legend, ...{ flex: "0 0 100%" } }}>
-                        Population deviation tolerance
-                      </legend>
-                      <Box
-                        id="description-districts"
-                        as="span"
-                        sx={{ ...style.cardHint, ...{ flex: "0 0 100%" } }}
-                      >
-                        How detailed of a map do you want to draw? Setting a lower tolerance means
-                        the population of your districts will need to be more exact. If you
-                        aren&apos;t sure, we think 5% is a good starting point.
-                      </Box>
-                      <Box sx={style.customInputContainer}>
-                        <InputField
-                          field="populationDeviation"
-                          label="Population deviation tolerance (%)"
-                          defaultValue={DEFAULT_POPULATION_DEVIATION}
-                          resource={createProjectResource}
-                          inputProps={{
-                            onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                              const value = parseFloat(e.currentTarget.value);
-                              const populationDeviation = isNaN(value) ? null : value;
-                              setCreateProjectResource({
-                                data: {
-                                  ...data,
-                                  populationDeviation
-                                }
-                              });
-                            }
-                          }}
-                        />
-                      </Box>
-                    </Flex>
-                  </Card>
-                </React.Fragment>
-              ) : (
-                undefined
-              )}
-              <Box sx={{ mt: 3, textAlign: "left" }}>
-                <Button
-                  type="submit"
-                  sx={{ "&[disabled]": { opacity: "0.2" } }}
-                  disabled={
-                    (("isPending" in createProjectResource && createProjectResource.isPending) ||
-                      !validate(data).valid) &&
-                    !("errorMessage" in createProjectResource)
-                  }
-                >
-                  Create map
-                </Button>
-              </Box>
-            </Flex>
+                    </Card>
+                  </React.Fragment>
+                ) : (
+                  undefined
+                )}
+                <Box sx={{ mt: 3, textAlign: "left" }}>
+                  <Button
+                    type="submit"
+                    sx={{ "&[disabled]": { opacity: "0.2" } }}
+                    disabled={
+                      (("isPending" in createProjectResource && createProjectResource.isPending) ||
+                        !validate(data).valid) &&
+                      !("errorMessage" in createProjectResource)
+                    }
+                  >
+                    Create map
+                  </Button>
+                </Box>
+              </React.Fragment>
+            )}
           </Flex>
-        )}
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -181,7 +181,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
   };
 
   function setupProjectFromTemplate(data: CreateProjectData) {
-    void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
+    return createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
   }
 
   useEffect(() => {

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -3,7 +3,7 @@ import { darken } from "@theme-ui/color";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { FileDrop } from "react-file-drop";
 import { connect } from "react-redux";
-import { Link, Redirect, useHistory } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 import {
   Box,
   Button,

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -295,24 +295,21 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
     });
   };
 
-  const onTemplateSelected = (data: CreateProjectData) => {
-    const loadProjectWithTemplate = async () => {
-      if (!file) {
-        return;
-      }
-      const importResponse = await importCsv(file, data.regionConfig.id);
-      if ("error" in importResponse) {
-        setImportResource({ data: null });
-        setFileError(importResponse.error);
-      } else {
-        createProject({
-          ...data,
-          districtsDefinition: importResponse.districtsDefinition,
-          numberOfDistricts: Math.max(importResponse.maxDistrictId, formData.numberOfDistricts || 0)
-        }).then((project: IProject) => history.push(`/projects/${project.id}`));
-      }
-    };
-    loadProjectWithTemplate();
+  const onTemplateSelected = async (data: CreateProjectData): Promise<void> => {
+    if (!file) {
+      return;
+    }
+    const importResponse = await importCsv(file, data.regionConfig.id);
+    if ("error" in importResponse) {
+      setImportResource({ data: null });
+      setFileError(importResponse.error);
+    } else {
+      return createProject({
+        ...data,
+        districtsDefinition: importResponse.districtsDefinition,
+        numberOfDistricts: Math.max(importResponse.maxDistrictId, formData.numberOfDistricts || 0)
+      }).then((project: IProject) => history.push(`/projects/${project.id}`));
+    }
   };
 
   const handleFileUpload = useCallback(

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -300,7 +300,7 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
       if (!file) {
         return;
       }
-      const importResponse = await importCsv(file);
+      const importResponse = await importCsv(file, data.regionConfig.id);
       if ("error" in importResponse) {
         setImportResource({ data: null });
         setFileError(importResponse.error);

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -736,8 +736,9 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
                   <Button
                     type="submit"
                     disabled={
-                      !validate(formData, importResource, templateData).valid &&
-                      !("errorMessage" in createProjectResource)
+                      ("isPending" in createProjectResource && createProjectResource.isPending) ||
+                      (!validate(formData, importResource, templateData).valid &&
+                        !("errorMessage" in createProjectResource))
                     }
                   >
                     Create map

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -152,16 +152,15 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
   const orgAdminUrl = `/o/${organizationSlug}/admin`;
   const history = useHistory();
 
-  function createProjectFromTemplate(data: CreateProjectData) {
-    void createProject(data).then((project: IProject) => history.push(`/projects/${project.id}`));
-  }
-
   function setupProjectFromTemplate(data: CreateProjectData) {
     if (userInOrg) {
-      createProjectFromTemplate(data);
+      return createProject(data).then((project: IProject) =>
+        history.push(`/projects/${project.id}`)
+      );
     } else {
       setProjectTemplateData(data);
       store.dispatch(showCopyMapModal(true));
+      return Promise.resolve(void 0);
     }
   }
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -329,7 +329,15 @@ export class ProjectsController implements CrudController<Project> {
       pinnedMetricFields,
       districtsDefinition
     });
-    const formdata = template ? { ...dto, ...templateFields(template) } : dto;
+    // most template fields take precedence, but districtsDefinition should preferentially use the
+    // DTO data, to support imports w/ templates
+    const formdata = template
+      ? {
+          ...dto,
+          ...templateFields(template),
+          districtsDefinition: dto.districtsDefinition || template.districtsDefinition
+        }
+      : dto;
     if (!formdata.numberOfDistricts) {
       // The validation in the DTO should prevent this
       throw new InternalServerErrorException();

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -28,7 +28,7 @@ export class CreateProjectDto implements CreateProjectData {
 
   @ValidateIf(o => o.projectTemplate?.id === undefined)
   @IsNotEmpty({ message: "Need to supply a region configuration" })
-  readonly regionConfig?: RegionConfigIdDto;
+  readonly regionConfig: RegionConfigIdDto;
 
   @IsArray()
   @ArrayNotEmpty()

--- a/src/server/src/users/controllers/users.controller.ts
+++ b/src/server/src/users/controllers/users.controller.ts
@@ -16,6 +16,15 @@ import { UsersService } from "../services/users.service";
       organizations: {
         allow: ["slug", "name", "logoUrl"],
         eager: true
+      },
+      "organizations.projectTemplates": {
+        alias: "org_templates",
+        exclude: ["districtsDefinition"],
+        eager: true
+      },
+      "organizations.projectTemplates.regionConfig": {
+        alias: "template_region_config",
+        eager: true
       }
     }
   },

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -222,7 +222,7 @@ export type ProjectNest = Pick<
 export interface CreateProjectData {
   readonly name?: string;
   readonly numberOfDistricts?: number;
-  readonly regionConfig?: Pick<IRegionConfig, "id">;
+  readonly regionConfig: Pick<IRegionConfig, "id">;
   readonly chamber?: Pick<IChamber, "id"> | null;
   readonly districtsDefinition?: DistrictsDefinition;
   readonly populationDeviation?: number;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -11,7 +11,10 @@ export type PaginationMetadata = {
   readonly totalPages?: number;
 };
 
-export type OrganizationNest = Pick<IOrganization, "slug" | "id" | "name" | "logoUrl">;
+export type OrganizationNest = Pick<
+  IOrganization,
+  "slug" | "id" | "name" | "logoUrl" | "projectTemplates"
+>;
 
 export interface IUser {
   readonly id: UserId;


### PR DESCRIPTION
## Overview

Allows selecting a project template during organization import

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![import-template](https://user-images.githubusercontent.com/4432106/135921571-451f90e3-44be-4092-ace6-86bc5ed1e573.gif)


### Notes

A bit going on here to make this feature work.
The general workflow is:
 - Upload a CSV, it gets validated against the primary state `RegionConfig`
 - We also check to see if the user's organizations have project templates that match the CSV. If so we allow to select an organization/template
 - After a template is selected, we _re_-upload the CSV to validate it against the `RegionConfig` for the template, which may be different (a county of the state in question, or one w/ different data or split census blocks).

## Testing Instructions

- Use `scripts/load-dev-data` to setup your `region_config` table (`TRUNCATE region_config CASCADE;` is a quick way to nuke your current regions first)
- The `scripts/load-dev-data` test organization has two templates configured, one for PA and one for Dane County.
  - Create a map for each template, and export them each to CSV
- Attempt to import each CSV. For the PA template, you should be able to import it w/ the template or using the "No Organization" option. For the Dane County CSV, attempt to import w/o a template will show warnings, which should go away after selecting the template

Closes #971
Closes #1019 

Supersedes #1003 
