### PR TITLE
Calculate population to be added correctly

### DIFF
--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -670,7 +670,7 @@ const SidebarRow = memo(
                     <div>
                       Add{" "}
                       {Math.floor(
-                        Math.abs(intermediateDeviation) + popDeviationThreshold
+                        Math.abs(intermediateDeviation) - popDeviationThreshold
                       ).toLocaleString()}{" "}
                       people to this district to meet the {popDeviation}% population deviation
                       tolerance


### PR DESCRIPTION
## Overview

The tooltip in the deviation column was incorrectly calculating the population that needed to be added to a district that was below the population deviation threshold. Instead of subtracting the current deviation from the maximum allowable deviation, it was being added,resulting in instructions to add very large population numbers in order to hit the target being displayed in the hover tooltip.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screenshot from 2021-10-28 14-57-16](https://user-images.githubusercontent.com/447977/139319339-24009be6-6767-4e8a-bd81-829c32a11776.png)

## Testing Instructions

- Create a new project with a population deviation other than 0. All the districts will have 0 population.
- Mouse over one of the districts and (probably using a calculator) confirm that the instructions are correct, i.e. that adding the number of people it suggests will result in a district population that meets the acceptable percentage deviation (on the low end).

Closes #1051 
