### PR TITLE
Switch to a more performant way of calculating maximum district ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084](https://github.com/PublicMapping/districtbuilder/pull/1084)
 - Fix disappearing user data on Community Maps page refresh [#1090](https://github.com/PublicMapping/districtbuilder/pull/1090)
 - Fix lack of error message in the import page when selecting a chamber with too few districts [#1091](https://github.com/PublicMapping/districtbuilder/pull/1091)
+- Fix import performance on larger regions [#1100](https://github.com/PublicMapping/districtbuilder/pull/1100)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -141,7 +141,7 @@ export class DistrictsController {
     );
     const districtsDefinition = geoCollection.importFromCSV(blockToDistricts);
 
-    const maxDistrictId = Math.max(...Object.values(blockToDistricts));
+    const maxDistrictId = Object.values(blockToDistricts).reduce((a, b) => Math.max(a, b), 0);
     const rowFlags = flaggedRows.filter(r => !!r);
     const numFlags = rowFlags.length;
 


### PR DESCRIPTION
## Overview

Upgrading Node.js on the backend uncovered a lingering performance issue in the CSV import in our use of `Math.max`, which we are using to detect the maximum district ID in the CSV. This caused the import to fail for larger states.

Per MDN, using `Math.max(...array)` on a large array is not recommended, and instead they suggest using reduce:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max#getting_the_maximum_element_of_an_array

Switching to the form suggested by MDN for large arrays fixed the issue.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

I searched the codebase for similar problematic uses of `Math.min` or `Math.max` and this was the only one case where we were using it on a very large array.

## Testing Instructions

- Attempt to import a map for a larger state like PA or NJ. On `develop` it will fail, on this branch it will succeed.

Closes #1098

