### PR TITLE
Add support for multi member districts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add support for creating/importing projects with multi-member districts [#1060](https://github.com/PublicMapping/districtbuilder/pull/1060) 
 ### Changed
 ### Fixed
 

--- a/scripts/load-dev-data
+++ b/scripts/load-dev-data
@@ -95,6 +95,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 FALSE,
                 FALSE,
                 '2020'
+             ), (
+                '893a9538-3f14-4225-9c91-d54ba818ab0d',
+                'New Jersey',
+                'US',
+                'NJ',
+                's3://global-districtbuilder-dev-us-east-1/regions/US/NJ/2021-10-26T01:42:56.227Z/',
+                '2021-10-26 01:42:56.227',
+                DEFAULT,
+                DEFAULT,
+                '2020'
              )
               ON CONFLICT DO NOTHING;
             "
@@ -107,13 +117,22 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 'e7f5999f-88d9-4c58-ab85-f65eae843ea1',
                 'House of Representatives',
                  18,
-                '6c440b8d-c26e-4bae-850f-dbff37fe0209'
+                '6c440b8d-c26e-4bae-850f-dbff37fe0209',
+                NULL
               ),
               (
                 '2202e945-161b-4f84-a282-5d65c7ba16b7',
                 'House of Representatives',
                  18,
-                '96bca832-99b3-4c4d-8913-ab4ca82ec442'
+                '96bca832-99b3-4c4d-8913-ab4ca82ec442',
+                NULL
+              ),
+              (
+                'ac0b99f1-baf9-4ee0-9f19-a6228ca61ab3',
+                'General Assembly',
+                 40,
+                '893a9538-3f14-4225-9c91-d54ba818ab0d',
+                ARRAY[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
               )
               ON CONFLICT DO NOTHING;
             "

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -240,11 +240,12 @@ export async function fetchRegionConfigs(): Promise<IRegionConfig> {
 
 export async function fetchRegionProperties(
   region: RegionConfigId,
-  geoLevel: string
+  geoLevel: string,
+  fields: readonly string[]
 ): Promise<readonly Record<string, unknown>[]> {
   return new Promise((resolve, reject) => {
     apiAxios
-      .get(`/api/region-configs/${region}/properties/${geoLevel}?fields=name`)
+      .get(`/api/region-configs/${region}/properties/${geoLevel}?fields=${fields.join("&fields=")}`)
       .then(response => {
         resolve(response.data);
       })

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -29,6 +29,7 @@ import {
   ReferenceLayerWithGeojson
 } from "./types";
 import { getJWT, setJWT } from "./jwt";
+import { fetchStaticMetadata } from "./s3";
 
 const apiAxios = axios.create();
 
@@ -486,4 +487,12 @@ export async function removeUserFromOrganization(
         reject(error.message);
       });
   });
+}
+
+// Retrieves total population for the region by fetching metadata & querying topojson properties
+export async function fetchTotalPopulation(region: IRegionConfig) {
+  const staticMetadata = await fetchStaticMetadata(region.s3URI);
+  const topLevel = staticMetadata.geoLevels[staticMetadata.geoLevels.length - 1].id;
+  const records = await fetchRegionProperties(region.id, topLevel, ["population"]);
+  return records.reduce((total, record) => total + Number(record["population"]), 0);
 }

--- a/src/client/components/MultiMemberForm.tsx
+++ b/src/client/components/MultiMemberForm.tsx
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { jsx, Styled, Input } from "theme-ui";
+
+interface Props {
+  readonly totalPopulation: number;
+  readonly numberOfMembers: readonly number[];
+  // eslint-disable-next-line functional/no-mixed-type
+  readonly onChange: (numberOfMembers: readonly number[]) => void;
+}
+
+const MultiMemberForm = ({ totalPopulation, numberOfMembers, onChange }: Props) => {
+  const totalReps = numberOfMembers.reduce((total, numberOfReps) => total + numberOfReps, 0);
+  const popPerRep = Math.floor(totalPopulation / totalReps);
+  return (
+    <Styled.table sx={{ margin: "0", width: "100%" }}>
+      <thead>
+        <tr>
+          <td>Districts</td>
+          <td>Number of reps</td>
+          <td sx={{ textAlign: "right" }}>Target population</td>
+        </tr>
+      </thead>
+      <tbody>
+        {numberOfMembers.map((numberOfReps, i) => (
+          <tr key={i}>
+            <td>{i + 1}</td>
+            <td>
+              <Input
+                sx={{ maxWidth: "200px" }}
+                value={numberOfReps}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const val = Number(e.target.value);
+                  onChange([...numberOfMembers.slice(0, i), val, ...numberOfMembers.slice(i + 1)]);
+                }}
+              ></Input>
+            </td>
+            <td sx={{ textAlign: "right" }}>{Number(numberOfReps * popPerRep).toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Styled.table>
+  );
+};
+
+export default MultiMemberForm;

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -620,6 +620,11 @@ const SidebarRow = memo(
         </Styled.td>
       );
 
+    const meetsThreshold =
+      districtId !== 0 ? absoluteDeviation <= popDeviationThreshold : absoluteDeviation === 0;
+    const aboveThreshold = intermediateDeviation < 0;
+    const belowThreshold = intermediateDeviation > 0;
+
     return (
       <Styled.tr
         sx={{ bg: selected ? selectedDistrictColor : "inherit", cursor: "pointer" }}
@@ -662,11 +667,11 @@ const SidebarRow = memo(
               placement="top-start"
               content={
                 districtId !== 0 ? (
-                  Math.abs(intermediateDeviation) <= popDeviationThreshold ? (
+                  meetsThreshold ? (
                     <div>
                       This district meets the {popDeviation}% population deviation tolerance
                     </div>
-                  ) : intermediateDeviation < 0 ? (
+                  ) : aboveThreshold ? (
                     <div>
                       Add{" "}
                       {Math.floor(
@@ -683,7 +688,7 @@ const SidebarRow = memo(
                       tolerance
                     </div>
                   )
-                ) : intermediateDeviation > 0 ? (
+                ) : belowThreshold ? (
                   <div>
                     This population is not assigned to any district. Make sure all population is
                     assigned to a district to complete your map.
@@ -696,10 +701,9 @@ const SidebarRow = memo(
               <span>
                 <span>{deviationDisplay}</span>
                 <span sx={style.deviationIcon}>
-                  {(districtId === 0 && absoluteDeviation === 0) ||
-                  (districtId !== 0 && absoluteDeviation <= popDeviationThreshold) ? (
+                  {meetsThreshold ? (
                     <Icon name="circle-check-solid" color="#388a64" />
-                  ) : intermediateDeviation < 0 ? (
+                  ) : aboveThreshold ? (
                     <Icon name="arrow-circle-down-solid" color="gray.4" />
                   ) : (
                     <Icon name="arrow-circle-up-solid" color="#000000" />

--- a/src/client/components/ProjectSidebar.tsx
+++ b/src/client/components/ProjectSidebar.tsx
@@ -33,7 +33,6 @@ import {
 import {
   areAnyGeoUnitsSelected,
   assertNever,
-  getTargetPopulation,
   mergeGeoUnits,
   hasMultipleElections,
   calculatePartyVoteShare,
@@ -42,7 +41,8 @@ import {
   has20Election,
   isMajorityMinority,
   getMajorityRaceDisplay,
-  capitalizeFirstLetter
+  capitalizeFirstLetter,
+  getPopulationPerRepresentative
 } from "../functions";
 import store from "../store";
 import { DistrictGeoJSON, DistrictsGeoJSON, SavingState } from "../types";
@@ -906,7 +906,7 @@ const SidebarRows = ({
     };
   }, [project, staticMetadata, selectedGeounits, highlightedGeounits]);
 
-  const averagePopulation = getTargetPopulation(geojson);
+  const popPerRep = getPopulationPerRepresentative(geojson, project.numberOfMembers);
   const demographicsMetricFields = getDemographicsMetricFields(staticMetadata);
   const electionsMetricFields = getVotingMetricFields(staticMetadata);
 
@@ -923,6 +923,9 @@ const SidebarRows = ({
             : selectedPopulation !== undefined
             ? -1 * selectedPopulation
             : undefined;
+        const numberOfReps = project.numberOfMembers[districtId - 1] || 0;
+        const popDeviationThreshold =
+          (project.populationDeviation / 100) * popPerRep * numberOfReps;
 
         return feature.properties.populationDeviation !== undefined ? (
           <SidebarRow
@@ -943,7 +946,7 @@ const SidebarRows = ({
             districtId={districtId}
             isReadOnly={isReadOnly}
             popDeviation={project.populationDeviation}
-            popDeviationThreshold={averagePopulation * (project.populationDeviation / 100)}
+            popDeviationThreshold={popDeviationThreshold}
           />
         ) : null;
       })}

--- a/src/client/components/Tour.tsx
+++ b/src/client/components/Tour.tsx
@@ -4,7 +4,7 @@ import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
 import { jsx } from "theme-ui";
 import { IProject, IStaticMetadata, IUser } from "../../shared/entities";
 import { patchUser } from "../api";
-import { geoLevelLabel, getTargetPopulation } from "../functions";
+import { geoLevelLabel, getPopulationPerRepresentative } from "../functions";
 import { ReactComponent as SalamanderIllustration } from "../media/tour-salamander-builder.svg";
 import { DistrictsGeoJSON } from "../types";
 import { Styled } from "theme-ui";
@@ -27,7 +27,9 @@ class Tour extends Component<Props, State> {
     super(props);
 
     const numberOfDistricts = props.project.numberOfDistricts;
-    const population = Math.round(getTargetPopulation(props.geojson)).toLocaleString();
+    const population = Math.round(
+      getPopulationPerRepresentative(props.geojson, props.project.numberOfMembers)
+    ).toLocaleString();
     const regionConfig = props.project.regionConfig.name;
     const geoLevelsSingular = props.staticMetadata.geoLevelHierarchy
       .map(geolevel => geolevel.id)
@@ -108,8 +110,8 @@ class Tour extends Component<Props, State> {
             <p>
               Your objective: build <strong>{numberOfDistricts} districts</strong> for{" "}
               <strong>{regionConfig}, </strong>
-              each with a population of <strong>{population}.</strong> Use DistrictBuilder to group{" "}
-              {availableGeolevelsText} into districts.
+              each with a population of <strong>{population}</strong> per representative. Use
+              DistrictBuilder to group {availableGeolevelsText} into districts.
             </p>
           ),
           disableBeacon: true,

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -44,34 +44,28 @@ const ProjectEvaluateSidebar = ({
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
-  const [avgCompactness, setAvgCompactness] = useState<number | undefined>(undefined);
-  const [avgPopulation, setAvgPopulation] = useState<number | undefined>(undefined);
-  const [geoLevel, setGeoLevel] = useState<string | undefined>(undefined);
   const [electionYear, setEvaluateElectionYear] = useState<ElectionYear>("combined");
   const [avgCompetitiveness, setAvgCompetitiveness] = useState<number | undefined>(undefined);
   const [party, setParty] = useState<Party | undefined>(undefined);
   const popThreshold = project && project.populationDeviation;
-  useEffect(() => {
-    if (geojson && !avgCompactness) {
-      const features = geojson.features.slice(1).filter(f => f.properties.compactness !== 0);
-      const totalCompactness = features.reduce(function(accumulator, feature) {
-        return accumulator + feature.properties.compactness;
-      }, 0);
-      setAvgCompactness(features.length !== 0 ? totalCompactness / features.length : undefined);
-    }
-  }, [geojson, avgCompactness]);
 
-  useEffect(() => {
-    if (geojson && !avgPopulation) {
-      setAvgPopulation(getTargetPopulation(geojson));
-    }
-  }, [geojson, avgPopulation]);
+  const featuresWithCompactness = geojson?.features
+    .slice(1)
+    .filter(f => f.properties.compactness !== 0);
+  const totalCompactness = featuresWithCompactness?.reduce(function(accumulator, feature) {
+    return accumulator + feature.properties.compactness;
+  }, 0);
+  const avgCompactness =
+    totalCompactness !== undefined &&
+    featuresWithCompactness &&
+    featuresWithCompactness.length !== 0
+      ? totalCompactness / featuresWithCompactness.length
+      : undefined;
 
-  useEffect(() => {
-    if (staticMetadata) {
-      setGeoLevel(staticMetadata.geoLevelHierarchy[staticMetadata.geoLevelHierarchy.length - 1].id);
-    }
-  }, [staticMetadata]);
+  const avgPopulation = geojson && getTargetPopulation(geojson);
+
+  const geoLevel =
+    staticMetadata?.geoLevelHierarchy[staticMetadata.geoLevelHierarchy.length - 1].id;
 
   useEffect(() => {
     if (project && project.regionConfig.regionCode && geoLevel) {

--- a/src/client/components/evaluate/detail/EqualPopulation.tsx
+++ b/src/client/components/evaluate/detail/EqualPopulation.tsx
@@ -67,23 +67,28 @@ const EqualPopulationMetricDetail = ({
 }) => {
   const choroplethStops =
     metric.popThreshold && metric.avgPopulation
-      ? getEqualPopulationStops(metric.popThreshold, metric.avgPopulation)
+      ? getEqualPopulationStops(metric.popThreshold)
       : undefined;
+  const numberOfMembers = metric.numberOfMembers;
 
   return (
     <Box>
       <Heading as="h2" sx={{ variant: "text.h5", mt: 4 }}>
-        {metric.value?.toString() || " "} of {metric.total} districts are within{" "}
+        {metric.value?.toString() || " "} of {metric.total} districts within{" "}
         {"popThreshold" in metric &&
           metric.popThreshold !== undefined &&
           ` ${Math.floor(metric.popThreshold)}%`}{" "}
-        of the target ({metric.avgPopulation && Math.floor(metric.avgPopulation).toLocaleString()})
+        of the target (
+        {metric.populationPerRepresentative &&
+          Math.floor(metric.populationPerRepresentative).toLocaleString()}
+        &nbsp;/&nbsp;Rep.)
       </Heading>
       <Styled.table sx={style.table}>
         <thead>
           <Styled.tr>
             <Styled.th sx={{ ...style.th, ...style.colFirst }}>Number</Styled.th>
             <Styled.th sx={style.th}>Deviation (%)</Styled.th>
+            <Styled.th sx={{ ...style.th, ...style.number }}>Number of reps</Styled.th>
             <Styled.th sx={{ ...style.th, ...style.number, ...style.colLast }}>Deviation</Styled.th>
           </Styled.tr>
         </thead>
@@ -108,13 +113,21 @@ const EqualPopulationMetricDetail = ({
                               choroplethStops &&
                               computeRowFill(
                                 choroplethStops,
-                                feature.properties.populationDeviation,
+                                feature.properties.percentDeviation,
                                 true
                               )
                           }}
                         ></Styled.div>
                         <Box>{Math.floor(feature.properties.percentDeviation * 1000) / 10}%</Box>
                       </Flex>
+                    ) : (
+                      <Box sx={style.blankValue}>-</Box>
+                    )}
+                  </Styled.td>
+
+                  <Styled.td sx={{ ...style.td, ...style.number }}>
+                    {numberOfMembers !== undefined && numberOfMembers[id - 1] ? (
+                      numberOfMembers[id - 1]
                     ) : (
                       <Box sx={style.blankValue}>-</Box>
                     )}

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -16,7 +16,7 @@ import {
   TypedArrays
 } from "../../../shared/entities";
 import { getAllIndices } from "../../../shared/functions";
-import { isBaseGeoLevelAlwaysVisible, getTargetPopulation } from "../../functions";
+import { isBaseGeoLevelAlwaysVisible } from "../../functions";
 import { mapValues } from "lodash";
 import { ChoroplethSteps, PviBucket, DistrictsGeoJSON } from "../../types";
 
@@ -138,20 +138,16 @@ export function getPviBuckets(): readonly PviBucket[] {
   ];
 }
 
-export function getEqualPopulationStops(
-  popThresholdNum: number,
-  avgPopulation: number
-): ChoroplethSteps {
+export function getEqualPopulationStops(popThresholdNum: number): ChoroplethSteps {
   const popThreshold = popThresholdNum / 100;
-  const isAvgFractional = avgPopulation % 1 !== 0;
   return [
-    [-1.0 * avgPopulation, "#c1e5f0"],
-    [-1 * (popThreshold + 0.02) * avgPopulation, "#66a9cf"],
-    [-1 * (popThreshold + 0.01) * avgPopulation, "#2166ac"],
-    [-1 * popThreshold * avgPopulation - (isAvgFractional ? 1 : 0.1), "#01665e"],
-    [popThreshold === 0 ? (isAvgFractional ? 1 : 0.1) : popThreshold * avgPopulation, "#efbe60"],
-    [(popThreshold + 0.01) * avgPopulation, "#f5d092"],
-    [(popThreshold + 0.02) * avgPopulation, "#f7e1c3"]
+    [-1.0, "#c1e5f0"],
+    [-1 * (popThreshold + 0.02), "#66a9cf"],
+    [-1 * (popThreshold + 0.01), "#2166ac"],
+    [popThreshold === 0 ? -1 * Number.MIN_VALUE : -1 * popThreshold, "#01665e"],
+    [popThreshold === 0 ? Number.MIN_VALUE : popThreshold, "#efbe60"],
+    [popThreshold + 0.01, "#f5d092"],
+    [popThreshold + 0.02, "#f7e1c3"]
   ];
 }
 
@@ -321,7 +317,6 @@ export function generateMapLayers(
     DISTRICTS_PLACEHOLDER_LAYER_ID
   );
 
-  const avgPopulation = getTargetPopulation(geojson);
   map.addLayer(
     // @ts-ignore
     {
@@ -332,9 +327,9 @@ export function generateMapLayers(
       filter: ["match", ["get", "color"], ["transparent"], false, true],
       paint: {
         "fill-color": {
-          property: "populationDeviation",
+          property: "percentDeviation",
           type: "interval",
-          stops: getEqualPopulationStops(populationDeviation, avgPopulation)
+          stops: getEqualPopulationStops(populationDeviation)
         },
         "fill-outline-color": "gray",
         "fill-opacity": 0.9

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -296,17 +296,16 @@ export function assignGeounitsToDistrict(
   }, districtsDefinitionCopy);
 }
 
-// The target population is based on the average population of all districts,
-// not including the unassigned district, so we use the number of districts,
-// rather than the district feature count (which includes the unassigned district)
-export function getTargetPopulation(geojson: DistrictsGeoJSON) {
-  return (
-    geojson.features.reduce(
-      (population, feature) => population + feature.properties.demographics.population,
-      0
-    ) /
-    (geojson.features.length - 1)
+export function getPopulationPerRepresentative(
+  geojson: DistrictsGeoJSON,
+  numberOfMembers: readonly number[]
+) {
+  const totalPopulation = geojson.features.reduce(
+    (total, feature) => total + feature.properties.demographics.population,
+    0
   );
+  const totalReps = numberOfMembers.reduce((total, numberOfReps) => total + numberOfReps, 0);
+  return totalPopulation / totalReps;
 }
 
 /*

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -1,5 +1,8 @@
-import { toast } from "react-toastify";
+import { isThisYear, isToday } from "date-fns";
+import format from "date-fns/format";
+import { FeatureCollection, Feature, Point } from "geojson";
 import { cloneDeep, mapKeys, pickBy } from "lodash";
+import { toast } from "react-toastify";
 
 import {
   DemographicCounts,
@@ -13,6 +16,8 @@ import {
   IStaticMetadata,
   ReferenceLayerProperties
 } from "../shared/entities";
+
+import { Resource } from "./resource";
 import {
   ChoroplethSteps,
   DistrictGeoJSON,
@@ -21,11 +26,6 @@ import {
   DistrictsGeoJSON,
   ReferenceLayerGeojson
 } from "./types";
-
-import { Resource } from "./resource";
-import { isThisYear, isToday } from "date-fns";
-import { FeatureCollection, Feature, Point } from "geojson";
-import format from "date-fns/format";
 
 export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
   return Object.values(geoUnits).some(geoUnitsForLevel => geoUnitsForLevel.size);
@@ -411,3 +411,17 @@ export const convertCsvToGeojson = (csv: ParseResults): ReferenceLayerGeojson =>
   }
   return geojson;
 };
+
+// Extends/shrinks the number of members array to match the provided number of districts
+export function updateNumberOfMembers(
+  numberOfDistricts: number | null,
+  numberOfMembers: readonly number[] | null
+): readonly number[] | null {
+  return numberOfDistricts === null
+    ? null
+    : numberOfMembers !== null
+    ? numberOfMembers.length > numberOfDistricts
+      ? numberOfMembers.slice(0, numberOfDistricts)
+      : numberOfMembers.concat(new Array(numberOfDistricts - numberOfMembers.length).fill(1))
+    : (new Array(numberOfDistricts).fill(1) as readonly number[]);
+}

--- a/src/client/reducers/regionConfig.ts
+++ b/src/client/reducers/regionConfig.ts
@@ -70,7 +70,7 @@ const regionConfigReducer: LoopReducer<RegionConfigState, Action> = (
         Cmd.run(fetchRegionProperties, {
           successActionCreator: regionPropertiesFetchSuccess,
           failActionCreator: regionPropertiesFetchFailure,
-          args: [action.payload.regionConfigId, action.payload.geoLevel] as Parameters<
+          args: [action.payload.regionConfigId, action.payload.geoLevel, ["name"]] as Parameters<
             typeof fetchRegionProperties
           >
         })

--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -22,7 +22,7 @@ function staticDataUri(path: S3URI, fileName: string): HttpsURI {
   return resolve(s3ToHttps(path), fileName);
 }
 
-async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata> {
+export async function fetchStaticMetadata(path: S3URI): Promise<IStaticMetadata> {
   return new Promise((resolve, reject) => {
     s3Axios
       .get(staticDataUri(path, "static-metadata.json"))

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -1,35 +1,46 @@
 /** @jsx jsx */
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { Redirect, useHistory } from "react-router-dom";
-import { userFetch } from "../actions/user";
-import { DEFAULT_POPULATION_DEVIATION } from "../../shared/constants";
+import { Link, Redirect, useHistory } from "react-router-dom";
 import {
   Box,
   Button,
   Card,
+  Checkbox,
+  Divider,
   Flex,
   Heading,
   jsx,
   Label,
   Radio,
-  ThemeUIStyleObject,
-  Styled
+  Styled,
+  ThemeUIStyleObject
 } from "theme-ui";
-import { Link } from "react-router-dom";
-import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
 
-import { IProject, IRegionConfig, IChamber, CreateProjectData } from "../../shared/entities";
+import { DEFAULT_POPULATION_DEVIATION } from "../../shared/constants";
+import { CreateProjectData, IChamber, IProject, IRegionConfig } from "../../shared/entities";
+
 import { regionConfigsFetch } from "../actions/regionConfig";
-import { createProject } from "../api";
+import { userFetch } from "../actions/user";
+import { createProject, fetchRegionProperties } from "../api";
 import { InputField, SelectField } from "../components/Field";
 import FormError from "../components/FormError";
-import { State } from "../reducers";
-import { UserState } from "../reducers/user";
-import { WriteResource, Resource } from "../resource";
-import store from "../store";
-import { OrganizationState } from "../reducers/organization";
+import MultiMemberForm from "../components/MultiMemberForm";
 import OrganizationTemplateForm from "../components/OrganizationTemplateForm";
+import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
+import { State } from "../reducers";
+import { OrganizationState } from "../reducers/organization";
+import { UserState } from "../reducers/user";
+import { Resource, WriteResource } from "../resource";
+import { fetchStaticMetadata } from "../s3";
+import store from "../store";
+
+async function fetchTotalPopulation(region: IRegionConfig) {
+  const staticMetadata = await fetchStaticMetadata(region.s3URI);
+  const topLevel = staticMetadata.geoLevels[staticMetadata.geoLevels.length - 1].id;
+  const records = await fetchRegionProperties(region.id, topLevel, ["population"]);
+  return records.reduce((total, record) => total + Number(record["population"]), 0);
+}
 
 interface StateProps {
   readonly regionConfigs: Resource<readonly IRegionConfig[]>;
@@ -38,7 +49,10 @@ interface StateProps {
 }
 
 const validate = (form: ProjectForm) =>
-  form.name.trim() !== "" && form.numberOfDistricts !== null && form.regionConfig !== null
+  form.name.trim() !== "" &&
+  form.numberOfDistricts !== null &&
+  form.numberOfMembers !== null &&
+  form.regionConfig !== null
     ? ({ ...form, valid: true } as ValidForm)
     : ({ ...form, valid: false } as InvalidForm);
 
@@ -48,6 +62,8 @@ interface ProjectForm {
   readonly regionConfig: IRegionConfig | null;
   readonly numberOfDistricts: number | null;
   readonly populationDeviation: number | null;
+  readonly numberOfMembers: readonly number[] | null;
+  readonly isMultiMember: boolean;
   readonly isCustom: boolean;
 }
 
@@ -57,6 +73,8 @@ interface ValidForm {
   readonly chamber?: IChamber;
   readonly numberOfDistricts: number;
   readonly populationDeviation: number;
+  readonly numberOfMembers: readonly number[];
+  readonly isMultiMember: boolean;
   readonly isCustom: boolean;
   readonly valid: true;
 }
@@ -156,10 +174,13 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       chamber: null,
       numberOfDistricts: null,
       populationDeviation: DEFAULT_POPULATION_DEVIATION,
+      numberOfMembers: null,
+      isMultiMember: false,
       isCustom: false
     }
   });
   const { data } = createProjectResource;
+  const [totalPopulation, setTotalPopulation] = useState<number | null>(null);
 
   const onDistrictChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     const chamber =
@@ -172,10 +193,19 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
         ...(chamber
           ? {
               numberOfDistricts: chamber.numberOfDistricts,
+              numberOfMembers:
+                chamber.numberOfMembers || new Array(chamber.numberOfDistricts).fill(1),
+              isMultiMember: chamber.numberOfMembers?.some(num => num > 1) || false,
               chamber: chamber || null,
               isCustom: false
             }
-          : { numberOfDistricts: null, isCustom: true, chamber: null })
+          : {
+              numberOfDistricts: null,
+              numberOfMembers: null,
+              isCustom: true,
+              isMultiMember: false,
+              chamber: null
+            })
       }
     });
   };
@@ -188,6 +218,11 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
     store.dispatch(regionConfigsFetch());
     store.dispatch(userFetch());
   }, []);
+
+  useEffect(() => {
+    data.regionConfig &&
+      fetchTotalPopulation(data.regionConfig).then(population => setTotalPopulation(population));
+  }, [data.regionConfig]);
 
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />
@@ -232,7 +267,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
               if (validatedForm.valid === true) {
                 setCreateProjectResource({ data, isPending: true });
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { isCustom, valid, ...validatedData } = validatedForm;
+                const { isCustom, isMultiMember, valid, ...validatedData } = validatedForm;
                 createProject({
                   ...validatedData,
                   chamber: validatedForm.chamber || undefined,
@@ -414,16 +449,57 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                                   onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
                                     const value = parseInt(e.currentTarget.value, 10);
                                     const numberOfDistricts = isNaN(value) ? null : value;
+                                    const numberOfMembers =
+                                      numberOfDistricts && data.numberOfMembers
+                                        ? data.numberOfMembers.length > numberOfDistricts
+                                          ? data.numberOfMembers.slice(0, numberOfDistricts)
+                                          : data.numberOfMembers.concat(
+                                              new Array(
+                                                numberOfDistricts - data.numberOfMembers.length
+                                              ).fill(1)
+                                            )
+                                        : (new Array(numberOfDistricts).fill(
+                                            1
+                                          ) as readonly number[]);
                                     setCreateProjectResource({
                                       data: {
                                         ...data,
-                                        numberOfDistricts
+                                        numberOfDistricts,
+                                        numberOfMembers
                                       }
                                     });
                                   }
                                 }}
                               />
                             </Box>
+                          ) : null}
+                          <Divider sx={{ width: "100%" }} />
+                          <Box>
+                            <Label
+                              sx={{
+                                display: "inline-flex"
+                              }}
+                            >
+                              <Checkbox
+                                name="project-is-multi-member"
+                                checked={data.isMultiMember}
+                                onChange={() =>
+                                  setCreateProjectResource({
+                                    data: { ...data, isMultiMember: !data.isMultiMember }
+                                  })
+                                }
+                              />
+                              <Flex as="span">Use multi-member districts</Flex>
+                            </Label>
+                          </Box>
+                          {data.numberOfMembers && data.isMultiMember && totalPopulation ? (
+                            <MultiMemberForm
+                              totalPopulation={totalPopulation}
+                              numberOfMembers={data.numberOfMembers}
+                              onChange={numberOfMembers => {
+                                setCreateProjectResource({ data: { ...data, numberOfMembers } });
+                              }}
+                            />
                           ) : null}
                         </Flex>
                       </fieldset>

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -14,7 +14,9 @@ import {
   Spinner,
   ThemeUIStyleObject,
   Label,
-  Radio
+  Radio,
+  Divider,
+  Checkbox
 } from "theme-ui";
 
 import { DEFAULT_POPULATION_DEVIATION, FIPS, MAX_UPLOAD_FILE_SIZE } from "../../shared/constants";
@@ -33,7 +35,7 @@ import {
 import { regionConfigsFetch } from "../actions/regionConfig";
 import { setImportFlagsModal } from "../actions/districtDrawing";
 
-import { createProject, importCsv } from "../api";
+import { createProject, importCsv, fetchTotalPopulation } from "../api";
 import { InputField } from "../components/Field";
 import Icon from "../components/Icon";
 import ImportFlagsModal from "../components/ImportFlagsModal";
@@ -43,7 +45,8 @@ import { WriteResource, Resource } from "../resource";
 import store from "../store";
 import OrganizationTemplateForm from "../components/OrganizationTemplateForm";
 import { userFetch } from "../actions/user";
-import { destructureResource } from "../functions";
+import { destructureResource, updateNumberOfMembers } from "../functions";
+import MultiMemberForm from "../components/MultiMemberForm";
 
 interface StateProps {
   readonly organization: Resource<IOrganization>;
@@ -62,9 +65,11 @@ const validate = (
     "resource" in importResource ? importResource.resource.districtsDefinition : null;
   const maxDistrictId = "resource" in importResource ? importResource.resource.maxDistrictId : null;
   const numberOfDistricts = form.numberOfDistricts;
+  const numberOfMembers = form.numberOfMembers;
   const populationDeviation = form.populationDeviation;
   const chamber = form.chamber;
   const isCustom = form.isCustom;
+  const isMultiMember = form.isCustom;
   const organizationSelected = "resource" in organization;
 
   return organizationSelected && templateData?.projectTemplate && districtsDefinition
@@ -74,10 +79,12 @@ const validate = (
         regionConfig: templateData.regionConfig,
         districtsDefinition,
         isCustom,
+        isMultiMember,
         valid: true
       }
     : !organizationSelected &&
       numberOfDistricts &&
+      numberOfMembers &&
       maxDistrictId &&
       regionConfig &&
       populationDeviation !== null &&
@@ -86,20 +93,24 @@ const validate = (
     ? // Valid for the standard RegionConfig for this CSV
       {
         numberOfDistricts,
+        numberOfMembers,
         regionConfig,
         districtsDefinition,
         chamber,
         isCustom,
+        isMultiMember,
         populationDeviation,
         valid: true
       }
     : // Invalid
       {
         numberOfDistricts,
+        numberOfMembers,
         regionConfig,
         districtsDefinition,
         chamber,
         isCustom,
+        isMultiMember,
         populationDeviation,
         valid: false
       };
@@ -109,7 +120,9 @@ type ImportResource = WriteResource<IRegionConfig | null, DistrictsImportApiSucc
 
 interface ConfigurableForm {
   readonly numberOfDistricts: number | null;
+  readonly numberOfMembers: readonly number[] | null;
   readonly isCustom: boolean;
+  readonly isMultiMember: boolean;
   readonly chamber: IChamber | null;
   readonly populationDeviation: number;
 }
@@ -121,7 +134,9 @@ interface ValidCustomForm {
   readonly chamber: Pick<IChamber, "id"> | null;
   readonly districtsDefinition: DistrictsDefinition;
   readonly numberOfDistricts: number;
+  readonly numberOfMembers: readonly number[];
   readonly isCustom: boolean;
+  readonly isMultiMember: boolean;
   readonly populationDeviation: number;
   readonly valid: true;
 }
@@ -131,6 +146,7 @@ interface ValidTemplateForm {
   readonly regionConfig: Pick<IRegionConfig, "id">;
   readonly projectTemplate: Pick<IRegionConfig, "id">;
   readonly isCustom: boolean;
+  readonly isMultiMember: boolean;
   readonly valid: true;
 }
 
@@ -141,14 +157,18 @@ interface InvalidForm {
   readonly chamber: Pick<IChamber, "id"> | null;
   readonly districtsDefinition: DistrictsDefinition | null;
   readonly numberOfDistricts: number | null;
+  readonly numberOfMembers: readonly number[] | null;
   readonly isCustom: boolean;
+  readonly isMultiMember: boolean;
   readonly populationDeviation: number | null;
   readonly valid: false;
 }
 
 const blankForm: ConfigurableForm = {
   numberOfDistricts: null,
-  isCustom: true,
+  numberOfMembers: null,
+  isCustom: false,
+  isMultiMember: false,
   chamber: null,
   populationDeviation: DEFAULT_POPULATION_DEVIATION
 };
@@ -305,6 +325,8 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
     []
   );
 
+  const [totalPopulation, setTotalPopulation] = useState<number | null>(null);
+
   const onDistrictChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
     const chamber =
       regionConfig !== null
@@ -316,10 +338,19 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
         ...(chamber
           ? {
               numberOfDistricts: chamber.numberOfDistricts,
+              numberOfMembers:
+                chamber.numberOfMembers || new Array(chamber.numberOfDistricts).fill(1),
+              isMultiMember: chamber.numberOfMembers?.some(num => num > 1) || false,
               chamber: chamber || null,
               isCustom: false
             }
-          : { numberOfDistricts: null, isCustom: true, chamber: null })
+          : {
+              numberOfDistricts: null,
+              numberOfMembers: null,
+              isCustom: true,
+              isMultiMember: false,
+              chamber: null
+            })
       }
     });
   };
@@ -447,6 +478,11 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
     setCreateProjectResource({ data: blankForm });
   }
 
+  useEffect(() => {
+    regionConfig &&
+      fetchTotalPopulation(regionConfig).then(population => setTotalPopulation(population));
+  }, [regionConfig]);
+
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />
   ) : "resource" in regionConfigs && "resource" in user ? (
@@ -487,7 +523,7 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
               if (validatedForm.valid === true) {
                 setCreateProjectResource({ data: formData, isPending: true });
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { isCustom, valid, ...validatedData } = validatedForm;
+                const { isCustom, isMultiMember, valid, ...validatedData } = validatedForm;
                 createProject(
                   "name" in validatedForm.regionConfig
                     ? {
@@ -684,16 +720,51 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
                                   onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
                                     const value = parseInt(e.currentTarget.value, 10);
                                     const numberOfDistricts = isNaN(value) ? null : value;
+                                    const numberOfMembers = updateNumberOfMembers(
+                                      numberOfDistricts,
+                                      formData.numberOfMembers
+                                    );
                                     setCreateProjectResource({
                                       data: {
                                         ...formData,
-                                        numberOfDistricts
+                                        numberOfDistricts,
+                                        numberOfMembers
                                       }
                                     });
                                   }
                                 }}
                               />
                             </Box>
+                          ) : null}
+                          <Divider sx={{ width: "100%" }} />
+                          <Box>
+                            <Label
+                              sx={{
+                                display: "inline-flex"
+                              }}
+                            >
+                              <Checkbox
+                                name="project-is-multi-member"
+                                checked={formData.isMultiMember}
+                                onChange={() =>
+                                  setCreateProjectResource({
+                                    data: { ...formData, isMultiMember: !formData.isMultiMember }
+                                  })
+                                }
+                              />
+                              <Flex as="span">Use multi-member districts</Flex>
+                            </Label>
+                          </Box>
+                          {formData.numberOfMembers && formData.isMultiMember && totalPopulation ? (
+                            <MultiMemberForm
+                              totalPopulation={totalPopulation}
+                              numberOfMembers={formData.numberOfMembers}
+                              onChange={numberOfMembers => {
+                                setCreateProjectResource({
+                                  data: { ...formData, numberOfMembers }
+                                });
+                              }}
+                            />
                           ) : null}
                         </Flex>
                       </fieldset>

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -89,7 +89,8 @@ export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
   readonly party?: Party;
   readonly hasMultipleElections?: boolean;
   readonly electionYear?: ElectionYear;
-  readonly avgPopulation?: number;
+  readonly populationPerRepresentative?: number;
+  readonly numberOfMembers?: readonly number[];
   readonly popThreshold?: number;
   readonly status?: boolean;
   // eslint-disable-next-line

--- a/src/manage/dev-data/azavea.yaml
+++ b/src/manage/dev-data/azavea.yaml
@@ -11,6 +11,7 @@ projectTemplates:
     name: Dane County
     regionConfig: 4a48268f-ddcf-4ae9-b41f-23cda93c3eba
     numberOfDistricts: 18
+    numberOfMembers: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     details:
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -20,6 +21,17 @@ projectTemplates:
     name: House of Representatives
     regionConfig: 96bca832-99b3-4c4d-8913-ab4ca82ec442
     numberOfDistricts: 18
+    numberOfMembers: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    details:
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+      Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+  - id: 9047ac5b-4837-4935-b3c8-2a5624b5aec8
+    name: General Assembly
+    regionConfig: 893a9538-3f14-4225-9c91-d54ba818ab0d
+    numberOfDistricts: 40
+    numberOfMembers: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
     description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     details:
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/src/manage/src/commands/create-random-projects.ts
+++ b/src/manage/src/commands/create-random-projects.ts
@@ -78,6 +78,7 @@ export default class CreateRandomProjects extends Command {
         districtsDefinition[countyIdx] = 0;
       }
       const lockedDistricts = new Array(numberOfDistricts).fill(false);
+      const numberOfMembers = new Array(numberOfDistricts).fill(1);
       const districts = geoCollection.merge({ districts: districtsDefinition }, numberOfDistricts);
       if (!districts) {
         this.log(`Could not generate geojson`);
@@ -89,6 +90,7 @@ export default class CreateRandomProjects extends Command {
       project.districtsDefinition = districtsDefinition;
       project.districts = districts;
       project.lockedDistricts = lockedDistricts;
+      project.numberOfMembers = numberOfMembers;
       project.populationDeviation = 5;
       project.user = user;
       project.regionConfigVersion = region.version;

--- a/src/manage/src/commands/update-organization.ts
+++ b/src/manage/src/commands/update-organization.ts
@@ -16,6 +16,7 @@ interface TemplateConfig {
   readonly name: string;
   readonly regionConfig: string;
   readonly numberOfDistricts: string;
+  readonly numberOfMembers: readonly number[];
   readonly description?: string;
   readonly details?: string;
 }
@@ -92,6 +93,7 @@ export default class UpdateOrganization extends Command {
       // @ts-ignore
       template.regionConfig = { id: config.regionConfig };
       template.numberOfDistricts = Number(config.numberOfDistricts);
+      template.numberOfMembers = config.numberOfMembers.map(n => Number(n));
       template.description = config.description || "";
       template.details = config.details || "";
       // @ts-ignore

--- a/src/server/migrations/1635542647717-number_of_members.ts
+++ b/src/server/migrations/1635542647717-number_of_members.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class numberOfMembers1635542647717 implements MigrationInterface {
+    name = 'numberOfMembers1635542647717'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "number_of_members" integer array DEFAULT '{}'`);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD "number_of_members" integer array DEFAULT '{}'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project_template" DROP COLUMN "number_of_members"`);
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "number_of_members"`);
+    }
+
+}

--- a/src/server/migrations/1635542832040-number_of_members_default.ts
+++ b/src/server/migrations/1635542832040-number_of_members_default.ts
@@ -1,0 +1,23 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class numberOfMembersDefault1635542832040 implements MigrationInterface {
+    name = 'numberOfMembersDefault1635542832040'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE "project" SET "number_of_members" =  ARRAY_FILL(1, ARRAY["number_of_districts"], ARRAY[1]);`);
+        await queryRunner.query(`UPDATE "project_template" SET "number_of_members" =  ARRAY_FILL(1, ARRAY["number_of_districts"], ARRAY[1]);`);
+
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "number_of_members" SET NOT NULL`);
+        await queryRunner.query(`COMMENT ON COLUMN "project"."number_of_members" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "project_template" ALTER COLUMN "number_of_members" SET NOT NULL`);
+        await queryRunner.query(`COMMENT ON COLUMN "project_template"."number_of_members" IS NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`COMMENT ON COLUMN "project_template"."number_of_members" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "project_template" ALTER COLUMN "number_of_members" DROP NOT NULL`);
+        await queryRunner.query(`COMMENT ON COLUMN "project"."number_of_members" IS NULL`);
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "number_of_members" DROP NOT NULL`);
+    }
+
+}

--- a/src/server/migrations/1636047799212-chamber_number_of_members.ts
+++ b/src/server/migrations/1636047799212-chamber_number_of_members.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class chamberNumberOfMembers1636047799212 implements MigrationInterface {
+    name = 'chamberNumberOfMembers1636047799212'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chamber" ADD "number_of_members" integer array`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chamber" DROP COLUMN "number_of_members"`);
+    }
+
+}

--- a/src/server/src/chambers/entities/chamber.entity.ts
+++ b/src/server/src/chambers/entities/chamber.entity.ts
@@ -13,6 +13,14 @@ export class Chamber implements IChamber {
   @Column({ type: "integer", name: "number_of_districts" })
   numberOfDistricts: number;
 
+  @Column({
+    type: "integer",
+    name: "number_of_members",
+    array: true,
+    nullable: true
+  })
+  numberOfMembers?: readonly number[];
+
   @ManyToOne(() => RegionConfig, { nullable: false })
   @JoinColumn({ name: "region_config_id" })
   regionConfig: RegionConfig;

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -78,6 +78,14 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
   })
   pinnedMetricFields: string[];
 
+  @Column({
+    type: "integer",
+    name: "number_of_members",
+    array: true,
+    default: () => "'{}'"
+  })
+  numberOfMembers: readonly number[];
+
   @Column({ name: "is_active", type: "boolean", default: true })
   isActive: boolean;
 }

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -220,6 +220,12 @@ export class ProjectsController implements CrudController<Project> {
         message: { lockedDistricts: [`Length of array does not match "numberOfDistricts"`] }
       } as Errors<UpdateProjectDto>);
     }
+    if (dto.numberOfMembers && existingProject?.numberOfDistricts !== dto.numberOfMembers.length) {
+      throw new BadRequestException({
+        error: "Bad Request",
+        message: { numberOfMembers: [`Length of array does not match "numberOfDistricts"`] }
+      } as Errors<UpdateProjectDto>);
+    }
 
     const staticMetadata = (await this.getGeoUnitProperties(existingProject.regionConfig.s3URI))
       .staticMetadata;
@@ -317,6 +323,7 @@ export class ProjectsController implements CrudController<Project> {
       regionConfig,
       chamber,
       numberOfDistricts,
+      numberOfMembers,
       populationDeviation,
       pinnedMetricFields,
       districtsDefinition
@@ -325,6 +332,7 @@ export class ProjectsController implements CrudController<Project> {
       regionConfig,
       chamber,
       numberOfDistricts,
+      numberOfMembers,
       populationDeviation,
       pinnedMetricFields,
       districtsDefinition
@@ -384,10 +392,12 @@ export class ProjectsController implements CrudController<Project> {
     const districtsDefinition =
       dto.districtsDefinition || new Array(geoCollection.hierarchy.length).fill(0);
     const lockedDistricts = new Array(dto.numberOfDistricts).fill(false);
+    const numberOfMembers = dto.numberOfMembers || new Array(dto.numberOfDistricts).fill(1);
     return {
       ...dto,
       districtsDefinition,
       lockedDistricts,
+      numberOfMembers,
       user: req.parsed.authPersist.userId,
       regionConfigVersion: regionConfig.version
     };

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -38,7 +38,7 @@ export class CreateProjectDto implements CreateProjectData {
   @IsArray()
   @ArrayNotEmpty()
   @IsOptional()
-  readonly numberOfMembers: readonly number[];
+  readonly numberOfMembers?: readonly number[];
 
   @IsOptional()
   @IsNumber()

--- a/src/server/src/projects/entities/create-project.dto.ts
+++ b/src/server/src/projects/entities/create-project.dto.ts
@@ -35,6 +35,11 @@ export class CreateProjectDto implements CreateProjectData {
   @IsOptional()
   readonly districtsDefinition?: DistrictsDefinition;
 
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsOptional()
+  readonly numberOfMembers: readonly number[];
+
   @IsOptional()
   @IsNumber()
   @Max(100, { message: "Population deviation must be between 0% and 100%" })

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -108,6 +108,14 @@ export class Project implements IProject {
   })
   pinnedMetricFields: string[];
 
+  @Column({
+    type: "integer",
+    name: "number_of_members",
+    array: true,
+    default: () => "'{}'"
+  })
+  numberOfMembers: readonly number[];
+
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {
     return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };

--- a/src/server/src/projects/entities/update-project.dto.ts
+++ b/src/server/src/projects/entities/update-project.dto.ts
@@ -17,29 +17,41 @@ export class UpdateProjectDto implements UpdateProjectData {
   @IsNotEmpty({ message: "Please enter a name for your project" })
   @IsOptional()
   readonly name: string;
+
   @IsArray()
   @ArrayNotEmpty()
   @IsOptional()
   readonly districtsDefinition: DistrictsDefinition;
+
   @IsArray()
   @ArrayNotEmpty()
   @IsOptional()
   readonly lockedDistricts: readonly boolean[];
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsOptional()
+  readonly numberOfMembers: readonly number[];
+
   @IsBoolean()
   @IsOptional()
   readonly advancedEditingEnabled: boolean;
+
   @IsOptional()
   @IsNumber()
   @Max(100, { message: "Population deviation must be between 0% and 100%" })
   @Min(0, { message: "Population deviation must be between 0% and 100%" })
   readonly populationDeviation: number;
+
   @IsEnum(ProjectVisibility)
   @IsOptional()
   readonly visibility: ProjectVisibility;
+
   @IsOptional()
   @IsArray()
   @ArrayNotEmpty()
   readonly pinnedMetricFields: string[];
+
   @IsBoolean()
   @IsOptional()
   readonly archived: boolean;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -189,6 +189,7 @@ export interface ProjectTemplateFields {
   readonly chamber?: IChamber;
   readonly populationDeviation: number;
   readonly pinnedMetricFields: readonly string[];
+  readonly numberOfMembers: readonly number[];
   readonly districtsDefinition: DistrictsDefinition;
 }
 

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -227,6 +227,7 @@ export type ProjectNest = Pick<
 export interface CreateProjectData {
   readonly name?: string;
   readonly numberOfDistricts?: number;
+  readonly numberOfMembers?: readonly number[];
   readonly regionConfig: Pick<IRegionConfig, "id">;
   readonly chamber?: Pick<IChamber, "id"> | null;
   readonly districtsDefinition?: DistrictsDefinition;

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -272,6 +272,7 @@ export interface IChamber {
   readonly id: ChamberId;
   readonly name: string;
   readonly numberOfDistricts: number;
+  readonly numberOfMembers?: readonly number[];
   readonly regionConfig: IRegionConfig;
 }
 


### PR DESCRIPTION
## Overview

Adds support for making a project use multi-member districts when creating / importing it.

Multi-member projects will have different population targets, based on the number of representatives per district (e.g. we're targeting equal population per _representative_, which thus far has been the same as equal population per district).

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Creating a multi-member project:
![create-multi-member](https://user-images.githubusercontent.com/4432106/140571083-90c5da4c-31c9-451a-9f17-1ca1651a2bf4.gif)

Importing:
![import-multi-member](https://user-images.githubusercontent.com/4432106/140571102-2116c334-4411-4c3d-a302-cab32ecb18c0.gif)

Evaluate mode Equal pop. detail:
![image](https://user-images.githubusercontent.com/4432106/140572731-ddd06747-2a4d-4e42-ad38-5133c21c5b71.png)


### Notes

The original issue didn't call for adding `multi-member` support to Project Templates or Chambers, but it was a relatively small part of this overall feature, and something we've discussed wanting to support.

Similarly, we hadn't fully considered how multi-member would affect Evaluate mode (which calculates equal pop. / district) or the Tour (which references the district target pop.).

For the tour, I simply switched to referencing target pop. / _representative_, which will be the same as a 1-member district whether or not multi-member districts are in use (the only time this might get confusing is when creating a map with no single-member districts).

For Evaluate mode, I switched to showing target pop. / representative as above, as well as added a "Number of reps" column.

## Testing Instructions

- `scripts/update`
- Try creating / importing a project without setting the multi-member checkbox - there shouldn't be any regressions
- Create a project with multi-member districts:
   - Calculations on the sidebar & evaluate equal population should take your multi-member districts into account
- Creating a project w/ a Chamber w/ multi-member districts, or for a a project template w/ multi-member districts should copy their `numberOfMembers` field over to your project

Closes #1024 
