### PR TITLE
Run reindex on monthly schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project-level info to geojson 'metadata' property [#1076](https://github.com/PublicMapping/districtbuilder/pull/1076)
 - Add instructions on configuring PG Admin and on releasing new region data [#1081](https://github.com/PublicMapping/districtbuilder/pull/1081)
 - Add blog link to Resource menu [#1083](https://github.com/PublicMapping/districtbuilder/pull/1083)
+- Added cron task to REINDEX project table monthly [#1101](https://github.com/PublicMapping/districtbuilder/pull/1101)
 
 ### Changed
 

--- a/deployment/terraform/scheduled_tasks.tf
+++ b/deployment/terraform/scheduled_tasks.tf
@@ -1,0 +1,35 @@
+resource "aws_cloudwatch_event_rule" "reindex_task" {
+  name                = "reindex-scheduled-ecs-event-rule"
+  // Run monthly at 5AM UTC (midnight EST)
+  schedule_expression = "cron(0 5 1 * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "reindex_task" {
+  target_id = "reindex-scheduled-ecs-event-rule"
+  rule      = aws_cloudwatch_event_rule.reindex_task.name
+  arn       = aws_ecs_cluster.app.arn
+  role_arn  = aws_iam_role.ecs_task_role.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.app.arn
+    // Reindex task doesn't load TopoJSON, so we can run it on Fargate
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets         = module.vpc.private_subnet_ids
+      // TODO: check if thi is really necessary
+      assign_public_ip = true
+      security_groups  = [aws_security_group.app.id]
+    }
+  }
+  input = <<DOC
+  {
+    "containerOverrides": [
+      {
+        "name": "app",
+        "command": ["run", "reindex"]
+      }
+    ]
+  }
+  DOC
+}

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -13,6 +13,7 @@
     "start:prod": "node dist/server/src/main",
     "lint": "eslint 'src/**/*.{ts,tsx,json}'",
     "fix": "eslint 'src/**/*.{ts,tsx,json}' --fix",
+    "reindex": "node dist/server/src/commands/reindex",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/server/src/commands/reindex.ts
+++ b/src/server/src/commands/reindex.ts
@@ -1,0 +1,27 @@
+import { Logger } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "../app.module";
+import { DEBUG } from "../common/constants";
+import { Connection } from "typeorm";
+
+async function bootstrap(): Promise<void> {
+  const logger = new Logger();
+  const app = await NestFactory.create(AppModule, {
+    logger: DEBUG ? ["debug", "verbose", "log", "warn", "error"] : ["log", "warn", "error"]
+  });
+
+  const connection = app.get(Connection);
+  const queryRunner = connection.createQueryRunner();
+  await queryRunner.connect();
+  try {
+    logger.log("Running REINDEX on project table");
+    await queryRunner.query("REINDEX TABLE CONCURRENTLY project");
+  } catch (e) {
+    logger.error("REINDEX on project table failed");
+  } finally {
+    await queryRunner.release();
+  }
+
+  await app.close();
+}
+bootstrap(); // eslint-disable-line @typescript-eslint/no-floating-promises

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -57,9 +57,12 @@ export class TopologyService {
   private readonly logger = new Logger(TopologyService.name);
   private readonly s3 = new S3();
 
-  constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
-    void repo.find().then(regionConfigs => {
+  constructor(@InjectRepository(RegionConfig) private readonly repo: Repository<RegionConfig>) {}
+
+  public loadLayers() {
+    void this.repo.find().then(regionConfigs => {
       const getLayers = async () => {
+        // eslint-disable-next-line functional/immutable-data
         this._layers = regionConfigs.reduce(
           (layers, regionConfig) => ({
             ...layers,
@@ -77,6 +80,7 @@ export class TopologyService {
         await asyncLoop(
           sortedRegions.map(region => () => {
             const promise = this.fetchLayer(region.s3URI, region.archived);
+            // eslint-disable-next-line functional/immutable-data
             this._layers = { ...this._layers, [region.s3URI]: promise };
             return promise;
           }),

--- a/src/server/src/main.ts
+++ b/src/server/src/main.ts
@@ -5,6 +5,8 @@ import { AppModule } from "./app.module";
 import { BadRequestExceptionFilter } from "./common/bad-request-exception.filter";
 import { DEBUG } from "./common/constants";
 import * as bodyParser from "body-parser";
+import { DistrictsModule } from "./districts/districts.module";
+import { TopologyService } from "./districts/services/topology.service";
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule, {
@@ -22,6 +24,10 @@ async function bootstrap(): Promise<void> {
   app.useGlobalFilters(new BadRequestExceptionFilter());
   app.use(bodyParser.json({ limit: "25mb" }));
   app.use(bodyParser.urlencoded({ limit: "25mb", extended: true }));
+
+  // Start TopoJSON loading
+  const topologyService = app.select(DistrictsModule).get(TopologyService, { strict: true });
+  topologyService.loadLayers();
 
   // Save the output of 'listen' to a variable, which is a Node http.Server
   const server = await app.listen(3005);

--- a/src/server/test/districts.controller.e2e-spec.ts
+++ b/src/server/test/districts.controller.e2e-spec.ts
@@ -7,6 +7,7 @@ import { IRegionConfig } from "../../shared/entities";
 import { RegionConfig } from "../src/region-configs/entities/region-config.entity";
 import { RegionConfigsService } from "../src/region-configs/services/region-configs.service";
 import { DistrictsModule } from "../src/districts/districts.module";
+import { TopologyService } from "../src/districts/services/topology.service";
 
 describe("DistrictsController", () => {
   let app: INestApplication;
@@ -37,6 +38,7 @@ describe("DistrictsController", () => {
 
     app = moduleRef.createNestApplication();
     await app.init();
+    app.select(DistrictsModule).get(TopologyService, { strict: true }).loadLayers();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Overview

Our largest table gets many frequent updates, leading over time to index bloat.
I have been manually running `REINDEX TABLE CONCURRENTLY project`, but we would prefer to do this automatically, not manually.

This PR aims to achieve that by creating a [stand-alone Nest.js application](https://docs.nestjs.com/standalone-applications) which runs `REINDEX`, and then calling that via a scheduled ECS task.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

 - This is both our first scheduled ECS task as well as our first stand-alone Nest.js application, so I didn't have any internal examples to draw on. Other than the documentation, I also used this [blog post](https://vthub.medium.com/running-ecs-fargate-tasks-on-a-schedule-fd1ca428e669) for inspiration.
 - ~This builds on top of #1099, I'll rebase this and change the base branch the PR is pointing to once that's merged~
 
## Testing Instructions

I'm not quite sure how to test this end-to-end.

I've run the `reindex` script locally, as well as ran `scripts/infra plan` and saw the new resources I expect in the plan output, though I haven't run `scripts/infra apply` yet (nor do I know of a great way to verify this works other than waiting until February)

Closes #1086 
