### PR TITLE
Display error message when there are too few districts in chamber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Reference Layer copy on other user's maps to reflect map's readonly status [#1078](https://github.com/PublicMapping/districtbuilder/pull/1078)
 - Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084](https://github.com/PublicMapping/districtbuilder/pull/1084)
 - Fix disappearing user data on Community Maps page refresh [#1090](https://github.com/PublicMapping/districtbuilder/pull/1090)
+- Fix lack of error message in the import page when selecting a chamber with too few districts [#1091](https://github.com/PublicMapping/districtbuilder/pull/1091)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -36,7 +36,7 @@ import { regionConfigsFetch } from "../actions/regionConfig";
 import { setImportFlagsModal } from "../actions/projectModals";
 
 import { createProject, importCsv, fetchTotalPopulation } from "../api";
-import { InputField } from "../components/Field";
+import Field, { InputField } from "../components/Field";
 import Icon from "../components/Icon";
 import ImportFlagsModal from "../components/ImportFlagsModal";
 import { ReactComponent as Logo } from "../media/logos/mark-white.svg";
@@ -444,11 +444,12 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
 
   useEffect(() => {
     // Set error if number of districts less than max district ID
-    if (
-      formData.numberOfDistricts !== null &&
-      maxDistrictId !== undefined &&
-      formData.numberOfDistricts < maxDistrictId
-    ) {
+    const selectedDistrict = formData.numberOfDistricts
+      ? formData.numberOfDistricts < maxDistrictId
+      : formData.chamber?.numberOfDistricts
+      ? formData.chamber.numberOfDistricts < maxDistrictId
+      : null;
+    if (maxDistrictId !== undefined && selectedDistrict) {
       setCreateProjectResource({
         data: formData,
         errors: {
@@ -735,6 +736,11 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
                                 }}
                               />
                             </Box>
+                          ) : "errors" in createProjectResource ? (
+                            <Field
+                              field="numberOfDistricts"
+                              resource={createProjectResource}
+                            ></Field>
                           ) : null}
                           <Divider sx={{ width: "100%" }} />
                           <Box>


### PR DESCRIPTION
## Overview

Initially the error message indicating that the user had chosen too few districts for the CSV provided was only displayed when the custom number of districts was too small. This PR adds the error message when the chosen chamber has too few districts, as well.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-01-04 at 2 52 38 PM](https://user-images.githubusercontent.com/77936689/148115873-64035dd0-31cc-4517-bcd4-01160b894a56.png)

## Testing Instructions

- Run `vagrant up` &#8594; `vagrant ssh` &#8594; `./scripts/server`
- Find a csv of a state with more districts than chamber districts. I used one [this one](https://app.districtbuilder.org/projects/b45854cb-b318-492b-9a12-3dd96da1f862), which has 22 districts compared to Illinois' 18 House of Representative districts.
- Navigate to **http://localhost:3003/import-project** and import your csv.
- Click the "House of Representatives" district choice. The error message should appear.

Closes #1028 
