### PR TITLE
Change "county" in County Split copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,55 +6,77 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-### Changed
-### Fixed
 
+### Added
+
+### Changed
+
+- Update evaluate copy to reflect terminology to match the top level geo of the map [#1077](https://github.com/PublicMapping/districtbuilder/pull/1077)
+
+### Fixed
 
 ## [1.13.0] - 2021-11-30
+
 ### Added
-- Add support for creating/importing projects with multi-member districts [#1060](https://github.com/PublicMapping/districtbuilder/pull/1060) 
-- Add Map Configuration  modal [#1065](https://github.com/PublicMapping/districtbuilder/pull/1065)
+
+- Add support for creating/importing projects with multi-member districts [#1060](https://github.com/PublicMapping/districtbuilder/pull/1060)
+- Add Map Configuration modal [#1065](https://github.com/PublicMapping/districtbuilder/pull/1065)
+
 ### Changed
+
 - Update Competitiveness metric on Evaluate [#1068](https://github.com/PublicMapping/districtbuilder/pull/1068)
+
 ### Fixed
+
 - Improve PlanScore integration and display toast on errors [#1062](https://github.com/PublicMapping/districtbuilder/pull/1062)
 - Fix duplicate regions in Community Maps dropdown [#1070](https://github.com/PublicMapping/districtbuilder/pull/1070)
 
 ## [1.12.1] - 2021-10-29
+
 ### Fixed
+
 - Fix import for regions that have a geounit with 1 identical geometry nested under it [#1053](https://github.com/PublicMapping/districtbuilder/pull/1053)
 - Fix simplification for geojson with invalid geometries [#1054](https://github.com/PublicMapping/districtbuilder/pull/1054)
 - Fix population deviation tooltip [#1055](https://github.com/PublicMapping/districtbuilder/pull/1055)
 
 ## [1.12.0] - 2021-10-25
+
 ### Changed
+
 - Support negative/adjusted population values [#1043](https://github.com/PublicMapping/districtbuilder/pull/1043)
 
 ## [1.11.0] - 2021-10-11
+
 ### Added
+
 - Add support for demographic groups, to support VAP / CVAP fields [#1034](https://github.com/PublicMapping/districtbuilder/pull/1034)
 - Added bulk-reprocess-regions command [#1022](https://github.com/PublicMapping/districtbuilder/pull/1022)
 - Import using a project template [#1033](https://github.com/PublicMapping/districtbuilder/pull/1033)
 
 ### Changed
+
 - Don't require AWS credentials to load public S3 assets [#1036](https://github.com/PublicMapping/districtbuilder/pull/1036)
 - Blocks and blockgroups are now populated with FIPS code in name field [#1022](https://github.com/PublicMapping/districtbuilder/pull/1022)
 - The process-geojson command now returns non-zero exit codes on error [#1022](https://github.com/PublicMapping/districtbuilder/pull/1022)
 - The process-geojson, publish-region, and update-region commands now include the input file in the output [#1022](https://github.com/PublicMapping/districtbuilder/pull/1022)
 
 ## [1.10.1] - 2021-09-29
+
 ### Fixed
+
 - Fixed project import [#1029](https://github.com/PublicMapping/districtbuilder/pull/1029)
 - Copy project template id when duplicating project [#1037](https://github.com/PublicMapping/districtbuilder/pull/1037)
 
 ## [1.10.0] - 2021-09-28
+
 ### Added
+
 - Add support for uploading reference layers to a project [#902](https://github.com/PublicMapping/districtbuilder/pull/902)
 - Show / delete reference layers for a project [#999](https://github.com/PublicMapping/districtbuilder/pull/999)
 - Copy project template reference layers to project [#1018](https://github.com/PublicMapping/districtbuilder/pull/1018)
 
 ### Changed
+
 - Support extra demographic fields on metrics viewer [#984](https://github.com/PublicMapping/districtbuilder/pull/984)
 - Sort region configs by region code [#1004](https://github.com/PublicMapping/districtbuilder/pull/1004)
 - Fix mini-maps for DC and other small regions [#1009](https://github.com/PublicMapping/districtbuilder/pull/1009)
@@ -62,9 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.9.0] - 2021-08-30
 
 ### Changed
+
 - Updated copy on home screen for new users [#985](https://github.com/PublicMapping/districtbuilder/pull/985)
 - Disable migration transactions in order to create project indexes concurrently [#989](https://github.com/PublicMapping/districtbuilder/pull/989)
+
 ### Fixed
+
 - Disable Send to Plan Score button for incomplete projects [#957](https://github.com/PublicMapping/districtbuilder/pull/957)
 - Fix Send to Plan Score button for other users projects [#958](https://github.com/PublicMapping/districtbuilder/pull/958)
 - Restore Community Maps & fix API perf. [#969](https://github.com/PublicMapping/districtbuilder/pull/969)
@@ -79,10 +104,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.0] - 2021-08-19
 
 ### Added
+
 - Add levers to tune LB health check configuration [#950](https://github.com/PublicMapping/districtbuilder/pull/950)
 
-
 ### Changed
+
 - Parameterize `max_old_space_size` [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
 - Don't define container-level CPU reservation [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
 - Remove CPU and memory limits for tasks on EC2 [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
@@ -90,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scale `vm.max_map_count` with container memory usage [#942](https://github.com/PublicMapping/districtbuilder/pull/942)
 
 ### Fixed
+
 - Fix CSV import by increasing max JSON payload to 25mb [#951](https://github.com/PublicMapping/districtbuilder/pull/951)
 - Fix CSV export for other user's projects [#943](https://github.com/PublicMapping/districtbuilder/pull/943)
 
@@ -101,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retry regions that fail to load in TopologyService [#944](https://github.com/PublicMapping/districtbuilder/pull/944)
 
 ### Fixed
+
 - Fixed export GeoJSON endpoint cache busting [#940](https://github.com/PublicMapping/districtbuilder/pull/940)
 - Fixed EC2-based ECS setup to use correct container [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
 - Fixed healthcheck when archived regions are loaded [#938](https://github.com/PublicMapping/districtbuilder/pull/938)
@@ -108,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.1] - 2021-08-12
 
 ### Fixed
+
 - Fixed loading mini-maps for Projects w/o cached districts column [#928](https://github.com/PublicMapping/districtbuilder/pull/928)
 
 ## [1.7.0] - 2021-08-12

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "npm run clear_cache:eslint && react-scripts start",
+    "start": "CHOKIDAR_USEPOLLING=true npm run clear_cache:eslint && react-scripts start",
     "build": "npm run clear_cache:eslint && react-scripts build",
     "test": "npm run clear_cache:eslint && react-scripts test --testPathPattern=src/client",
     "eject": "react-scripts eject",

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -231,10 +231,20 @@ const ProjectEvaluateSidebar = ({
       name: `${geoLevel ? geoLevelLabelSingular(geoLevel) : ""} splits`,
       type: "count",
       description: "are split",
-      shortText:
-        "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
-      longText:
-        "County splits occur when a county is split between two or more districts. Some states require minimizing county splits, to the extent practicable.",
+      shortText: `${
+        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+      } occur when a ${
+        geoLevel ? geoLevel : "jurisdiction"
+      } is split between two or more districts. Some states require minimizing ${
+        geoLevel ? geoLevel : ""
+      } splits, to the extent practicable.`,
+      longText: `${
+        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+      } occur when a ${
+        geoLevel ? geoLevel : "jurisdiction"
+      } is split between two or more districts. Some states require minimizing ${
+        geoLevel ? geoLevel : ""
+      } splits, to the extent practicable.`,
       showInSummary: true,
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,


### PR DESCRIPTION
## Overview

The copy describing county splits wasn't always reflecting the right terminology that matched the top level geo of the map. This PR changes the copy to use the same word as the "County Splits" title.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-11-30 at 1 26 38 PM](https://user-images.githubusercontent.com/77936689/144107058-68d3f850-030f-4b0e-8483-2602bb848789.png)

## Testing Instructions

- Run `./scripts/server`
- Create a Dane County map using the Azavea's project template
- Click "Evaluate". You should see "Ward Splits" at the bottom under "Optional", as well as the word "ward" where there was the word "county".
- Create another map of anywhere but Dane County and click "Evaluate". The sidebar should now say "County Splits" and use the word "county".

Closes #1057 
