### PR TITLE
Add more descriptive titles to app pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase alloted memory for VM in Vagrantfile [#1079](https://github.com/PublicMapping/districtbuilder/pull/1079)
 - Update README with clearer instructions on email verification [#1082](https://github.com/PublicMapping/districtbuilder/pull/1082)
 - Update Node / Nest.JS / TypeORM / eslint / prettier [#1082](https://github.com/PublicMapping/districtbuilder/pull/1088)
+- Change page titles to be more descriptive [#1096](https://github.com/PublicMapping/districtbuilder/pull/1096)
 
 ### Fixed
 

--- a/src/client/screens/CreateProjectScreen.tsx
+++ b/src/client/screens/CreateProjectScreen.tsx
@@ -217,6 +217,11 @@ const CreateProjectScreen = ({ regionConfigs, user, organization }: StateProps) 
       fetchTotalPopulation(data.regionConfig).then(population => setTotalPopulation(population));
   }, [data.regionConfig]);
 
+  useEffect(() => {
+    //eslint-disable-next-line
+    document.title = "DistrictBuilder | New Map";
+  });
+
   return "resource" in createProjectResource ? (
     <Redirect to={`/projects/${createProjectResource.resource.id}`} />
   ) : (

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -39,6 +39,11 @@ const HomeScreen = ({ projects, isSaving, duplicatedProject, user, pagination }:
     isLoggedIn && store.dispatch(userFetch());
   }, [isLoggedIn]);
 
+  useEffect(() => {
+    //eslint-disable-next-line
+    document.title = "DistrictBuilder | My Maps";
+  });
+
   return isSaving === "saved" && duplicatedProject !== null ? (
     <Redirect to={`/projects/${duplicatedProject.id}`} />
   ) : (

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -439,6 +439,11 @@ const ImportProjectScreen = ({ organization, regionConfigs, user }: StateProps) 
   }, [organization]);
 
   useEffect(() => {
+    //eslint-disable-next-line
+    document.title = "DistrictBuilder | Import Map";
+  });
+
+  useEffect(() => {
     handleFileUpload();
   }, [file, templateData]);
 

--- a/src/client/screens/OrganizationScreen.tsx
+++ b/src/client/screens/OrganizationScreen.tsx
@@ -192,6 +192,12 @@ const OrganizationScreen = ({ organization, organizationProjects, user }: StateP
     store.dispatch(organizationFeaturedProjectsFetch(organizationSlug));
   }, [organizationSlug]);
 
+  useEffect(() => {
+    //eslint-disable-next-line
+    document.title =
+      "DistrictBuilder " + ("resource" in organization ? `| ${organization.resource.name}` : "");
+  });
+
   function signupAndJoinOrg() {
     store.dispatch(showCopyMapModal(true));
   }

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -147,6 +147,11 @@ const ProjectScreen = ({
     projectId && store.dispatch(projectDataFetch(projectId));
   }, [projectId, isLoggedIn]);
 
+  useEffect(() => {
+    //eslint-disable-next-line
+    document.title = "DistrictBuilder " + (project ? `| ${project.name}` : "");
+  });
+
   return isFirstLoadPending ? (
     <CenteredContent>
       <Flex sx={{ justifyContent: "center" }}>

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -90,6 +90,11 @@ const PublishedMapsListScreen = ({
     isLoggedIn && store.dispatch(userFetch());
   }, [isLoggedIn]);
 
+  useEffect(() => {
+    //eslint-disable-next-line
+    document.title = "DistrictBuilder | Community Maps " + (regionCode ? `| ${regionCode}` : "");
+  });
+
   const regionConfigOptions = regionConfigs
     ? [...regionConfigs]
         .sort((a, b) => a.regionCode.localeCompare(b.regionCode))


### PR DESCRIPTION
## Overview

This PR changes the title for the landing page, organization, community maps, map/project view, new map, and import project pages to provide better search optimization and insight into page content.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-01-05 at 3 54 36 PM](https://user-images.githubusercontent.com/77936689/148289082-eb630cc5-c647-4faf-ac7a-c0fe3bd61241.png)

This new title is visible in the browser tab.

### Notes

I tried to condense and centralize the logic of this into one place so that title changed at the parent component level using a dictionary mapping paths to titles to find and change each component's relevant title on path change. However, I ultimately decided that this method wasn't going to work with React's "no side effects" architecture, as it required the parent components to have an idea of what was happening with the smaller components. So I went with what feels like a clunkier but more React-friendly method.

## Testing Instructions

- Run `vagrant up` &#8594; `vagrant ssh` &#8594; `./scripts/server`
- Navigate to http://localhost:3003/. You should see that the browser tab says "DistrictBuilder | My Maps"
- Check the organization, map/project, new map, and import project pages. Each should have a similar title, saying "DistrictBuilder |" followed by the organization name, project name, "New Map", and "Import Map" respectively.
- Go to the Community Maps page and verify the "DistrictBuilder | Community Maps" title is there. Then filter for a particular state and verify that the tab now says "DistrictBuilder | Community Maps | [state abbreviation]".

Closes #1063 
