### PR TITLE
Add project-level metadata property to geojson export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add project-level info to geojson 'metadata' property [#1076](https://github.com/PublicMapping/districtbuilder/pull/1076)
+
 ### Changed
 
 - Update evaluate copy to reflect terminology to match the top level geo of the map [#1077](https://github.com/PublicMapping/districtbuilder/pull/1077)

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -9,11 +9,15 @@ import {
   DemographicCounts,
   PaginationMetadata,
   IProject,
-  IReferenceLayer
+  IReferenceLayer,
+  ProjectProperties
 } from "../shared/entities";
 
+// TODO #179: Move to shared/entities
 export type DistrictGeoJSON = Feature<MultiPolygon, DistrictProperties>;
-export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
+export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties> & {
+  readonly metadata?: ProjectProperties;
+};
 
 export interface DynamicProjectData {
   readonly project: IProject;

--- a/src/manage/src/commands/create-random-projects.ts
+++ b/src/manage/src/commands/create-random-projects.ts
@@ -79,7 +79,12 @@ export default class CreateRandomProjects extends Command {
       }
       const lockedDistricts = new Array(numberOfDistricts).fill(false);
       const numberOfMembers = new Array(numberOfDistricts).fill(1);
-      const districts = geoCollection.merge({ districts: districtsDefinition }, numberOfDistricts);
+      const districts = geoCollection.merge({
+        districtsDefinition,
+        numberOfDistricts,
+        user,
+        regionConfig: region
+      });
       if (!districts) {
         this.log(`Could not generate geojson`);
         this.exit(1);

--- a/src/server/src/chambers/chambers.module.ts
+++ b/src/server/src/chambers/chambers.module.ts
@@ -2,11 +2,12 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { Chamber } from "./entities/chamber.entity";
+import { ChambersService } from "./services/chambers";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Chamber])],
   controllers: [],
-  providers: [],
-  exports: []
+  providers: [ChambersService],
+  exports: [ChambersService, TypeOrmModule]
 })
 export class ChambersModule {}

--- a/src/server/src/chambers/services/chambers.ts
+++ b/src/server/src/chambers/services/chambers.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
+import { Repository } from "typeorm";
+
+import { Chamber } from "../entities/chamber.entity";
+
+@Injectable()
+export class ChambersService extends TypeOrmCrudService<Chamber> {
+  constructor(@InjectRepository(Chamber) repo: Repository<Chamber>) {
+    super(repo);
+  }
+}

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -2,7 +2,12 @@ import { FeatureCollection, MultiPolygon } from "geojson";
 import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
 import { ProjectVisibility } from "../../../../shared/constants";
-import { DistrictProperties, DistrictsDefinition, IProject } from "../../../../shared/entities";
+import {
+  DistrictProperties,
+  DistrictsDefinition,
+  IProject,
+  ProjectProperties
+} from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { Chamber } from "../../chambers/entities/chamber.entity";
 import { User } from "../../users/entities/user.entity";
@@ -13,7 +18,9 @@ import {
 } from "../../../../shared/constants";
 
 // TODO #179: Move to shared/entities
-export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
+export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties> & {
+  readonly metadata?: ProjectProperties;
+};
 
 @Entity()
 @Index("IDX_PUBLISHED_PROJECTS", { synchronize: false })

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -95,6 +95,16 @@ export type DistrictProperties = {
   /* eslint-enable */
 };
 
+export interface ProjectProperties {
+  readonly completed: boolean;
+  readonly creator: Pick<IUser, "id" | "name">;
+  readonly regionConfig: Pick<
+    IRegionConfig,
+    "id" | "name" | "countryCode" | "regionCode" | "s3URI"
+  >;
+  readonly chamber?: IChamber;
+}
+
 export interface IStaticFile {
   readonly id: string;
   readonly fileName: string;


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/144054687-cd71d6bb-6855-4f0b-8076-0e3e464f9355.png)

### Notes

We'll need to run `UPDATE region_config SET version = NOW();` after deploying this, to trigger a cache invalidation for all cached districts geojson.

## Testing Instructions

- Create a project for a region, (make sure to choose a chamber, instead of selecting "Custom" and entering a number of districts)
- Exporting the geojson for that project should show a new top-level `metadata` field with project-level properties
- If you update the project, or duplicate it from the homescreen flyout menu, the metadata should still be present
- If you duplicate another users project, the `creator` prperty in the `metadata` should be updated

Closes #1044 
