### PR TITLE
Add Map Configuration modal to project screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add support for creating/importing projects with multi-member districts [#1060](https://github.com/PublicMapping/districtbuilder/pull/1060) 
+- Add Map Configuration  modal [#1065](https://github.com/PublicMapping/districtbuilder/pull/1065)
 ### Changed
 ### Fixed
 - Improve PlanScore integration and display toast on errors [#1062](https://github.com/PublicMapping/districtbuilder/pull/1062)

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -62,6 +62,10 @@ export const updateProjectNameSuccess = createAction("Update project name succes
   DynamicProjectData
 >();
 
+export const updateProjectDetailsSuccess = createAction("Update project details success")<
+  DynamicProjectData
+>();
+
 export const updateProjectVisibility = createAction("Update project visibility")<
   ProjectVisibility
 >();
@@ -98,6 +102,7 @@ export const duplicateProjectSuccess = createAction("Duplicate project success")
 export const duplicateProjectFailure = createAction("Duplicate project failure")<string>();
 
 export const toggleReferenceLayersModal = createAction("Toggle reference layers modal")();
+export const toggleProjectDetailsModal = createAction("Toggle project details modal")();
 
 export const clearDuplicationState = createAction("Clear duplication state")();
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -262,7 +262,7 @@ export async function patchProject(
     apiAxios
       .patch(`/api/projects/${id}`, projectData)
       .then(response => resolve(response.data))
-      .catch(() => reject());
+      .catch(error => reject(error.response?.data || error));
   });
 }
 

--- a/src/client/components/MultiMemberForm.tsx
+++ b/src/client/components/MultiMemberForm.tsx
@@ -1,45 +1,71 @@
 /** @jsx jsx */
-import { jsx, Styled, Input } from "theme-ui";
+import React from "react";
+import { jsx, Box, Styled, Input } from "theme-ui";
 
 interface Props {
   readonly totalPopulation: number;
   readonly numberOfMembers: readonly number[];
+  readonly errors?: readonly string[];
   // eslint-disable-next-line functional/no-mixed-type
   readonly onChange: (numberOfMembers: readonly number[]) => void;
 }
 
-const MultiMemberForm = ({ totalPopulation, numberOfMembers, onChange }: Props) => {
-  const totalReps = numberOfMembers.reduce((total, numberOfReps) => total + numberOfReps, 0);
+const MultiMemberForm = ({ totalPopulation, numberOfMembers, errors, onChange }: Props) => {
+  const totalReps = numberOfMembers.reduce(
+    (total, numberOfReps) => (Number.isNaN(numberOfReps) ? total : total + numberOfReps),
+    0
+  );
   const popPerRep = Math.floor(totalPopulation / totalReps);
   return (
-    <Styled.table sx={{ margin: "0", width: "100%" }}>
-      <thead sx={{ bg: "muted" }}>
-        <tr>
-          <td>Districts</td>
-          <td>Number of reps</td>
-          <td sx={{ textAlign: "right" }}>Target population</td>
-        </tr>
-      </thead>
-      <tbody>
-        {numberOfMembers.map((numberOfReps, i) => (
-          <tr key={i}>
-            <td>{i + 1}</td>
-            <td>
-              <Input
-                sx={{ maxWidth: "200px" }}
-                value={numberOfReps}
-                pattern="[0-9]+"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const val = Number(e.target.value);
-                  onChange([...numberOfMembers.slice(0, i), val, ...numberOfMembers.slice(i + 1)]);
-                }}
-              ></Input>
-            </td>
-            <td sx={{ textAlign: "right" }}>{Number(numberOfReps * popPerRep).toLocaleString()}</td>
+    <React.Fragment>
+      {errors && (
+        <Box sx={{ fontSize: 1, color: "warning", textAlign: "left" }}>
+          {errors &&
+            errors.map((msg: string, index: number) => (
+              <React.Fragment key={index}>
+                {msg}
+                <Styled.div />
+              </React.Fragment>
+            ))}
+        </Box>
+      )}
+      <Styled.table sx={{ margin: "0", width: "100%" }}>
+        <thead sx={{ bg: "muted" }}>
+          <tr>
+            <td>Districts</td>
+            <td>Number of reps</td>
+            <td sx={{ textAlign: "right" }}>Target population</td>
           </tr>
-        ))}
-      </tbody>
-    </Styled.table>
+        </thead>
+        <tbody>
+          {numberOfMembers.map((numberOfReps: number, i: number) => (
+            <tr key={i}>
+              <td>{i + 1}</td>
+              <td>
+                <Input
+                  sx={{ maxWidth: "200px" }}
+                  value={Number.isNaN(numberOfReps) ? "" : numberOfReps}
+                  pattern="[0-9]+"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const val = e.target.value ? Number(e.target.value) : NaN;
+                    onChange([
+                      ...numberOfMembers.slice(0, i),
+                      val,
+                      ...numberOfMembers.slice(i + 1)
+                    ]);
+                  }}
+                ></Input>
+              </td>
+              <td sx={{ textAlign: "right" }}>
+                {Number.isNaN(numberOfReps)
+                  ? ""
+                  : Number(numberOfReps * popPerRep).toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Styled.table>
+    </React.Fragment>
   );
 };
 

--- a/src/client/components/MultiMemberForm.tsx
+++ b/src/client/components/MultiMemberForm.tsx
@@ -13,7 +13,7 @@ const MultiMemberForm = ({ totalPopulation, numberOfMembers, onChange }: Props) 
   const popPerRep = Math.floor(totalPopulation / totalReps);
   return (
     <Styled.table sx={{ margin: "0", width: "100%" }}>
-      <thead>
+      <thead sx={{ bg: "muted" }}>
         <tr>
           <td>Districts</td>
           <td>Number of reps</td>
@@ -28,6 +28,7 @@ const MultiMemberForm = ({ totalPopulation, numberOfMembers, onChange }: Props) 
               <Input
                 sx={{ maxWidth: "200px" }}
                 value={numberOfReps}
+                pattern="[0-9]+"
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const val = Number(e.target.value);
                   onChange([...numberOfMembers.slice(0, i), val, ...numberOfMembers.slice(i + 1)]);

--- a/src/client/components/ProjectDetailsModal.tsx
+++ b/src/client/components/ProjectDetailsModal.tsx
@@ -1,0 +1,324 @@
+/** @jsx jsx */
+import React, { useState } from "react";
+import AriaModal from "react-aria-modal";
+import { connect } from "react-redux";
+import { InputField } from "./Field";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  jsx,
+  ThemeUIStyleObject,
+  Label,
+  Checkbox,
+  Divider
+} from "theme-ui";
+
+import { IProject } from "../../shared/entities";
+import { State } from "../reducers";
+import store from "../store";
+import { toggleProjectDetailsModal, updateProjectDetailsSuccess } from "../actions/projectData";
+import { WriteResource } from "../resource";
+import FormError from "./FormError";
+import { DistrictsGeoJSON } from "../types";
+import MultiMemberForm from "./MultiMemberForm";
+import { patchProject } from "../api";
+
+const style: ThemeUIStyleObject = {
+  footer: {
+    marginTop: 5
+  },
+  header: {
+    mb: 5
+  },
+  heading: {
+    fontFamily: "heading",
+    fontWeight: "bold",
+    fontSize: 4
+  },
+  helpText: {
+    fontSize: "13px",
+    textTransform: "none",
+    fontWeight: "normal"
+  },
+  label: {
+    fontSize: "16px",
+    color: "heading",
+    fontWeight: "bold",
+    textTransform: "none"
+  },
+  modal: {
+    bg: "muted",
+    p: 5,
+    width: "small",
+    maxWidth: "90vw",
+    overflow: "visible"
+  },
+  customInputContainer: {
+    width: "100%",
+    mb: 5
+  },
+  multiMemberContainer: {
+    overflow: "hidden",
+    maxHeight: "calc(100vh - 42rem)",
+    width: "100%",
+    "> div": {
+      overflow: "auto",
+      width: "100%",
+      flex: "0 0 auto",
+      maxHeight: "inherit"
+    },
+    thead: {
+      position: "sticky",
+      top: 0
+    }
+  }
+};
+
+const validate = (form: ConfigurableForm): ProjectDetailsForm => {
+  const name = form.name;
+  const populationDeviation = form.populationDeviation;
+  const numberOfMembers = form.numberOfMembers;
+  const isMultiMember = form.isMultiMember;
+
+  return name && populationDeviation !== null && numberOfMembers !== null
+    ? {
+        name,
+        populationDeviation,
+        numberOfMembers,
+        isMultiMember,
+        valid: true
+      }
+    : {
+        name,
+        populationDeviation,
+        numberOfMembers,
+        isMultiMember,
+        valid: false
+      };
+};
+
+type ProjectDetailsForm = ValidForm | InvalidForm;
+
+interface ValidForm {
+  readonly name: string;
+  readonly populationDeviation: number;
+  readonly numberOfMembers: readonly number[];
+  readonly isMultiMember: boolean;
+  readonly valid: true;
+}
+
+interface InvalidForm {
+  readonly name: string | null;
+  readonly populationDeviation: number | null;
+  readonly numberOfMembers: readonly number[];
+  readonly isMultiMember: boolean;
+  readonly valid: false;
+}
+
+interface ConfigurableForm {
+  readonly name: string | null;
+  readonly populationDeviation: number | null;
+  readonly numberOfMembers: readonly number[];
+  readonly isMultiMember: boolean;
+}
+
+const ProjectDetailModal = ({
+  project,
+  geojson,
+  showModal
+}: {
+  readonly project: IProject;
+  readonly geojson: DistrictsGeoJSON;
+  readonly showModal: boolean;
+}) => {
+  const totalPopulation = geojson.features.reduce(
+    (total, feature) => total + feature.properties.demographics.population,
+    0
+  );
+
+  const hideModal = () => store.dispatch(toggleProjectDetailsModal()) && resetForm();
+
+  const blankForm: ConfigurableForm = {
+    name: project.name,
+    populationDeviation: project.populationDeviation,
+    numberOfMembers: project.numberOfMembers,
+    isMultiMember: project.numberOfMembers.some(num => num !== 1)
+  };
+
+  const [projectDetailsResource, setProjectDetailsResource] = useState<
+    WriteResource<ConfigurableForm, void>
+  >({
+    data: blankForm
+  });
+  const formData = projectDetailsResource.data;
+
+  function resetForm() {
+    setProjectDetailsResource({ data: blankForm });
+  }
+
+  return showModal ? (
+    <AriaModal
+      titleId="edit-project-details-modal"
+      onExit={hideModal}
+      initialFocus="#primary-action"
+      getApplicationNode={() => document.getElementById("root") as Element}
+      underlayStyle={{ paddingTop: "4.5rem" }}
+    >
+      <Box sx={style.modal}>
+        <React.Fragment>
+          <Box sx={style.header}>
+            <Heading as="h1" sx={style.heading} id="project-details-header">
+              Map configuration
+            </Heading>
+          </Box>
+          <Flex
+            as="form"
+            sx={{ flexDirection: "column" }}
+            onSubmit={(e: React.FormEvent) => {
+              e.preventDefault();
+              const validatedForm = validate(formData);
+              if (validatedForm.valid === true) {
+                setProjectDetailsResource({ data: formData, isPending: true });
+                const projectData = {
+                  name: validatedForm.name,
+                  populationDeviation: validatedForm.populationDeviation,
+                  numberOfMembers: validatedForm.numberOfMembers
+                };
+
+                patchProject(project.id, projectData)
+                  .then((project: IProject) => {
+                    store.dispatch(updateProjectDetailsSuccess({ project, geojson }));
+                  })
+                  .catch(errors => {
+                    setProjectDetailsResource({ data: formData, errors });
+                  });
+              }
+            }}
+          >
+            <Box>
+              <Flex sx={{ flexWrap: "wrap" }}>
+                <Box sx={style.customInputContainer}>
+                  <FormError resource={projectDetailsResource} />
+                  <InputField
+                    field="name"
+                    label={
+                      <Box as="span" sx={style.label}>
+                        Map name
+                      </Box>
+                    }
+                    description={
+                      <Box as="span" sx={style.helpText}>
+                        e.g. ‘Arizona House of Representatives’. Make it specific to help tell your
+                        maps apart.
+                      </Box>
+                    }
+                    resource={projectDetailsResource}
+                    inputProps={{
+                      value: formData.name || "",
+                      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                        setProjectDetailsResource({
+                          data: { ...formData, name: e.currentTarget.value }
+                        })
+                    }}
+                  />
+                </Box>
+                <Box sx={style.customInputContainer}>
+                  <Box sx={style.label}>Districts</Box>
+                  <Label
+                    sx={{
+                      display: "inline-flex"
+                    }}
+                  >
+                    <Checkbox
+                      name="project-is-multi-member"
+                      checked={formData.isMultiMember}
+                      onChange={() =>
+                        setProjectDetailsResource({
+                          data: { ...formData, isMultiMember: !formData.isMultiMember }
+                        })
+                      }
+                    />
+                    <Flex as="span">Use multi-member districts</Flex>
+                  </Label>
+                  {formData.isMultiMember ? (
+                    <Box sx={style.multiMemberContainer}>
+                      <Box>
+                        <MultiMemberForm
+                          totalPopulation={totalPopulation}
+                          numberOfMembers={formData.numberOfMembers}
+                          onChange={numberOfMembers => {
+                            setProjectDetailsResource({ data: { ...formData, numberOfMembers } });
+                          }}
+                        />
+                      </Box>
+                    </Box>
+                  ) : null}
+                </Box>
+
+                <Box sx={style.customInputContainer}>
+                  <InputField
+                    field="populationDeviation"
+                    label={
+                      <Box as="span" sx={style.label}>
+                        Population deviation tolerance (%)
+                      </Box>
+                    }
+                    description={
+                      <Box as="span" sx={style.helpText}>
+                        How detailed of a map do you want to draw? Setting a lower tolerance means
+                        the population of your districts will need to be more exact. If you
+                        aren&apos;t sure, we think 5% is a good starting point.
+                      </Box>
+                    }
+                    resource={projectDetailsResource}
+                    inputProps={{
+                      value:
+                        formData.populationDeviation !== null ? formData.populationDeviation : "",
+                      onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                        const value = parseFloat(e.currentTarget.value);
+                        const populationDeviation = isNaN(value) ? null : value;
+                        setProjectDetailsResource({
+                          data: {
+                            ...formData,
+                            populationDeviation
+                          }
+                        });
+                      }
+                    }}
+                  />
+                </Box>
+              </Flex>
+            </Box>
+
+            <Divider />
+            <Flex sx={style.footer}>
+              <Button
+                id="primary-action"
+                type="submit"
+                disabled={
+                  !validate(formData).valid ||
+                  ("isPending" in projectDetailsResource && projectDetailsResource.isPending)
+                }
+              >
+                Save changes
+              </Button>
+              <Button sx={{ ml: 2, variant: "buttons.subtle" }} onClick={() => hideModal()}>
+                Cancel
+              </Button>
+            </Flex>
+          </Flex>
+        </React.Fragment>
+      </Box>
+    </AriaModal>
+  ) : null;
+};
+
+function mapStateToProps(state: State) {
+  return {
+    showModal: state.project.showProjectDetailsModal
+  };
+}
+
+export default connect(mapStateToProps)(ProjectDetailModal);

--- a/src/client/components/ProjectDetailsModal.tsx
+++ b/src/client/components/ProjectDetailsModal.tsx
@@ -24,6 +24,7 @@ import FormError from "./FormError";
 import { DistrictsGeoJSON } from "../types";
 import MultiMemberForm from "./MultiMemberForm";
 import { patchProject } from "../api";
+import { extractErrors } from "../functions";
 
 const style: ThemeUIStyleObject = {
   footer: {
@@ -246,6 +247,7 @@ const ProjectDetailModal = ({
                     <Box sx={style.multiMemberContainer}>
                       <Box>
                         <MultiMemberForm
+                          errors={extractErrors(projectDetailsResource, "numberOfMembers")}
                           totalPopulation={totalPopulation}
                           numberOfMembers={formData.numberOfMembers}
                           onChange={numberOfMembers => {

--- a/src/client/components/ProjectName.tsx
+++ b/src/client/components/ProjectName.tsx
@@ -6,7 +6,11 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Input, jsx, Styled, Text } from "theme-ui";
 import { IProject, IProjectTemplate } from "../../shared/entities";
-import { setProjectNameEditing, updateProjectName } from "../actions/projectData";
+import {
+  setProjectNameEditing,
+  updateProjectName,
+  toggleProjectDetailsModal
+} from "../actions/projectData";
 import { State } from "../reducers";
 import store from "../store";
 import { SavingState } from "../types";
@@ -39,6 +43,7 @@ const style = {
 
 enum MenuKeys {
   Rename = "Rename",
+  Config = "Config",
   AboutTemplate = "AboutTemplate"
 }
 
@@ -65,7 +70,7 @@ const ProjectName = ({
     projectNameSaving === "unsaved" && inputRef.current && inputRef.current.focus();
   }, [inputRef, projectNameSaving]);
 
-  const EditButton = project.projectTemplate ? (
+  const EditButton = (
     <Wrapper
       sx={{ position: "relative", pr: 1 }}
       closeOnSelection={true}
@@ -74,6 +79,8 @@ const ProjectName = ({
           store.dispatch(setProjectNameEditing(true));
         } else if (menuKey === MenuKeys.AboutTemplate) {
           setModalVisibility(true);
+        } else if (menuKey === MenuKeys.Config) {
+          store.dispatch(toggleProjectDetailsModal());
         }
       }}
     >
@@ -104,20 +111,23 @@ const ProjectName = ({
               <Box sx={menuButtonStyles.menuListItem}>Rename map</Box>
             </MenuItem>
           </li>
-          <li key={MenuKeys.AboutTemplate}>
-            <MenuItem value={MenuKeys.AboutTemplate}>
-              <Box sx={menuButtonStyles.menuListItem}>
-                About “{project.projectTemplate?.name}” template
-              </Box>
+          <li key={MenuKeys.Config}>
+            <MenuItem value={MenuKeys.Config}>
+              <Box sx={menuButtonStyles.menuListItem}>Map configuration</Box>
             </MenuItem>
           </li>
+          {project.projectTemplate && (
+            <li key={MenuKeys.AboutTemplate}>
+              <MenuItem value={MenuKeys.AboutTemplate}>
+                <Box sx={menuButtonStyles.menuListItem}>
+                  About “{project.projectTemplate.name}” template
+                </Box>
+              </MenuItem>
+            </li>
+          )}
         </ul>
       </Menu>
     </Wrapper>
-  ) : (
-    <Button sx={style.button} onClick={() => store.dispatch(setProjectNameEditing(true))}>
-      <Icon name="pencil" />
-    </Button>
   );
 
   const TemplateModal = ({ template }: { readonly template: IProjectTemplate }) => (

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -17,7 +17,7 @@ import {
   ReferenceLayerProperties
 } from "../shared/entities";
 
-import { Resource } from "./resource";
+import { Resource, WriteResource } from "./resource";
 import {
   ChoroplethSteps,
   DistrictGeoJSON,
@@ -423,4 +423,13 @@ export function updateNumberOfMembers(
       ? numberOfMembers.slice(0, numberOfDistricts)
       : numberOfMembers.concat(new Array(numberOfDistricts - numberOfMembers.length).fill(1))
     : (new Array(numberOfDistricts).fill(1) as readonly number[]);
+}
+
+export function extractErrors<D, T>(
+  resource: WriteResource<D, T>,
+  field: keyof D
+): readonly string[] | undefined {
+  return "errors" in resource && typeof resource.errors.message === "object"
+    ? resource.errors.message[field]
+    : undefined;
 }

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -43,7 +43,9 @@ import {
   referenceLayerDelete,
   referenceLayerDeleteSuccess,
   referenceLayerDeleteFailure,
-  setDeleteReferenceLayer
+  setDeleteReferenceLayer,
+  toggleProjectDetailsModal,
+  updateProjectDetailsSuccess
 } from "../actions/projectData";
 import { clearSelectedGeounits, setSavingState, FindTool } from "../actions/districtDrawing";
 import { updateCurrentState } from "../reducers/undoRedo";
@@ -104,6 +106,7 @@ export type ProjectDataState = {
   readonly saving: SavingState;
   readonly referenceLayers: Resource<readonly IReferenceLayer[]>;
   readonly showReferenceLayersModal: boolean;
+  readonly showProjectDetailsModal: boolean;
   readonly duplicatedProject: IProject | null;
   readonly deleteReferenceLayer?: IReferenceLayer;
 };
@@ -119,6 +122,7 @@ export const initialProjectDataState = {
   projectNameSaving: "saved",
   saving: "unsaved",
   showReferenceLayersModal: false,
+  showProjectDetailsModal: false,
   duplicatedProject: null
 } as const;
 
@@ -298,6 +302,11 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         ...state,
         showReferenceLayersModal: !state.showReferenceLayersModal
       };
+    case getType(toggleProjectDetailsModal):
+      return {
+        ...state,
+        showProjectDetailsModal: !state.showProjectDetailsModal
+      };
     case getType(staticDataFetchFailure):
       return loop(
         {
@@ -373,6 +382,13 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       return {
         ...state,
         saving: "saved",
+        projectData: { resource: action.payload }
+      };
+    case getType(updateProjectDetailsSuccess):
+      return {
+        ...state,
+        saving: "saved",
+        showProjectDetailsModal: false,
         projectData: { resource: action.payload }
       };
     case getType(updateDistrictsDefinition):

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -33,7 +33,7 @@ import { OrganizationState } from "../reducers/organization";
 import { UserState } from "../reducers/user";
 import { Resource, WriteResource } from "../resource";
 import store from "../store";
-import { updateNumberOfMembers } from "../functions";
+import { updateNumberOfMembers, extractErrors } from "../functions";
 
 interface StateProps {
   readonly regionConfigs: Resource<readonly IRegionConfig[]>;
@@ -479,6 +479,7 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
                           </Box>
                           {data.numberOfMembers && data.isMultiMember && totalPopulation ? (
                             <MultiMemberForm
+                              errors={extractErrors(createProjectResource, "numberOfMembers")}
                               totalPopulation={totalPopulation}
                               numberOfMembers={data.numberOfMembers}
                               onChange={numberOfMembers => {

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -45,7 +45,7 @@ import { WriteResource, Resource } from "../resource";
 import store from "../store";
 import OrganizationTemplateForm from "../components/OrganizationTemplateForm";
 import { userFetch } from "../actions/user";
-import { destructureResource, updateNumberOfMembers } from "../functions";
+import { destructureResource, updateNumberOfMembers, extractErrors } from "../functions";
 import MultiMemberForm from "../components/MultiMemberForm";
 
 interface StateProps {
@@ -757,6 +757,7 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
                           </Box>
                           {formData.numberOfMembers && formData.isMultiMember && totalPopulation ? (
                             <MultiMemberForm
+                              errors={extractErrors(createProjectResource, "numberOfMembers")}
                               totalPopulation={totalPopulation}
                               numberOfMembers={formData.numberOfMembers}
                               onChange={numberOfMembers => {

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -47,6 +47,7 @@ import ProjectEvaluateSidebar from "../components/evaluate/ProjectEvaluateSideba
 import ConvertMapModal from "../components/ConvertMapModal";
 import AddReferenceLayerModal from "../components/AddReferenceLayerModal";
 import DeleteReferenceLayerModal from "../components/DeleteReferenceLayerModal";
+import ProjectDetailsModal from "../components/ProjectDetailsModal";
 
 interface StateProps {
   readonly project?: IProject;
@@ -262,6 +263,7 @@ const ProjectScreen = ({
                   staticMetadata={staticMetadata}
                 />
                 <AddReferenceLayerModal project={project} />
+                <ProjectDetailsModal project={project} geojson={geojson} />
                 <DeleteReferenceLayerModal />
                 <Flex id="tour-start" sx={style.tourStart}></Flex>
               </React.Fragment>


### PR DESCRIPTION
## Overview

Allows editing name, pop. deviation, and multi-member settings via a new modal on the Project screen

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/142038453-9ef658e3-c5e4-4ca4-94bf-3030c5191d1e.png)

![image](https://user-images.githubusercontent.com/4432106/142038516-9e3a292b-b8ce-4d74-b4b8-391fc3466b91.png)

![image](https://user-images.githubusercontent.com/4432106/142038592-33af7c36-3b57-4baf-9af5-fe2831d13833.png)


## Testing Instructions

- Create a new map or go to an existing map and use the "..." menu button in the header next to the project name to open the Map Configuration modal
  - Saved changes should be reflected (sidebar updating, name changing, etc)
  - Validation errors should be displayed in the form (e.g. deviation > 100)
  - The "..." menu should _not_ be shown for a public map that is not yours (or while you are not logged in)

Closes #1025 
