### PR TITLE
Update Competitiveness metric on Evaluate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for creating/importing projects with multi-member districts [#1060](https://github.com/PublicMapping/districtbuilder/pull/1060) 
 - Add Map Configuration  modal [#1065](https://github.com/PublicMapping/districtbuilder/pull/1065)
 ### Changed
+- Update Competitiveness metric on Evaluate [#1068](https://github.com/PublicMapping/districtbuilder/pull/1068)
 ### Fixed
 - Improve PlanScore integration and display toast on errors [#1062](https://github.com/PublicMapping/districtbuilder/pull/1062)
 

--- a/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateMetricDetail.tsx
@@ -2,7 +2,7 @@
 import { Box, Button, Flex, jsx, ThemeUIStyleObject, Heading, Text, Select } from "theme-ui";
 import { IProject, IStaticMetadata, RegionLookupProperties } from "../../../shared/entities";
 import Icon from "../Icon";
-import { DistrictsGeoJSON, ElectionYear, EvaluateMetricWithValue } from "../../types";
+import { DistrictsGeoJSON, ElectionYear, EvaluateMetricWithValue, PviBucket } from "../../types";
 import store from "../../store";
 import { selectEvaluationMetric } from "../../actions/districtDrawing";
 import ContiguityMetricDetail from "./detail/Contiguity";
@@ -36,6 +36,7 @@ const ProjectEvaluateMetricDetail = ({
   regionProperties,
   geoLevel,
   electionYear,
+  pviBuckets,
   setElectionYear,
   staticMetadata
 }: {
@@ -45,6 +46,7 @@ const ProjectEvaluateMetricDetail = ({
   readonly regionProperties: Resource<readonly RegionLookupProperties[]>;
   readonly geoLevel: string;
   readonly electionYear: ElectionYear | undefined;
+  readonly pviBuckets: readonly (PviBucket | undefined)[] | undefined;
   readonly setElectionYear: (year: ElectionYear) => void;
   readonly staticMetadata?: IStaticMetadata;
 }) => {
@@ -124,7 +126,12 @@ const ProjectEvaluateMetricDetail = ({
         ) : metric && "type" in metric && metric.key === "equalPopulation" ? (
           <EqualPopulationMetricDetail metric={metric} geojson={geojson} />
         ) : metric && "type" in metric && metric.key === "competitiveness" ? (
-          <CompetitivenessMetricDetail metric={metric} geojson={geojson} project={project} />
+          <CompetitivenessMetricDetail
+            metric={metric}
+            geojson={geojson}
+            project={project}
+            pviBuckets={pviBuckets}
+          />
         ) : metric && "type" in metric && metric.key === "majorityMinority" ? (
           <MajorityRaceMetricDetail metric={metric} geojson={geojson} />
         ) : (

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -4,7 +4,7 @@ import { Box, IconButton, Flex, jsx, ThemeUIStyleObject, Heading, Text } from "t
 import Icon from "../Icon";
 import store from "../../store";
 import { EvaluateMetricWithValue } from "../../types";
-import { formatPvi, formatPviByDistrict } from "../../functions";
+import { formatPviByDistrict } from "../../functions";
 import { selectEvaluationMetric, toggleEvaluate } from "../../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
@@ -64,8 +64,6 @@ const ProjectEvaluateView = ({
     switch (metric.type) {
       case "fraction":
         return `${metric.value} / ${metric.total || 18}`;
-      case "pvi":
-        return formatPvi(metric.party, metric.value);
       case "pvibydistrict":
         return formatPviByDistrict(metric.pviByDistrict)?.join(" / ") || "N/A";
       case "percent":

--- a/src/client/components/evaluate/ProjectEvaluateSummary.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSummary.tsx
@@ -4,7 +4,7 @@ import { Box, IconButton, Flex, jsx, ThemeUIStyleObject, Heading, Text } from "t
 import Icon from "../Icon";
 import store from "../../store";
 import { EvaluateMetricWithValue } from "../../types";
-import { formatPvi } from "../../functions";
+import { formatPvi, formatPviByDistrict } from "../../functions";
 import { selectEvaluationMetric, toggleEvaluate } from "../../actions/districtDrawing";
 
 const style: ThemeUIStyleObject = {
@@ -66,6 +66,8 @@ const ProjectEvaluateView = ({
         return `${metric.value} / ${metric.total || 18}`;
       case "pvi":
         return formatPvi(metric.party, metric.value);
+      case "pvibydistrict":
+        return formatPviByDistrict(metric.pviByDistrict)?.join(" / ") || "N/A";
       case "percent":
         return metric.value !== undefined ? `${Math.floor(metric.value * 100)}%` : "";
       case "count":

--- a/src/client/components/evaluate/detail/Competitiveness.tsx
+++ b/src/client/components/evaluate/detail/Competitiveness.tsx
@@ -109,12 +109,11 @@ const CompetitivenessMetricDetail = ({
         {formatPviByDistrict(pviBuckets)?.map(
           (bucket: string, index: number, array: readonly string[]) => {
             const divider = array.length > index + 1 && "/";
-            const bucketColor =
-              (bucket.includes("R")
-                ? getPartyColor("republican")
-                : bucket.includes("D")
-                ? getPartyColor("democrat")
-                : "#141414") || "#000";
+            const bucketColor = bucket.includes("R")
+              ? getPartyColor("republican")
+              : bucket.includes("D")
+              ? getPartyColor("democrat")
+              : "#141414";
             return divider ? (
               <span sx={{ color: "#000", mb: "10px" }} key={index}>
                 <span sx={{ color: bucketColor, ml: "10px", mb: "10px", mr: "10px" }}>

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -1,23 +1,26 @@
 /** @jsx jsx */
 import { Flex, jsx } from "theme-ui";
-import { DistrictsGeoJSON, EvaluateMetricWithValue, PviBucket } from "../../../types";
+import { PviBucket } from "../../../types";
 import { Bar } from "@visx/shape";
 import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
 import { scaleLinear, scaleBand } from "@visx/scale";
 import { Axis } from "@visx/axis";
-import { getPviBuckets, getPviSteps } from "../../map";
-import { calculatePVI } from "../../../functions";
+import { getPviBuckets } from "../../map";
+//import { calculatePVI } from "../../../functions";
 import { countBy } from "lodash";
 
+//probably no longer even need geojson and metric passed in
 const CompetitivenessChart = ({
-  geojson,
-  metric
+  //geojson,
+  //metric,
+  pviBuckets
 }: {
-  readonly geojson?: DistrictsGeoJSON;
-  readonly metric?: EvaluateMetricWithValue;
+  //readonly geojson?: DistrictsGeoJSON;
+  //readonly metric?: EvaluateMetricWithValue;
+  readonly pviBuckets?: readonly (PviBucket | undefined)[] | undefined;
 }) => {
-  const buckets: readonly (PviBucket | undefined)[] | undefined =
+  /*const buckets: readonly (PviBucket | undefined)[] | undefined =
     geojson &&
     geojson?.features
       .filter(f => f.id !== 0 && f.geometry.coordinates.length > 0)
@@ -25,35 +28,36 @@ const CompetitivenessChart = ({
         const pvi = f.properties.voting && calculatePVI(f.properties.voting, metric?.electionYear);
         const data: PviBucket | undefined = pvi !== undefined ? computeRowBucket(pvi) : undefined;
         return data;
-      });
-  const bucketCounts = countBy(buckets, "name");
+      });*/
+
+  const bucketCounts = countBy(pviBuckets, "name");
 
   const chartData: readonly PviBucket[] = getPviBuckets().map(bucket => {
     return { ...bucket, count: bucketCounts[bucket.name] || 0 };
   });
-
-  function computeRowBucket(value: number): PviBucket | undefined {
-    const buckets: readonly PviBucket[] = getPviBuckets();
-    const stops = getPviSteps();
-    // eslint-disable-next-line
-    for (let i = 0; i < stops.length; i++) {
-      const r = stops[i];
-      if (value >= r[0]) {
-        if (i < stops.length - 1) {
-          const r1 = stops[i + 1];
-          if (value < r1[0]) {
+  /*
+    function computeRowBucket(value: number): PviBucket | undefined {
+      const buckets: readonly PviBucket[] = getPviBuckets();
+      const stops = getPviSteps();
+      // eslint-disable-next-line
+      for (let i = 0; i < stops.length; i++) {
+        const r = stops[i];
+        if (value >= r[0]) {
+          if (i < stops.length - 1) {
+            const r1 = stops[i + 1];
+            if (value < r1[0]) {
+              return buckets[i];
+            }
+          } else {
             return buckets[i];
           }
         } else {
           return buckets[i];
         }
-      } else {
-        return buckets[i];
       }
+      return undefined;
     }
-    return undefined;
-  }
-
+  */
   return (
     <Flex
       sx={{

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -7,57 +7,19 @@ import { ParentSize } from "@visx/responsive";
 import { scaleLinear, scaleBand } from "@visx/scale";
 import { Axis } from "@visx/axis";
 import { getPviBuckets } from "../../map";
-//import { calculatePVI } from "../../../functions";
 import { countBy } from "lodash";
 
-//probably no longer even need geojson and metric passed in
 const CompetitivenessChart = ({
-  //geojson,
-  //metric,
   pviBuckets
 }: {
-  //readonly geojson?: DistrictsGeoJSON;
-  //readonly metric?: EvaluateMetricWithValue;
   readonly pviBuckets?: readonly (PviBucket | undefined)[] | undefined;
 }) => {
-  /*const buckets: readonly (PviBucket | undefined)[] | undefined =
-    geojson &&
-    geojson?.features
-      .filter(f => f.id !== 0 && f.geometry.coordinates.length > 0)
-      .map(f => {
-        const pvi = f.properties.voting && calculatePVI(f.properties.voting, metric?.electionYear);
-        const data: PviBucket | undefined = pvi !== undefined ? computeRowBucket(pvi) : undefined;
-        return data;
-      });*/
-
   const bucketCounts = countBy(pviBuckets, "name");
 
   const chartData: readonly PviBucket[] = getPviBuckets().map(bucket => {
     return { ...bucket, count: bucketCounts[bucket.name] || 0 };
   });
-  /*
-    function computeRowBucket(value: number): PviBucket | undefined {
-      const buckets: readonly PviBucket[] = getPviBuckets();
-      const stops = getPviSteps();
-      // eslint-disable-next-line
-      for (let i = 0; i < stops.length; i++) {
-        const r = stops[i];
-        if (value >= r[0]) {
-          if (i < stops.length - 1) {
-            const r1 = stops[i + 1];
-            if (value < r1[0]) {
-              return buckets[i];
-            }
-          } else {
-            return buckets[i];
-          }
-        } else {
-          return buckets[i];
-        }
-      }
-      return undefined;
-    }
-  */
+
   return (
     <Flex
       sx={{

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -22,7 +22,6 @@ import {
   ChoroplethSteps,
   DistrictGeoJSON,
   ElectionYear,
-  Party,
   DistrictsGeoJSON,
   ReferenceLayerGeojson,
   PviBucket
@@ -75,14 +74,6 @@ export const getPartyColor = (party: string) =>
 export const getMajorityRaceDisplay = (feature: DistrictGeoJSON) =>
   feature.properties.majorityRace && capitalizeFirstLetter(feature.properties.majorityRace);
 
-export function formatPvi(party?: Party, value?: number): string {
-  return value !== undefined && party !== undefined
-    ? `${party.label}+${Math.abs(value).toLocaleString(undefined, {
-        maximumFractionDigits: 0
-      })}`
-    : "N/A";
-}
-
 /* Creates array of party-labelled pvi bucket counts as strings */
 export function formatPviByDistrict(
   pviBuckets: readonly (PviBucket | undefined)[] | undefined
@@ -90,12 +81,10 @@ export function formatPviByDistrict(
   const partyLabels = ["R", "E (Even)", "D"];
   // Count by partyLabels
   const bucketCounts = pviBuckets?.reduce(
-    // eslint-disable-next-line
-    (allBuckets: { [key: string]: number } | undefined, bucket: PviBucket | undefined) => {
+    (allBuckets: { readonly [key: string]: number } | undefined, bucket: PviBucket | undefined) => {
       const name =
         bucket &&
         partyLabels.find(label => bucket.name.includes(label) || label.includes(bucket.name));
-      // eslint-disable-next-line
       return name
         ? allBuckets && name in allBuckets
           ? { ...allBuckets, [name]: allBuckets[name] + 1 }
@@ -110,7 +99,7 @@ export function formatPviByDistrict(
     partyLabels
       .map((label: string) => {
         return bucketCounts[label]
-          ? `${Math.abs(bucketCounts[label]).toLocaleString(undefined, {
+          ? `${bucketCounts[label].toLocaleString(undefined, {
               maximumFractionDigits: 0
             })} ${label}`
           : undefined;

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -24,7 +24,8 @@ import {
   ElectionYear,
   Party,
   DistrictsGeoJSON,
-  ReferenceLayerGeojson
+  ReferenceLayerGeojson,
+  PviBucket
 } from "./types";
 
 export function areAnyGeoUnitsSelected(geoUnits: GeoUnits) {
@@ -80,6 +81,42 @@ export function formatPvi(party?: Party, value?: number): string {
         maximumFractionDigits: 0
       })}`
     : "N/A";
+}
+
+/* Creates array of party-labelled pvi bucket counts as strings */
+export function formatPviByDistrict(
+  pviBuckets: readonly (PviBucket | undefined)[] | undefined
+): readonly string[] | undefined {
+  const partyLabels = ["R", "E (Even)", "D"];
+  // Count by partyLabels
+  const bucketCounts = pviBuckets?.reduce(
+    // eslint-disable-next-line
+    (allBuckets: { [key: string]: number } | undefined, bucket: PviBucket | undefined) => {
+      const name =
+        bucket &&
+        partyLabels.find(label => bucket.name.includes(label) || label.includes(bucket.name));
+      // eslint-disable-next-line
+      return name
+        ? allBuckets && name in allBuckets
+          ? { ...allBuckets, [name]: allBuckets[name] + 1 }
+          : { ...allBuckets, [name]: 1 }
+        : allBuckets;
+    },
+    {}
+  );
+  // Create string with partyLabels label
+  const bucketCountsStrings =
+    bucketCounts &&
+    partyLabels
+      .map((label: string) => {
+        return bucketCounts[label]
+          ? `${Math.abs(bucketCounts[label]).toLocaleString(undefined, {
+              maximumFractionDigits: 0
+            })} ${label}`
+          : undefined;
+      })
+      .filter((bucket: string | undefined): bucket is string => bucket !== undefined);
+  return bucketCountsStrings && bucketCountsStrings.length > 0 ? bucketCountsStrings : undefined;
 }
 
 function computeRowFillInterval(stops: ChoroplethSteps, value?: number) {

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -70,11 +70,6 @@ export interface BaseEvaluateMetric {
 
 export type ElectionYear = "16" | "20" | "combined";
 
-export interface Party {
-  readonly color: string;
-  readonly label: "D" | "R" | "E (even)";
-}
-
 export interface PviBucket {
   readonly name: string;
   readonly label: string;
@@ -83,10 +78,9 @@ export interface PviBucket {
 }
 
 export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
-  readonly type: "fraction" | "percent" | "count" | "pvi" | "pvibydistrict";
+  readonly type: "fraction" | "percent" | "count" | "pvibydistrict";
   readonly value?: number;
   readonly total?: number;
-  readonly party?: Party;
   readonly hasMultipleElections?: boolean;
   readonly electionYear?: ElectionYear;
   readonly populationPerRepresentative?: number;

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -72,7 +72,7 @@ export type ElectionYear = "16" | "20" | "combined";
 
 export interface Party {
   readonly color: string;
-  readonly label: "D" | "R";
+  readonly label: "D" | "R" | "E (even)";
 }
 
 export interface PviBucket {
@@ -83,7 +83,7 @@ export interface PviBucket {
 }
 
 export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
-  readonly type: "fraction" | "percent" | "count" | "pvi";
+  readonly type: "fraction" | "percent" | "count" | "pvi" | "pvibydistrict";
   readonly value?: number;
   readonly total?: number;
   readonly party?: Party;
@@ -92,6 +92,7 @@ export interface EvaluateMetricWithValue extends BaseEvaluateMetric {
   readonly populationPerRepresentative?: number;
   readonly numberOfMembers?: readonly number[];
   readonly popThreshold?: number;
+  readonly pviByDistrict?: readonly (PviBucket | undefined)[] | undefined;
   readonly status?: boolean;
   // eslint-disable-next-line
   readonly [key: string]: any;


### PR DESCRIPTION
## Overview

Update the Competitiveness metric on the Evaluate panel to instead display PVI breakdown by districts, according to the following format:

- By partisan breakdown i.e. “4 R / 5 D” or “5R / 1E (Even) / 2D” 
- Colored according to party color within Heading of `CompetitivenessMetricDetail`
- “N/A” if districts' PVI data is undefined

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Expected display within `CompetitivenessMetricDetail`:
![Screen Shot 2021-11-18 at 12 31 28 PM](https://user-images.githubusercontent.com/36374797/142494813-3932dfa5-1649-42cf-b620-91e355ed5113.png)

Expected display of Competitveness metric within `ProjectEvaluateView`:
![Screen Shot 2021-11-18 at 12 31 38 PM](https://user-images.githubusercontent.com/36374797/142494946-414ac4bd-50c1-4386-bad3-012ca4844214.png)

### Notes

Since the competitiveness metric now uses `pviByDistrict` (derived from `pviBuckets` passed down through props) instead of a competitiveness value as well as implements `formatPviByDistrict` for party labelling and coloring, we no longer need `value` and `party` to be updated for this metric. However, I’ve kept the `selectEvaluationMetric` store dispatch as part of  `ProjectEvaluateSidebar` to update `electionYear` since that value is still used throughout the project. As far as I can tell, there are no side effects to getting rid of `party` and `value` in the competitiveness metric and the resulting `EvaluateMetric`, but it would be worth double-checking.

## Testing Instructions

- Create/import a map and assign some districts. Confirm the Competitiveness metric on the Evaluate panel as well as on the Competitiveness Evaluate mode screen displays the new format as expected.
- Create an empty map or create/import a map with no PVI district data and confirm "N/A" displays as the Competitiveness metric

Closes #1050 
