### PR TITLE
Fix disappearing user data on community maps page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Option to toggle which demographics to use for calculations [#1085](https://github.com/PublicMapping/districtbuilder/pull/1085)
 
 - Add project-level info to geojson 'metadata' property [#1076](https://github.com/PublicMapping/districtbuilder/pull/1076)
@@ -23,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Reference Layer copy on other user's maps to reflect map's readonly status [#1078](https://github.com/PublicMapping/districtbuilder/pull/1078)
-- Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084] (https://github.com/PublicMapping/districtbuilder/pull/1084)
+- Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084](https://github.com/PublicMapping/districtbuilder/pull/1084)
+- Fix disappearing user data on Community Maps page refresh [#1090](https://github.com/PublicMapping/districtbuilder/pull/1090)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -13,6 +13,8 @@ import {
   globalProjectsSetRegion
 } from "../actions/projects";
 import { UserState } from "../reducers/user";
+import { userFetch } from "../actions/user";
+import { isUserLoggedIn } from "../jwt";
 import FeaturedProjectCard from "../components/FeaturedProjectCard";
 import PaginationFooter from "../components/PaginationFooter";
 import { regionConfigsFetch } from "../actions/regionConfig";
@@ -66,6 +68,7 @@ const PublishedMapsListScreen = ({
   regionConfigs
 }: StateProps) => {
   const [regionCode, setRegionCode] = useQueryParam("region", StringParam);
+  const isLoggedIn = isUserLoggedIn();
 
   useEffect(() => {
     if (regionCode) {
@@ -82,6 +85,10 @@ const PublishedMapsListScreen = ({
   useEffect(() => {
     !regionConfigs && store.dispatch(regionConfigsFetch());
   }, [regionConfigs]);
+
+  useEffect(() => {
+    isLoggedIn && store.dispatch(userFetch());
+  }, [isLoggedIn]);
 
   const regionConfigOptions = regionConfigs
     ? [...regionConfigs]


### PR DESCRIPTION
## Overview

User data was not appearing on the Community Maps page when either navigated to directly or on page reload.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Run `vagrant up` &#8594; `vagrant ssh` &#8594; `./scripts/server`
- Navigate to **localhost:3003/maps**. The header and the user data should appear to the left as they do on all other pages.
- Refresh the page. Verify that the header and user data do not disappear.

Closes #1006 
