### PR TITLE
Support adjusted population values

### DIFF
--- a/src/client/components/DemographicsChart.tsx
+++ b/src/client/components/DemographicsChart.tsx
@@ -20,10 +20,10 @@ const DemographicsChart = ({
   readonly demographics: { readonly [id: string]: number };
 }) => {
   // Only showing hard-coded core metrics here for space reasons, so we can hard-code population as well
+  const total = Math.abs(demographics.population);
   const percentages = mapValues(
     demographics,
-    (population: number) =>
-      `${(demographics.population ? population / demographics.population : 0) * 100}%`
+    (population: number) => `${Math.min((total ? population / total : 0) * 100, 100)}%`
   );
   return (
     <Flex sx={{ flexDirection: "column", width: "40px", minHeight: "20px", flexShrink: 0 }}>

--- a/src/client/components/DemographicsTooltip.tsx
+++ b/src/client/components/DemographicsTooltip.tsx
@@ -45,7 +45,7 @@ const Row = ({
     <Styled.td sx={{ minWidth: "50px", py: 0 }}>
       <Box
         style={{
-          width: `${percent}%`
+          width: percent ? `${Math.min(percent, 100)}%` : 0
         }}
         sx={{
           height: "10px",
@@ -71,10 +71,11 @@ const DemographicsTooltip = ({
   readonly abbreviate?: boolean;
 }) => {
   // Only showing hard-coded core metrics here for space reasons, so we can hard-code population as well
+  // To handle cases where adjustments have caused negative pop. use absolute values
   const percentages = mapValues(
     demographics,
     (population: number) =>
-      (demographics.population ? population / demographics.population : 0) * 100
+      (demographics.population ? population / Math.abs(demographics.population) : 0) * 100
   );
   const rows = DEMOGRAPHIC_FIELDS_ORDER.filter(
     race => percentages[race] !== undefined

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -710,7 +710,7 @@ const SidebarRow = memo(
             <Tooltip
               placement="top-start"
               content={
-                demographics.population > 0 ? (
+                demographics.population !== 0 ? (
                   <DemographicsTooltip
                     demographics={demographics}
                     isMajorityMinority={isMajorityMinority(district)}
@@ -760,7 +760,7 @@ const SidebarRow = memo(
                   <Tooltip
                     placement="top-start"
                     content={
-                      demographics.population > 0 ? (
+                      demographics.population !== 0 ? (
                         <VotingSidebarTooltip voting={voting} />
                       ) : (
                         <em>

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -93,20 +93,20 @@ const ProjectEvaluateSidebar = ({
           Math.abs(f.properties.populationDeviation) < 1)
       );
     }).length;
-  const numDistrictsWithPopulation =
-    geojson && geojson.features.filter(f => f.properties.demographics.population > 0).length;
+  const numDistrictsWithGeometries =
+    geojson && geojson.features.filter(f => f.geometry.coordinates.length > 0).length;
 
   useEffect(() => {
     if (
       (!avgCompetitiveness ||
         (metric && "electionYear" in metric && electionYear !== metric.electionYear)) &&
-      numDistrictsWithPopulation &&
-      numDistrictsWithPopulation > 1
+      numDistrictsWithGeometries &&
+      numDistrictsWithGeometries > 1
     ) {
       const numDistrictsWithPvi =
         geojson &&
         geojson.features
-          .filter(f => f.id !== 0 && f.properties.demographics.population > 0)
+          .filter(f => f.id !== 0 && f.geometry.coordinates.length > 0)
           .filter(f => Object.keys(f.properties.voting || {}).length > 0).length;
 
       const competitiveness =
@@ -143,7 +143,7 @@ const ProjectEvaluateSidebar = ({
           );
       }
     }
-  }, [electionYear, geojson, metric, avgCompetitiveness, numDistrictsWithPopulation]);
+  }, [electionYear, geojson, metric, avgCompetitiveness, numDistrictsWithGeometries]);
 
   const multipleElections = hasMultipleElections(staticMetadata);
 
@@ -153,8 +153,8 @@ const ProjectEvaluateSidebar = ({
       name: "Equal Population",
       status:
         numEqualPopDistricts !== undefined &&
-        numDistrictsWithPopulation !== undefined &&
-        numEqualPopDistricts === numDistrictsWithPopulation,
+        numDistrictsWithGeometries !== undefined &&
+        numEqualPopDistricts === numDistrictsWithGeometries,
       description: "have equal population",
       shortText:
         "The U.S. constitution requires that each district have about the same population for a map to be considered valid.",

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -20,7 +20,7 @@ const CompetitivenessChart = ({
   const buckets: readonly (PviBucket | undefined)[] | undefined =
     geojson &&
     geojson?.features
-      .filter(f => f.id !== 0 && f.properties.demographics.population > 0)
+      .filter(f => f.id !== 0 && f.geometry.coordinates.length > 0)
       .map(f => {
         const pvi = f.properties.voting && calculatePVI(f.properties.voting, metric?.electionYear);
         const data: PviBucket | undefined = pvi !== undefined ? computeRowBucket(pvi) : undefined;

--- a/src/client/components/evaluate/detail/MajorityRace.tsx
+++ b/src/client/components/evaluate/detail/MajorityRace.tsx
@@ -110,7 +110,7 @@ const MajorityRaceMetricDetail = ({
                     <Tooltip
                       placement="top-start"
                       content={
-                        feature.properties.demographics.population > 0 ? (
+                        feature.properties.demographics.population !== 0 ? (
                           <DemographicsTooltip
                             demographics={feature.properties.demographics}
                             isMajorityMinority={isMajorityMinority(feature)}

--- a/src/client/components/map/DefaultSelectionTool.ts
+++ b/src/client/components/map/DefaultSelectionTool.ts
@@ -20,7 +20,7 @@ import {
   FeatureId,
   IStaticMetadata,
   LockedDistricts,
-  UintArrays
+  TypedArrays
 } from "../../../shared/entities";
 
 function areAllUnlockedChildGeoUnitsSelected(
@@ -28,7 +28,7 @@ function areAllUnlockedChildGeoUnitsSelected(
   unlockedGeoUnits: GeoUnits,
   geoUnitForFeature: GeoUnitIndices | undefined,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ): boolean {
   if (!geoUnitForFeature) {
     return false;
@@ -62,7 +62,7 @@ const DefaultSelectionTool: ISelectionTool = {
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
-    staticGeoLevels: UintArrays
+    staticGeoLevels: TypedArrays
   ) {
     /* eslint-disable */
     this.setCursor = () => (map.getCanvas().style.cursor = "pointer");

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -550,7 +550,7 @@ const DistrictsMap = ({
 
       // eslint-disable-next-line functional/immutable-data
       feature.properties.percentDeviation =
-        feature.properties.demographics.population > 0 && feature.id !== 0
+        feature.properties.demographics.population !== 0 && feature.id !== 0
           ? populationDeviation / avgPopulation
           : undefined;
       const electionYear =
@@ -566,10 +566,7 @@ const DistrictsMap = ({
 
       // eslint-disable-next-line
       feature.properties.populationDeviation = populationDeviation;
-      if (
-        feature.properties.demographics.population &&
-        feature.properties.demographics.population > 0
-      ) {
+      if (feature.properties.demographics.population !== 0) {
         // If specified, use first demographic group to determine which fields are "race" fields
         // If not specified, use set of fields allowed in tooltip / chart
         const coreGroup =

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../actions/districtDrawing";
 import { getDistrictColor } from "../../constants/colors";
 import {
-  UintArrays,
+  TypedArrays,
   GeoUnits,
   IProject,
   IStaticMetadata,
@@ -210,7 +210,7 @@ interface Props {
   readonly project: IProject;
   readonly geojson: DistrictsGeoJSON;
   readonly staticMetadata: IStaticMetadata;
-  readonly staticGeoLevels: UintArrays;
+  readonly staticGeoLevels: TypedArrays;
   readonly selectedGeounits: GeoUnits;
   readonly selectedDistrictId: number;
   readonly hoveredDistrictId: number | null;

--- a/src/client/components/map/MapTooltip.tsx
+++ b/src/client/components/map/MapTooltip.tsx
@@ -206,6 +206,7 @@ const MapTooltip = ({
         : data.voting && Object.keys(data.voting).length > 0
         ? data.voting
         : undefined;
+    const hasNegativePopulation = data.demographics.population < 0;
 
     return (
       <Box
@@ -239,6 +240,7 @@ const MapTooltip = ({
             }}
           >
             {Number(data.demographics.population).toLocaleString()}
+            {hasNegativePopulation && "*"}
           </Box>
         </Grid>
         <Divider sx={{ my: 1, borderColor: "gray.6" }} />
@@ -248,6 +250,12 @@ const MapTooltip = ({
             <React.Fragment>
               <Divider sx={{ my: 1, borderColor: "gray.6" }} />
               <VotingMapTooltip voting={voting} />
+            </React.Fragment>
+          )}
+          {hasNegativePopulation && (
+            <React.Fragment>
+              <Divider sx={{ my: 1, borderColor: "gray.6" }} />
+              <Box>* population reallocated</Box>
             </React.Fragment>
           )}
         </Box>

--- a/src/client/components/map/PaintBrushSelectionTool.ts
+++ b/src/client/components/map/PaintBrushSelectionTool.ts
@@ -6,7 +6,7 @@ import {
   GeoUnits,
   IStaticMetadata,
   LockedDistricts,
-  UintArrays
+  TypedArrays
 } from "../../../shared/entities";
 import booleanIntersects from "@turf/boolean-intersects";
 import distance from "@turf/distance";
@@ -43,7 +43,7 @@ const PaintBrushSelectionTool: ISelectionTool = {
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
-    staticGeoLevels: UintArrays,
+    staticGeoLevels: TypedArrays,
     paintBrushSize: PaintBrushSize,
     setActive: (isActive: boolean) => void,
     limitSelectionToCounty: boolean,

--- a/src/client/components/map/RectangleSelectionTool.ts
+++ b/src/client/components/map/RectangleSelectionTool.ts
@@ -7,7 +7,7 @@ import {
   GeoUnits,
   IStaticMetadata,
   LockedDistricts,
-  UintArrays
+  TypedArrays
 } from "../../../shared/entities";
 
 import {
@@ -49,7 +49,7 @@ const RectangleSelectionTool: ISelectionTool = {
     staticMetadata: IStaticMetadata,
     districtsDefinition: DistrictsDefinition,
     lockedDistricts: LockedDistricts,
-    staticGeoLevels: UintArrays,
+    staticGeoLevels: TypedArrays,
     setActive: (isActive: boolean) => void,
     limitSelectionToCounty: boolean
   ) {

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -13,7 +13,7 @@ import {
   MutableGeoUnits,
   IStaticMetadata,
   LockedDistricts,
-  UintArrays
+  TypedArrays
 } from "../../../shared/entities";
 import { getAllIndices } from "../../../shared/functions";
 import { isBaseGeoLevelAlwaysVisible, getTargetPopulation } from "../../functions";
@@ -713,7 +713,7 @@ export function deselectChildGeounits(
   map: MapboxGL.Map,
   geoUnits: GeoUnits,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ) {
   const isBaseLevelAlwaysVisible = isBaseGeoLevelAlwaysVisible(staticMetadata.geoLevelHierarchy);
 
@@ -797,7 +797,7 @@ export function featuresToGeoUnits(
 export function getChildGeoUnits(
   geoUnitIndices: GeoUnitIndices,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ) {
   const childGeoLevelIdx = staticMetadata.geoLevelHierarchy.length - geoUnitIndices.length - 1;
   const childGeoLevel = staticMetadata.geoLevelHierarchy[childGeoLevelIdx];
@@ -824,7 +824,7 @@ export function onlyUnlockedGeoUnits(
   lockedDistricts: LockedDistricts,
   geoUnits: GeoUnits,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ): GeoUnits {
   const unlockedGeoUnits = cloneDeep(geoUnits) as MutableGeoUnits;
   removeLockedGeoUnits(
@@ -845,7 +845,7 @@ export function removeLockedGeoUnits(
   lockedDistricts: LockedDistricts,
   geoUnits: MutableGeoUnits,
   staticMetadata: IStaticMetadata,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ) {
   Object.entries(geoUnits).forEach(([geoLevel, geoUnitsForLevel]) => {
     geoUnitsForLevel.forEach((geoUnitIndices, featureId) => {
@@ -884,7 +884,7 @@ export function featuresToUnlockedGeoUnits(
   staticMetadata: IStaticMetadata,
   districtsDefinition: DistrictsDefinition,
   lockedDistricts: LockedDistricts,
-  staticGeoLevels: UintArrays
+  staticGeoLevels: TypedArrays
 ): GeoUnits {
   return onlyUnlockedGeoUnits(
     districtsDefinition,

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -142,7 +142,7 @@ export function getPartyVoteShareDisplay(percent?: number): string {
 }
 
 export function computeDemographicSplit(demographic: number, total: number): string | undefined {
-  const percent = total > 0 ? (demographic / total) * 100 : undefined;
+  const percent = total !== 0 ? Math.abs(demographic / total) * 100 : undefined;
   return percent ? percent.toLocaleString(undefined, { maximumFractionDigits: 0 }) : "0";
 }
 

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -13,7 +13,7 @@ import {
   IStaticMetadata,
   RegionLookupProperties,
   IUser,
-  UintArrays,
+  TypedArrays,
   IReferenceLayer
 } from "../../shared/entities";
 import { ElectionYear, EvaluateMetricWithValue } from "../types";
@@ -52,7 +52,7 @@ interface StateProps {
   readonly project?: IProject;
   readonly geojson?: DistrictsGeoJSON;
   readonly staticMetadata?: IStaticMetadata;
-  readonly staticGeoLevels: UintArrays;
+  readonly staticGeoLevels: TypedArrays;
   readonly projectNotFound?: boolean;
   readonly findMenuOpen: boolean;
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -3,7 +3,7 @@ import * as H from "history";
 import {
   IProject,
   IStaticMetadata,
-  UintArrays,
+  TypedArrays,
   GeoUnitHierarchy,
   DistrictProperties,
   DemographicCounts,
@@ -27,13 +27,13 @@ export interface PaginatedResponse<T> {
 
 export interface StaticProjectData {
   readonly staticMetadata: IStaticMetadata;
-  readonly staticGeoLevels: UintArrays;
+  readonly staticGeoLevels: TypedArrays;
   readonly geoUnitHierarchy: GeoUnitHierarchy;
 }
 
 export interface WorkerProjectData {
-  readonly staticDemographics: UintArrays;
-  readonly staticVotingData?: UintArrays;
+  readonly staticDemographics: TypedArrays;
+  readonly staticVotingData?: TypedArrays;
   readonly geoUnitHierarchy: GeoUnitHierarchy;
 }
 

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -886,11 +886,11 @@ export function abbreviateNumber(value: number) {
   let shortValue = value.toPrecision(1);
   let suffixNum = 0;
 
-  if (value >= 10) {
-    suffixNum = Math.floor(Math.log10(value) / 3);
+  if (Math.abs(value) >= 10) {
+    suffixNum = Math.floor(Math.log10(Math.abs(value)) / 3);
     const abbrevNum = value / Math.pow(1000, suffixNum);
 
-    if (Math.log10(abbrevNum) >= 2) {
+    if (Math.log10(Math.abs(abbrevNum)) >= 2) {
       shortValue = abbrevNum.toPrecision(3);
     } else {
       shortValue = abbrevNum.toPrecision(2);

--- a/src/manage/src/test/process-geojson.spec.ts
+++ b/src/manage/src/test/process-geojson.spec.ts
@@ -30,4 +30,33 @@ describe("process geojson", () => {
     expect(abbreviateNumber(999500000000)).toEqual("1t");
     expect(abbreviateNumber(1000000000000)).toEqual("1t");
   });
+
+  it("should abbreviate negative numbers numbers", () => {
+    expect(abbreviateNumber(-5)).toEqual("-5");
+    expect(abbreviateNumber(-10)).toEqual("-10");
+    expect(abbreviateNumber(-99)).toEqual("-99");
+    expect(abbreviateNumber(-100)).toEqual("-100");
+    expect(abbreviateNumber(-999)).toEqual("-999");
+    expect(abbreviateNumber(-1000)).toEqual("-1k");
+    expect(abbreviateNumber(-1500)).toEqual("-1.5k");
+    expect(abbreviateNumber(-9000)).toEqual("-9k");
+    expect(abbreviateNumber(-9500)).toEqual("-9.5k");
+    expect(abbreviateNumber(-9950)).toEqual("-9.9k");
+    expect(abbreviateNumber(-9999)).toEqual("-10k");
+    expect(abbreviateNumber(-99499)).toEqual("-99k");
+    expect(abbreviateNumber(-99500)).toEqual("-100k");
+    expect(abbreviateNumber(-100000)).toEqual("-100k");
+    expect(abbreviateNumber(-110000)).toEqual("-110k");
+    expect(abbreviateNumber(-150000)).toEqual("-150k");
+    expect(abbreviateNumber(-999499)).toEqual("-999k");
+    expect(abbreviateNumber(-999500)).toEqual("-1m");
+    expect(abbreviateNumber(-1000000)).toEqual("-1m");
+    expect(abbreviateNumber(-1500000)).toEqual("-1.5m");
+    expect(abbreviateNumber(-999499999)).toEqual("-999m");
+    expect(abbreviateNumber(-999500000)).toEqual("-1b");
+    expect(abbreviateNumber(-1000000000)).toEqual("-1b");
+    expect(abbreviateNumber(-999499999999)).toEqual("-999b");
+    expect(abbreviateNumber(-999500000000)).toEqual("-1t");
+    expect(abbreviateNumber(-1000000000000)).toEqual("-1t");
+  });
 });

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -19,7 +19,7 @@ import {
   GeoUnitDefinition,
   HierarchyDefinition,
   IStaticMetadata,
-  UintArrays,
+  TypedArrays,
   DistrictsDefinition,
   GeoUnitHierarchy
 } from "../../../../shared/entities";
@@ -187,9 +187,9 @@ export class GeoUnitTopology {
     public readonly topology: Topology,
     public readonly definition: GeoUnitDefinition,
     public readonly staticMetadata: IStaticMetadata,
-    public readonly demographics: UintArrays,
-    public readonly voting: UintArrays,
-    public readonly geoLevels: UintArrays
+    public readonly demographics: TypedArrays,
+    public readonly voting: TypedArrays,
+    public readonly geoLevels: TypedArrays
   ) {
     this.hierarchy = group(topology, definition);
   }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -99,6 +99,7 @@ export interface IStaticFile {
   readonly id: string;
   readonly fileName: string;
   readonly bytesPerElement: number;
+  readonly unsigned?: boolean;
 }
 
 export interface GeoLevelInfo {
@@ -304,7 +305,9 @@ export type DistrictId = number;
 export type LockedDistricts = readonly boolean[];
 
 export type UintArray = Uint8Array | Uint16Array | Uint32Array;
-export type UintArrays = ReadonlyArray<UintArray>;
+export type IntArray = Int8Array | Int16Array | Int32Array;
+export type TypedArray = UintArray | IntArray;
+export type TypedArrays = ReadonlyArray<TypedArray>;
 export type RegionLookupProperties = Record<string, unknown>;
 
 export type DistrictImportField = "" | "BLOCKID" | "DISTRICT";

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -1,5 +1,5 @@
 import {
-  UintArray,
+  TypedArray,
   DemographicCounts,
   IStaticMetadata,
   IStaticFile,
@@ -12,7 +12,7 @@ import { CORE_METRIC_FIELDS, DEMOGRAPHIC_FIELDS_ORDER } from "./constants";
 // Helper for finding all indices in an array buffer matching a value.
 // Note: mutation is used, because the union type of array buffers proved
 // too difficult to line up types for reduce or map/filter.
-export function getAllIndices(arrayBuf: UintArray, vals: ReadonlySet<number>): readonly number[] {
+export function getAllIndices(arrayBuf: TypedArray, vals: ReadonlySet<number>): readonly number[] {
   // eslint-disable-next-line
   let indices: number[] = [];
   arrayBuf.forEach((el: number, ind: number) => {
@@ -27,7 +27,7 @@ export function getAllIndices(arrayBuf: UintArray, vals: ReadonlySet<number>): r
 
 // Recursively finds all base indices matching a set of values at a specified level
 export function getAllBaseIndices(
-  descGeoLevels: readonly UintArray[],
+  descGeoLevels: readonly TypedArray[],
   levelIndex: number,
   vals: readonly number[]
 ): readonly number[] {
@@ -45,7 +45,7 @@ export function getAllBaseIndices(
 export function getDemographics(
   baseIndices: readonly number[] | ReadonlySet<number>,
   staticMetadata: IStaticMetadata,
-  staticDemographics: readonly UintArray[]
+  staticDemographics: readonly TypedArray[]
 ): DemographicCounts {
   return getAggregatedCounts(
     baseIndices,
@@ -58,7 +58,7 @@ export function getDemographics(
 export function getVoting(
   baseIndices: readonly number[] | ReadonlySet<number>,
   staticMetadata: IStaticMetadata,
-  staticVoting: readonly UintArray[]
+  staticVoting: readonly TypedArray[]
 ): DemographicCounts {
   return staticMetadata.voting
     ? getAggregatedCounts(baseIndices, staticMetadata, staticVoting, staticMetadata.voting)
@@ -68,7 +68,7 @@ export function getVoting(
 export function getAggregatedCounts(
   baseIndices: readonly number[] | ReadonlySet<number>,
   staticMetadata: IStaticMetadata,
-  staticFiles: readonly UintArray[],
+  staticFiles: readonly TypedArray[],
   fileProperties: readonly IStaticFile[]
 ): DemographicCounts {
   // Aggregate numeric data for the IDs


### PR DESCRIPTION
## Overview

Due to prisoner population reallocation, some of the blocks near prisons in the latest updates from several states have populations different from the census provided population values, sometimes including _negative_ population values.

We needed to make a few updates to the application to support this:
 - We were always storing data in typed array buffers as unsigned integers - now they can be signed as well
 - Percentages calculated using `population` always had the possibility of not adding up to 100%, but now they can do truly bizarre things like exceed 100% (as demographic data other than total population has not been adjusted)

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
Tooltip / sidebar for block / district w/ neg. population:
![image](https://user-images.githubusercontent.com/4432106/137502125-e6cb274c-5bac-4a33-9e60-4d1391d7af9c.png)
Expanded sidebar:
![image](https://user-images.githubusercontent.com/4432106/137502701-3385c97c-268e-4ee1-aeff-a465520e1e4f.png)
Evaluate mode:
![image](https://user-images.githubusercontent.com/4432106/137502922-e20221bc-2798-457c-ac34-13bd12aefa0a.png)


### Notes

 - It's debatable what exactly to show for a percentage value when population is negative - after discussion w/ @jfrankl we decided on calculating percent as `Math.abs(demographic / population) * 100`.

 - It ended up not being necessary for this PR, but I included an refactor to `process-geojson` to include the new `demographicsGroups` option in https://github.com/PublicMapping/districtbuilder/commit/54e70863834bfa088dc4633eada2b06aea238915

## Testing Instructions
- Process the latest `VA` adjusted population data:
  - `./scripts/manage process-geojson data/all_geojsons/va_adj_1620.geojson -o data/output/Virginia_adjusted -n 12,4,4 -x 12,12,12  -v "voterep16:republican16,votedem16:democrat16,voteoth16:other party16" -d "population,white,black,asian,hispanic,native,pacific"`
  - `./scripts/manage publish-region data/output/Virginia_adjusted US VA "Virginia"`

- Create a map for VA, and find a block w/ negative population. I added a reference layer w/ VA prisons which was helpful in this regard (the screenshots above are near Powhatan Correctional Center): [Virginia_Prison_Facilities.zip](https://github.com/PublicMapping/districtbuilder/files/7354117/Virginia_Prison_Facilities.zip)
- Turn on the population labels using the dropdown in the upper-right. The values should display as negative numbers.
- Add a block w/ negative population to an otherwise empty district, so the district contains just that 1 block & has negative population.
   - The values in the sidebar should display as negative numbers, both before & after saving your changes.
   - Percents in the expanded metrics viewer should match the map tooltip.
   - The evaluate mode should show the district as having "population" even when it is negative.

Closes #995 
