### PR TITLE
Add support for VAP/CVAP fields, additional data fields

### DIFF
--- a/src/client/components/DemographicsChart.tsx
+++ b/src/client/components/DemographicsChart.tsx
@@ -19,6 +19,7 @@ const DemographicsChart = ({
 }: {
   readonly demographics: { readonly [id: string]: number };
 }) => {
+  // Only showing hard-coded core metrics here for space reasons, so we can hard-code population as well
   const percentages = mapValues(
     demographics,
     (population: number) =>

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -70,6 +70,7 @@ const DemographicsTooltip = ({
   readonly isMajorityMinority?: boolean;
   readonly abbreviate?: boolean;
 }) => {
+  // Only showing hard-coded core metrics here for space reasons, so we can hard-code population as well
   const percentages = mapValues(
     demographics,
     (population: number) =>

--- a/src/client/components/ProjectListFlyout.tsx
+++ b/src/client/components/ProjectListFlyout.tsx
@@ -46,8 +46,7 @@ const ProjectListFlyout = (props: FlyoutProps) => {
         sx={{
           ...{ variant: "buttons.ghost", fontWeight: "light", "& > svg": { m: "0 !important" } },
           ...style.menuButton,
-          ...invertStyles(props),
-          ...props
+          ...invertStyles(props)
         }}
         className="project-list-flyout-menu"
       >

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -158,5 +158,3 @@ export const REGION_TO_FIPS = Object.fromEntries(
 export const MAX_UPLOAD_FILE_SIZE = 25_000_000;
 
 export const MAX_IMPORT_ERRORS = 1_000;
-
-export const REGION_LABELS = ["election"] as const;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -105,11 +105,17 @@ export interface GeoLevelInfo {
 }
 
 export type GeoLevelHierarchy = readonly GeoLevelInfo[];
+export interface DemographicsGroup {
+  readonly subgroups: readonly string[];
+  readonly total?: string;
+  readonly tooltip?: string;
+}
 
 export interface IStaticMetadata {
   readonly demographics: readonly IStaticFile[];
   readonly geoLevels: readonly IStaticFile[];
   readonly voting?: readonly IStaticFile[];
+  readonly demographicsGroups?: readonly DemographicsGroup[];
   readonly bbox: readonly [number, number, number, number];
   readonly geoLevelHierarchy: GeoLevelHierarchy;
 }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -1,4 +1,4 @@
-import { ProjectVisibility, ReferenceLayerTypes, REGION_LABELS } from "./constants";
+import { ProjectVisibility, ReferenceLayerTypes } from "./constants";
 
 export type UserId = string;
 
@@ -105,7 +105,6 @@ export interface GeoLevelInfo {
 }
 
 export type GeoLevelHierarchy = readonly GeoLevelInfo[];
-export type RegionLabels = Record<typeof REGION_LABELS[number], string>;
 
 export interface IStaticMetadata {
   readonly demographics: readonly IStaticFile[];
@@ -113,7 +112,6 @@ export interface IStaticMetadata {
   readonly voting?: readonly IStaticFile[];
   readonly bbox: readonly [number, number, number, number];
   readonly geoLevelHierarchy: GeoLevelHierarchy;
-  readonly labels?: RegionLabels;
 }
 
 export interface Login {

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -101,8 +101,11 @@ export function getDemographicsMetricFields(staticMetadata: IStaticMetadata): Me
       ? []
       : [[file.id, getMetricFieldForDemographicsId(file.id)]]
   );
-  // Need to loosen up the types here
-  const order: readonly string[] = DEMOGRAPHIC_FIELDS_ORDER;
+  // If the configuration has demographic groups specified use that order, otherwise use the default ordering
+  const order: readonly string[] =
+    staticMetadata.demographicsGroups?.flatMap(g =>
+      g.total ? [g.total, ...g.subgroups] : g.subgroups
+    ) || DEMOGRAPHIC_FIELDS_ORDER;
   // eslint-disable-next-line functional/immutable-data
   data.sort(([a], [b]) => order.indexOf(a) - order.indexOf(b));
   return data;


### PR DESCRIPTION
## Overview

San Bernadino requested a large number of additional data fields, which we needed to make a few tweaks to support:
 - VAP / CVAP fields need to use the VAP / CVAP population when calculating percentages
 - We needed a way to order these fields in the expanded metrics viewer
 - Majority race calculations needed to be updated to not use the extra fields

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_projects_556f6c44-f70c-42a6-9dc8-e45080d57857](https://user-images.githubusercontent.com/4432106/136097421-343296fa-392f-4f0d-be8f-fc9d1093d760.png)

### Notes

I specifically chose **not** to update `process-geojson` to add a way to persist these changes into `static-metadata.json` as part of the command, since the configuration ended up somewhat complex. Rather, we have a default that should work for most regions (display the same fields as are in the tooltip / used for the majority race calculation), and we can _manually_ edit the JSON file to add `demographicGroups` when needed.

I have already updated the `static-metadata.json` at `s3://global-districtbuilder-dev-us-east-1/regions/US/CA/2021-09-30T18:00:31.844Z/static-metadata.json` to include a groups definition.

While I was changing things in the `IStaticMetadata` type, I also removed the currently no longer used `labels` field (https://github.com/PublicMapping/districtbuilder/commit/a6339e00dda8fb356f6af8193533ebf933e21f32), and I also fixed a React warning that popped up from a misuse of Theme-UI had been lurking around unnoticed (https://github.com/PublicMapping/districtbuilder/commit/1c547fe93a54aa212fa21a17caa6496089e158c8)



## Testing Instructions

- Set up a region using the preprocessed data mentioned in the issue:
   - `INSERT INTO region_config VALUES (DEFAULT, 'San Bernadino', 'US', 'CA', 's3://global-districtbuilder-dev-us-east-1/regions/US/CA/2021-09-30T18:00:31.844Z/', DEFAULT, DEFAULT, DEFAULT, '2020');`
- The expanded metrics viewer should show all fields, in the correct order (first group, majority race col, all other groups) for a map in the above region (on `develop` they will not be in the correct order)
- The majority race calculation should show Hispanic for the region as a whole (on `develop` it shows a non-race field)
- There shouldn't be regressions in a map for a region w/o `demographicsGroups` specified

Closes #1031 
