### PR TITLE
Fix Equal Population status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Reference Layer copy on other user's maps to reflect map's readonly status [#1078](https://github.com/PublicMapping/districtbuilder/pull/1078)
+- Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084] (https://github.com/PublicMapping/districtbuilder/pull/1084)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -50,13 +50,13 @@ const ProjectEvaluateSidebar = ({
   const featuresWithCompactness = geojson?.features
     .slice(1)
     .filter(f => f.properties.compactness !== 0);
-  const totalCompactness = featuresWithCompactness?.reduce(function (accumulator, feature) {
+  const totalCompactness = featuresWithCompactness?.reduce(function(accumulator, feature) {
     return accumulator + feature.properties.compactness;
   }, 0);
   const avgCompactness =
     totalCompactness !== undefined &&
-      featuresWithCompactness &&
-      featuresWithCompactness.length !== 0
+    featuresWithCompactness &&
+    featuresWithCompactness.length !== 0
       ? totalCompactness / featuresWithCompactness.length
       : undefined;
 
@@ -85,7 +85,6 @@ const ProjectEvaluateSidebar = ({
     }).length;
   const numDistrictsWithGeometries =
     geojson && geojson.features.filter(f => f.id !== 0 && f.geometry.coordinates.length > 0).length;
-
 
   const pviBuckets: readonly (PviBucket | undefined)[] | undefined =
     geojson &&
@@ -232,14 +231,20 @@ const ProjectEvaluateSidebar = ({
       name: `${geoLevel ? geoLevelLabelSingular(geoLevel) : ""} splits`,
       type: "count",
       description: "are split",
-      shortText: `${geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
-        } occur when a ${geoLevel ? geoLevel : "jurisdiction"
-        } is split between two or more districts. Some states require minimizing ${geoLevel ? geoLevel : ""
-        } splits, to the extent practicable.`,
-      longText: `${geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
-        } occur when a ${geoLevel ? geoLevel : "jurisdiction"
-        } is split between two or more districts. Some states require minimizing ${geoLevel ? geoLevel : ""
-        } splits, to the extent practicable.`,
+      shortText: `${
+        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+      } occur when a ${
+        geoLevel ? geoLevel : "jurisdiction"
+      } is split between two or more districts. Some states require minimizing ${
+        geoLevel ? geoLevel : ""
+      } splits, to the extent practicable.`,
+      longText: `${
+        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+      } occur when a ${
+        geoLevel ? geoLevel : "jurisdiction"
+      } is split between two or more districts. Some states require minimizing ${
+        geoLevel ? geoLevel : ""
+      } splits, to the extent practicable.`,
       showInSummary: true,
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,

--- a/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
+++ b/src/client/components/evaluate/ProjectEvaluateSidebar.tsx
@@ -50,13 +50,13 @@ const ProjectEvaluateSidebar = ({
   const featuresWithCompactness = geojson?.features
     .slice(1)
     .filter(f => f.properties.compactness !== 0);
-  const totalCompactness = featuresWithCompactness?.reduce(function(accumulator, feature) {
+  const totalCompactness = featuresWithCompactness?.reduce(function (accumulator, feature) {
     return accumulator + feature.properties.compactness;
   }, 0);
   const avgCompactness =
     totalCompactness !== undefined &&
-    featuresWithCompactness &&
-    featuresWithCompactness.length !== 0
+      featuresWithCompactness &&
+      featuresWithCompactness.length !== 0
       ? totalCompactness / featuresWithCompactness.length
       : undefined;
 
@@ -84,7 +84,8 @@ const ProjectEvaluateSidebar = ({
       );
     }).length;
   const numDistrictsWithGeometries =
-    geojson && geojson.features.filter(f => f.geometry.coordinates.length > 0).length;
+    geojson && geojson.features.filter(f => f.id !== 0 && f.geometry.coordinates.length > 0).length;
+
 
   const pviBuckets: readonly (PviBucket | undefined)[] | undefined =
     geojson &&
@@ -231,20 +232,14 @@ const ProjectEvaluateSidebar = ({
       name: `${geoLevel ? geoLevelLabelSingular(geoLevel) : ""} splits`,
       type: "count",
       description: "are split",
-      shortText: `${
-        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
-      } occur when a ${
-        geoLevel ? geoLevel : "jurisdiction"
-      } is split between two or more districts. Some states require minimizing ${
-        geoLevel ? geoLevel : ""
-      } splits, to the extent practicable.`,
-      longText: `${
-        geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
-      } occur when a ${
-        geoLevel ? geoLevel : "jurisdiction"
-      } is split between two or more districts. Some states require minimizing ${
-        geoLevel ? geoLevel : ""
-      } splits, to the extent practicable.`,
+      shortText: `${geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+        } occur when a ${geoLevel ? geoLevel : "jurisdiction"
+        } is split between two or more districts. Some states require minimizing ${geoLevel ? geoLevel : ""
+        } splits, to the extent practicable.`,
+      longText: `${geoLevel ? `${geoLevelLabelSingular(geoLevel)} splits` : "Splits"
+        } occur when a ${geoLevel ? geoLevel : "jurisdiction"
+        } is split between two or more districts. Some states require minimizing ${geoLevel ? geoLevel : ""
+        } splits, to the extent practicable.`,
       showInSummary: true,
       value: project?.districtsDefinition.filter(x => Array.isArray(x)).length || 0,
       total: project ? project.districtsDefinition.length : 0,


### PR DESCRIPTION
## Overview

Updates the status value for the Equal Population metric used to toggle between a green check and error image in the ProjectEvaluateSummary and ProjectEvaluateMetricDetail. Ensures that the filter used to gather districts with geometries doesn’t include the transparent placeholder “district”.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Ensure you have region configs for NY and import map: https://app.districtbuilder.org/projects/b9e492df-3acc-45bd-9b99-65810a48b29b 
- Confirm that green check mark displays in Equal Population summary 
- Confirm that green check mark displays in Equal Population detail
- In a different map, confirm image status still correctly displays as a red "x" when districts are outside of deviation threshold


Closes #1073 
