### PR TITLE
Add link to Medium blog to Resources menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add project-level info to geojson 'metadata' property [#1076](https://github.com/PublicMapping/districtbuilder/pull/1076)
 - Add instructions on configuring PG Admin and on releasing new region data [#1081](https://github.com/PublicMapping/districtbuilder/pull/1081)
+- Add blog link to Resource menu [#1083](https://github.com/PublicMapping/districtbuilder/pull/1083)
 
 ### Changed
 

--- a/src/client/components/SupportMenu.tsx
+++ b/src/client/components/SupportMenu.tsx
@@ -17,6 +17,8 @@ const guideLink =
 
 const contactLink = "mailto:support@districtbuilder.org";
 
+const blogLink = "https://medium.com/districtbuilder";
+
 const showKeyboardShortcuts = () => store.dispatch(toggleKeyboardShortcutsModal());
 
 interface StateProps {
@@ -48,6 +50,14 @@ const SupportMenu = ({ project, ...props }: SupportProps & StateProps) => {
               <Styled.a href={guideLink} target="_blank" sx={style.menuListItem}>
                 <Icon name="book-spells" sx={style.menuListIcon} />
                 Getting Started Guide
+              </Styled.a>
+            </MenuItem>
+          </li>
+          <li key={UserMenuKeys.Guide}>
+            <MenuItem value={UserMenuKeys.Guide}>
+              <Styled.a href={blogLink} target="_blank" sx={style.menuListItem}>
+                <Icon name="book-spells" sx={style.menuListIcon} />
+                Blog
               </Styled.a>
             </MenuItem>
           </li>

--- a/src/client/components/SupportMenu.tsx
+++ b/src/client/components/SupportMenu.tsx
@@ -9,6 +9,7 @@ import { toggleKeyboardShortcutsModal } from "../actions/districtDrawing";
 enum UserMenuKeys {
   Contact = "contact",
   Guide = "guide",
+  Blog = "blog",
   KeyboardShortcuts = "keyboardShortcuts"
 }
 
@@ -53,8 +54,8 @@ const SupportMenu = ({ project, ...props }: SupportProps & StateProps) => {
               </Styled.a>
             </MenuItem>
           </li>
-          <li key={UserMenuKeys.Guide}>
-            <MenuItem value={UserMenuKeys.Guide}>
+          <li key={UserMenuKeys.Blog}>
+            <MenuItem value={UserMenuKeys.Blog}>
               <Styled.a href={blogLink} target="_blank" sx={style.menuListItem}>
                 <Icon name="book-spells" sx={style.menuListIcon} />
                 Blog


### PR DESCRIPTION
## Overview

This PR adds a link to DistrictBuilder's Medium blog to the app's Resources menu.

### Checklist

- [X] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2021-12-06 at 11 30 56 AM](https://user-images.githubusercontent.com/77936689/144884389-e6417861-5eea-407c-bee2-1bc681c51bb0.png)

## Testing Instructions

- Run `./scripts/server`
- Click on the "Resources" tab in the righthand corner of the screen. You should see "Blog" as an option in the dropdown menu.
- Click on "Blog". It should bring you to the DistrictBuilder Medium webpage.

Closes #1026
