### PR TITLE
Increase VirtualBox memory in Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update evaluate copy to reflect terminology to match the top level geo of the map [#1077](https://github.com/PublicMapping/districtbuilder/pull/1077)
+- Increase alloted memory for VM in Vagrantfile [#1079](https://github.com/PublicMapping/districtbuilder/pull/1079)
 
 ### Fixed
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
   config.vm.provider :virtualbox do |vb|
-    vb.memory = 6144
+    vb.memory = 8192
     vb.cpus = 4
   end
 


### PR DESCRIPTION
## Overview

Some computers were killing the server while trying to run the VM due to the allotted memory for the VM being too small. This PR increases the allotted memory.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

I'm not sure what the ideal increase in memory is; this was enough for my computer to let the server run without seeming like an unnecessary amount of memory.

## Testing Instructions

- Run `vagrant up`, then `vagrant ssh`, and then `./scripts/server`
- If you open up the VirtualBox UI you should see that your VM's base memory has increased to 8192 MB
- Let the server start up and let it run for a few minutes. If your server was repeatedly being killed (like mine) with the original memory allotment, it should run without being killed now
