### PR TITLE
Fix duplicate regions in Community Maps dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Improve PlanScore integration and display toast on errors [#1062](https://github.com/PublicMapping/districtbuilder/pull/1062)
+- Fix duplicate regions in Community Maps dropdown [#1070](https://github.com/PublicMapping/districtbuilder/pull/1070)
 
 ## [1.12.1] - 2021-10-29
 ### Fixed

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -37,7 +37,8 @@ import * as _ from "lodash";
       }
     },
     filter: {
-      archived: false
+      archived: false,
+      hidden: false
     }
   },
   routes: {


### PR DESCRIPTION
## Overview

The community maps page dropdown is currently showing duplicate states. This adds an option to ensure hidden regions are filtered out as part of the query request used to populate the dropdown (`api/region-configs/`).

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

New dropdown should not display duplicate options:
![Screen Shot 2021-11-19 at 12 56 30 PM](https://user-images.githubusercontent.com/36374797/142674610-aa49a81f-b86f-48ae-a464-38c24f20d55b.png)

SQL query output by `.scripts/server` includes hidden filter, highlighted below:
![Screen Shot 2021-11-19 at 12 58 02 PM](https://user-images.githubusercontent.com/36374797/142674625-92217d3d-42a7-444a-bad2-a80393ff5b2d.png)

## Testing Instructions

- Run `./scripts/server` and navigate to the community maps screen: `http://localhost:3003/maps`
- Click on the "Filter by State:" dropdown and confirm there are no duplicates
- In terminal, confirm SQL query output by `.scripts/server` includes hidden filter in the WHERE clause (see query in the Demo section)

Closes #1047 
