### PR TITLE
Change copy under Reference Layers on other users' maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Reference Layer copy on other user's maps to reflect map's readonly status [#1078](https://github.com/PublicMapping/districtbuilder/pull/1078)
+
 ## [1.13.0] - 2021-11-30
 
 ### Added

--- a/src/client/components/ProjectReferenceLayers.tsx
+++ b/src/client/components/ProjectReferenceLayers.tsx
@@ -120,7 +120,9 @@ const ProjectReferenceLayers = ({
             ))
           ) : referenceLayers !== undefined ? (
             <Box sx={{ pb: 1, maxWidth: "fit-content" }}>
-              Add a polygon or point layer as a reference layer for your map.
+              {isReadOnly
+                ? "This map has no reference layers. Copy the map to your account to add reference layers."
+                : "Add a polygon or point layer as a reference layer for your map."}
             </Box>
           ) : null}
           {!isReadOnly && (


### PR DESCRIPTION
## Overview

When viewing another user's map, the Reference Layer modal showed the same language as when viewing your own map about adding a layer. This PR changes that language to reflect the map's readonly status.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-12-02 at 7 43 24 AM](https://user-images.githubusercontent.com/77936689/144426921-7be4dcdf-e871-4f24-a8a3-b9286e663f43.png)

New language when viewing another person's map.

## Testing Instructions

- Run `./scripts/server`
- Open another user's map
- Click on the Reference Layers modal at the bottom of the sidebar. It should say "This map has no reference layers. Copy the map to your account to add reference layers."

Closes #1032 
