### PR TITLE
Create template from project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add modal to allow organization admins to create templates from projects [#1107](https://github.com/PublicMapping/districtbuilder/pull/1107)
 
 ### Changed
 

--- a/src/client/actions/projects.ts
+++ b/src/client/actions/projects.ts
@@ -20,6 +20,10 @@ export const setDeleteProject = createAction("Set the id for the delete project 
   IProject | undefined
 >();
 
+export const setTemplateProject = createAction("Set the id for the template project modal")<
+  IProject | undefined
+>();
+
 export const projectArchive = createAction("Archive project")<ProjectId>();
 export const projectArchiveSuccess = createAction("Archive project success")<IProject>();
 export const projectArchiveFailure = createAction("Archive project failure")<string>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -20,7 +20,9 @@ import {
   PlanScoreAPIResponse,
   IReferenceLayer,
   ReferenceLayerId,
-  CreateReferenceLayerData
+  CreateReferenceLayerData,
+  IProjectTemplate,
+  CreateProjectTemplateData
 } from "../shared/entities";
 import {
   DistrictsGeoJSON,
@@ -371,6 +373,18 @@ export async function fetchOrganizationProjects(
       .catch(error => {
         reject(error.response.data);
       });
+  });
+}
+
+export async function createProjectTemplate(
+  slug: OrganizationSlug,
+  data: CreateProjectTemplateData
+): Promise<IProjectTemplate> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/project_templates/${slug}`, data)
+      .then(response => resolve(response.data))
+      .catch(error => reject(error.response?.data || error));
   });
 }
 

--- a/src/client/components/HomeScreenProjectCard.tsx
+++ b/src/client/components/HomeScreenProjectCard.tsx
@@ -61,7 +61,13 @@ const style: Record<string, ThemeUIStyleObject> = {
   }
 };
 
-const HomeScreenProjectCard = ({ project }: { readonly project: IProject }) => {
+const HomeScreenProjectCard = ({
+  project,
+  isOrganizationAdmin
+}: {
+  readonly project: IProject;
+  readonly isOrganizationAdmin: boolean;
+}) => {
   const history = useHistory();
 
   function goToProject(project: IProject) {
@@ -100,7 +106,7 @@ const HomeScreenProjectCard = ({ project }: { readonly project: IProject }) => {
         </Text>
       </Box>
       <span sx={style.flyoutButton}>
-        <ProjectListFlyout project={project} />
+        <ProjectListFlyout project={project} isOrganizationAdmin={isOrganizationAdmin} />
       </span>
     </Flex>
   );

--- a/src/client/components/ProjectListFlyout.tsx
+++ b/src/client/components/ProjectListFlyout.tsx
@@ -6,19 +6,21 @@ import { style, invertStyles } from "./MenuButton.styles";
 import Icon from "./Icon";
 import store from "../store";
 import { exportCsv, exportGeoJson, exportShp, duplicateProject } from "../actions/projectData";
-import { setDeleteProject } from "../actions/projects";
+import { setDeleteProject, setTemplateProject } from "../actions/projects";
 
 enum UserMenuKeys {
   Delete = "delete",
   CopyMap = "copy",
   ExportCsv = "csv",
   ExportShapefile = "shp",
-  ExportGeoJson = "geojson"
+  ExportGeoJson = "geojson",
+  CreateTemplate = "createtemplate"
 }
 
 interface FlyoutProps {
   readonly invert?: boolean;
   readonly project: IProject;
+  readonly isOrganizationAdmin: boolean;
 }
 
 // Flyout ("..." button) for each project on the project list page.
@@ -39,7 +41,9 @@ const ProjectListFlyout = (props: FlyoutProps) => {
             ? exportShp
             : userMenuKey === UserMenuKeys.CopyMap
             ? duplicateProject
-            : exportGeoJson;
+            : userMenuKey === UserMenuKeys.ExportGeoJson
+            ? exportGeoJson
+            : setTemplateProject;
         store.dispatch(action(props.project));
       }}
       sx={{ display: "inline-block" }}
@@ -56,25 +60,40 @@ const ProjectListFlyout = (props: FlyoutProps) => {
       </MenuButton>
       <Menu sx={{ ...style.menu }}>
         <ul sx={style.menuList}>
-          <li key={UserMenuKeys.ExportCsv}>
+          <li key={UserMenuKeys.ExportShapefile}>
             <MenuItem value={UserMenuKeys.ExportShapefile}>
               <Box sx={style.menuListItem}>Export Shapefile</Box>
             </MenuItem>
-            {!isArchived && (
+          </li>
+          {!isArchived && (
+            <li key={UserMenuKeys.ExportCsv}>
               <MenuItem value={UserMenuKeys.ExportCsv}>
                 <Box sx={style.menuListItem}>Export CSV</Box>
               </MenuItem>
-            )}
+            </li>
+          )}
+          <li key={UserMenuKeys.ExportGeoJson}>
             <MenuItem value={UserMenuKeys.ExportGeoJson}>
               <Box sx={style.menuListItem}>Export GeoJSON</Box>
             </MenuItem>
+          </li>
+          <li key={UserMenuKeys.CopyMap}>
             <MenuItem value={UserMenuKeys.CopyMap}>
               <Box sx={style.menuListItem}>Duplicate Map</Box>
             </MenuItem>
+          </li>
+          <li key={UserMenuKeys.Delete}>
             <MenuItem value={UserMenuKeys.Delete}>
               <Box sx={style.menuListItem}>Delete Map</Box>
             </MenuItem>
           </li>
+          {props.isOrganizationAdmin && (
+            <li key={UserMenuKeys.CreateTemplate}>
+              <MenuItem value={UserMenuKeys.CreateTemplate}>
+                <Box sx={style.menuListItem}>Copy to Template</Box>
+              </MenuItem>
+            </li>
+          )}
         </ul>
       </Menu>
     </Wrapper>

--- a/src/client/components/TemplateFromProjectModal.tsx
+++ b/src/client/components/TemplateFromProjectModal.tsx
@@ -1,0 +1,193 @@
+/** @jsx jsx */
+import AriaModal from "react-aria-modal";
+import { connect } from "react-redux";
+import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject, Select, Label } from "theme-ui";
+
+import Icon from "./Icon";
+import { IProject, IProjectTemplate, OrganizationNest } from "../../shared/entities";
+import { setTemplateProject } from "../actions/projects";
+import { State } from "../reducers";
+import store from "../store";
+import React, { useState } from "react";
+import { WriteResource } from "../resource";
+import { InputField } from "./Field";
+import { createProjectTemplate } from "../api";
+import { useHistory } from "react-router-dom";
+
+const style: Record<string, ThemeUIStyleObject> = {
+  modal: {
+    bg: "muted",
+    p: 3,
+    width: "small",
+    maxWidth: "90vw"
+  },
+  header: {
+    bg: "error",
+    padding: "16px 12px",
+    margin: "-12px -12px 24px"
+  },
+  footer: {
+    flex: "auto",
+    textAlign: "right",
+    fontVariant: "tabular-nums",
+    py: 2,
+    mt: 2,
+    fontSize: 1
+  }
+};
+
+interface Form {
+  readonly organization?: OrganizationNest;
+  readonly description: string;
+  readonly details: string;
+}
+
+function validate(form: Form): boolean {
+  return form.organization !== undefined && form.description !== "" && form.details !== "";
+}
+
+const TemplateFromProjectModal = ({
+  project,
+  adminOrganizations
+}: {
+  readonly project?: IProject;
+  readonly adminOrganizations: readonly OrganizationNest[];
+}) => {
+  const history = useHistory();
+  const hideModal = () => store.dispatch(setTemplateProject(undefined));
+  const [resource, setResource] = useState<WriteResource<Form, IProjectTemplate>>({
+    data: {
+      organization: adminOrganizations.length === 1 ? adminOrganizations[0] : undefined,
+      description: "",
+      details: ""
+    }
+  });
+
+  return project !== undefined && adminOrganizations.length !== 0 ? (
+    <AriaModal
+      titleId="template-project-modal-header"
+      onExit={hideModal}
+      initialFocus="#cancel-template-project"
+      getApplicationNode={() => document.getElementById("root") as Element}
+      underlayStyle={{ paddingTop: "4.5rem" }}
+    >
+      <Box
+        sx={style.modal}
+        as="form"
+        onSubmit={(e: React.FormEvent) => {
+          e.preventDefault();
+          const { description, details } = resource.data;
+          const slug = resource.data.organization?.slug;
+
+          if (slug) {
+            setResource({ ...resource, isPending: true });
+            createProjectTemplate(slug, {
+              description,
+              details,
+              project: { id: project.id }
+            })
+              .then(() => {
+                hideModal();
+                history.push(`/o/${slug}`);
+              })
+              .catch(errors => {
+                setResource({ ...resource, errors });
+              });
+          }
+        }}
+      >
+        <Box sx={style.header}>
+          <Heading
+            as="h3"
+            sx={{
+              marginBottom: "0",
+              fontWeight: "medium",
+              display: "flex",
+              alignItems: "center",
+              color: "muted"
+            }}
+            id="template-project-modal-header"
+          >
+            <span sx={{ fontSize: 4, mr: 2, display: "flex" }}>
+              <Icon name="alert-triangle" />
+            </span>
+            Create Template from Map
+          </Heading>
+        </Box>
+        <Box>
+          {/* If the user is only the admin of 1 organization, they don't need a dropdown */}
+          {adminOrganizations.length > 1 && (
+            <Select
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                const organization = adminOrganizations.find(
+                  org => org.slug === e.currentTarget.value
+                );
+                setResource({ ...resource, data: { ...resource.data, organization } });
+              }}
+            >
+              <option>Select organization...</option>
+              {adminOrganizations.map(org => (
+                <option key={org.slug} value={org.slug}>
+                  {org.name}
+                </option>
+              ))}
+            </Select>
+          )}
+        </Box>
+        <Box>
+          <InputField
+            field="description"
+            label="Description"
+            resource={resource}
+            inputProps={{
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                const description = e.currentTarget.value;
+                setResource({ ...resource, data: { ...resource.data, description } });
+              }
+            }}
+          />
+        </Box>
+        <Box>
+          <Label>Details</Label>
+          <textarea
+            sx={{ width: "100%", resize: "vertical", minHeight: "4rem" }}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+              const details = e.currentTarget.value;
+              setResource({ ...resource, data: { ...resource.data, details } });
+            }}
+          ></textarea>
+        </Box>
+        <Box>
+          {`Do you want to create a template from “${project.name}” for the “${
+            resource.data.organization?.name || "—"
+          }” organization?`}
+        </Box>
+        <Flex sx={style.footer}>
+          <Button
+            id="cancel-template-project"
+            onClick={hideModal}
+            type="button"
+            sx={{ variant: "buttons.secondary", mr: 2 }}
+          >
+            Cancel
+          </Button>
+          <Button
+            sx={{ variant: "buttons.danger" }}
+            disabled={("isPending" in resource && resource.isPending) || !validate(resource.data)}
+            type="submit"
+          >
+            Create template
+          </Button>
+        </Flex>
+      </Box>
+    </AriaModal>
+  ) : null;
+};
+
+function mapStateToProps(state: State) {
+  return {
+    project: state.projects.templateProject
+  };
+}
+
+export default connect(mapStateToProps)(TemplateFromProjectModal);

--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -15,7 +15,8 @@ import {
   userProjectsFetch,
   userProjectsFetchSuccess,
   userProjectsFetchFailure,
-  userProjectsFetchPage
+  userProjectsFetchPage,
+  setTemplateProject
 } from "../actions/projects";
 
 import { IProject, PaginationMetadata } from "../../shared/entities";
@@ -27,6 +28,7 @@ export interface ProjectsState {
   readonly projects: Resource<readonly IProject[]>;
   readonly globalProjects: Resource<readonly IProject[]>;
   readonly deleteProject?: IProject;
+  readonly templateProject?: IProject;
   readonly globalProjectsPagination: PaginationMetadata;
   readonly userProjectsPagination: PaginationMetadata;
   readonly globalProjectsRegion: string | null;
@@ -170,6 +172,11 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
       return {
         ...state,
         deleteProject: action.payload
+      };
+    case getType(setTemplateProject):
+      return {
+        ...state,
+        templateProject: action.payload
       };
     case getType(projectArchive):
       return loop(

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import SiteHeader from "../components/SiteHeader";
 import HomeScreenProjectCard from "../components/HomeScreenProjectCard";
 import { SavingState } from "../types";
 import { Redirect } from "react-router-dom";
+import TemplateFromProjectModal from "../components/TemplateFromProjectModal";
 
 interface StateProps {
   readonly projects: Resource<readonly IProject[]>;
@@ -33,6 +34,7 @@ const HomeScreen = ({ projects, isSaving, duplicatedProject, user, pagination }:
   const isLoggedIn = isUserLoggedIn();
   const projectList =
     "resource" in projects ? projects.resource.filter(project => !project.archived) : [];
+  const isOrganizationAdmin = "resource" in user && user.resource.adminOrganizations.length > 0;
 
   useEffect(() => {
     isLoggedIn && store.dispatch(userProjectsFetch());
@@ -49,6 +51,9 @@ const HomeScreen = ({ projects, isSaving, duplicatedProject, user, pagination }:
   ) : (
     <Flex sx={{ flexDirection: "column" }}>
       <DeleteProjectModal />
+      {"resource" in user && (
+        <TemplateFromProjectModal adminOrganizations={user.resource.adminOrganizations} />
+      )}
       <SiteHeader user={user} />
       <Flex
         as="main"
@@ -88,7 +93,11 @@ const HomeScreen = ({ projects, isSaving, duplicatedProject, user, pagination }:
               }}
             >
               {projectList.map((project: IProject) => (
-                <HomeScreenProjectCard project={project} key={project.id} />
+                <HomeScreenProjectCard
+                  project={project}
+                  key={project.id}
+                  isOrganizationAdmin={isOrganizationAdmin}
+                />
               ))}
               {pagination.totalPages && (
                 <Box

--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -66,7 +66,8 @@ export class AuthService {
       email: user.email,
       isEmailVerified: user.isEmailVerified,
       hasSeenTour: user.hasSeenTour,
-      organizations: user.organizations
+      organizations: user.organizations,
+      adminOrganizations: user.adminOrganizations
     };
     return this.jwtService.sign(payload);
   }

--- a/src/server/src/project-templates/controllers/project-templates.controller.ts
+++ b/src/server/src/project-templates/controllers/project-templates.controller.ts
@@ -9,7 +9,9 @@ import {
   Header,
   UnauthorizedException,
   HostParam,
-  InternalServerErrorException
+  InternalServerErrorException,
+  Post,
+  Body
 } from "@nestjs/common";
 import stringify from "csv-stringify/lib/sync";
 
@@ -24,6 +26,9 @@ import { ProjectTemplatesService } from "../services/project-templates.service";
 import { TopologyService } from "../../districts/services/topology.service";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
 import { getDemographicLabel } from "../../../../shared/functions";
+import { CreateProjectTemplateDto } from "../entities/create-project-template.dto";
+import { ProjectsService } from "../../projects/services/projects.service";
+import { ReferenceLayersService } from "../../reference-layers/services/reference-layers.service";
 
 function getIds(
   topoLayers: { [s3uri: string]: GeoUnitTopology },
@@ -43,6 +48,8 @@ function getIds(
 export class ProjectTemplatesController {
   constructor(
     private readonly service: ProjectTemplatesService,
+    private readonly projectsService: ProjectsService,
+    private readonly referenceLayersService: ReferenceLayersService,
     private readonly orgService: OrganizationsService,
     private readonly topologyService: TopologyService
   ) {}
@@ -77,6 +84,51 @@ export class ProjectTemplatesController {
     } else {
       throw new BadRequestException(`User is not an admin for organization ${organizationSlug}`);
     }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(":slug/")
+  async createTemplate(
+    @Param("slug") organizationSlug: OrganizationSlug,
+    @Request() req: any,
+    @Body() dto: CreateProjectTemplateDto
+  ): Promise<ProjectTemplate> {
+    const userId = req.user.id;
+    const org = await this.getOrg(organizationSlug);
+    const userIsAdmin = org && org.admin.id === userId;
+    if (!userIsAdmin) {
+      throw new BadRequestException(`User is not an admin for organization ${organizationSlug}`);
+    }
+    const project = await this.projectsService.findOne(dto.project.id, {
+      relations: ["regionConfig", "chamber"]
+    });
+    if (!project) {
+      throw new NotFoundException(`Project ${dto.project.id} not found`);
+    }
+
+    const projectTemplate = await this.service.createFromProject(
+      dto.description,
+      dto.details,
+      org,
+      project
+    );
+
+    const refLayers = await this.referenceLayersService.getProjectReferenceLayers(project.id);
+    // We need to wait for reference layers to be copied, but then we don't
+    // actually need to do anything with the result
+    await Promise.all(
+      refLayers.map(refLayer =>
+        this.referenceLayersService.create({
+          name: refLayer.name,
+          label_field: refLayer.label_field,
+          layer: refLayer.layer,
+          layer_type: refLayer.layer_type,
+          projectTemplate
+        })
+      )
+    );
+
+    return projectTemplate;
   }
 
   @UseGuards(OptionalJwtAuthGuard)

--- a/src/server/src/project-templates/entities/create-project-template.dto.ts
+++ b/src/server/src/project-templates/entities/create-project-template.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty } from "class-validator";
+
+import { CreateProjectTemplateData } from "../../../../shared/entities";
+import { ProjectIdDto } from "../../projects/entities/project-id.dto";
+
+export class CreateProjectTemplateDto implements CreateProjectTemplateData {
+  @IsNotEmpty({ message: "Please enter a description" })
+  readonly description: string;
+
+  @IsNotEmpty({ message: "Please enter details" })
+  readonly details: string;
+
+  @IsNotEmpty({ message: "Please enter project id" })
+  readonly project: ProjectIdDto;
+}

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -68,7 +68,7 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
     name: "pinned_metric_fields",
     default: DEFAULT_PINNED_METRIC_FIELDS
   })
-  pinnedMetricFields: string[];
+  pinnedMetricFields: readonly string[];
 
   @Column({
     type: "integer",

--- a/src/server/src/project-templates/project-templates.module.ts
+++ b/src/server/src/project-templates/project-templates.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { RegionConfigsModule } from "../region-configs/region-configs.module";
@@ -7,13 +7,17 @@ import { ProjectTemplatesController } from "./controllers/project-templates.cont
 import { ProjectTemplatesService } from "./services/project-templates.service";
 import { ProjectTemplate } from "./entities/project-template.entity";
 import { DistrictsModule } from "../districts/districts.module";
+import { ProjectsModule } from "../projects/projects.module";
+import { ReferenceLayersModule } from "../reference-layers/reference-layers.module";
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ProjectTemplate]),
     DistrictsModule,
     RegionConfigsModule,
-    OrganizationsModule
+    OrganizationsModule,
+    forwardRef(() => ProjectsModule),
+    forwardRef(() => ReferenceLayersModule)
   ],
   controllers: [ProjectTemplatesController],
   providers: [ProjectTemplatesService],

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -11,6 +11,8 @@ import {
   UserId,
   ProjectId
 } from "../../../../shared/entities";
+import { Organization } from "../../organizations/entities/organization.entity";
+import { Project } from "../../projects/entities/project.entity";
 
 export type ProjectExportRow = {
   readonly userId: UserId;
@@ -120,5 +122,32 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
       .orderBy("projects.name")
       .getMany();
     return data;
+  }
+
+  async createFromProject(
+    description: string,
+    details: string,
+    organization: Organization,
+    project: Project
+  ): Promise<ProjectTemplate> {
+    const template = new ProjectTemplate();
+    /* eslint-disable functional/immutable-data */
+    template.description = description;
+    template.details = details;
+    template.organization = organization;
+
+    template.name = project.name;
+    template.numberOfDistricts = project.numberOfDistricts;
+    template.districtsDefinition = project.districtsDefinition;
+    template.numberOfMembers = project.numberOfMembers;
+    template.pinnedMetricFields = project.pinnedMetricFields;
+    template.populationDeviation = project.populationDeviation;
+
+    template.regionConfig = project.regionConfig;
+    template.chamber = project.chamber;
+    /* eslint-enable functional/immutable-data */
+
+    // @ts-ignore
+    return this.repo.save(template);
   }
 }

--- a/src/server/src/projects/projects.module.ts
+++ b/src/server/src/projects/projects.module.ts
@@ -21,7 +21,7 @@ import { ReferenceLayersModule } from "../reference-layers/reference-layers.modu
     RegionConfigsModule,
     ChambersModule,
     OrganizationsModule,
-    ProjectTemplatesModule,
+    forwardRef(() => ProjectTemplatesModule),
     forwardRef(() => ReferenceLayersModule),
     UsersModule
   ],

--- a/src/server/src/reference-layers/controllers/reference-layers.controller.ts
+++ b/src/server/src/reference-layers/controllers/reference-layers.controller.ts
@@ -119,7 +119,7 @@ export class ReferenceLayersController implements CrudController<ReferenceLayer>
   ): Promise<IReferenceLayer[]> {
     const userId =
       typeof req.parsed.authPersist.userId === "string" ? req.parsed.authPersist.userId : undefined;
-    return this.service.getProjectReferenceLayers(projectId, userId);
+    return this.service.getPublicReferenceLayers(projectId, userId);
   }
 
   @UseInterceptors(CrudRequestInterceptor)

--- a/src/server/src/reference-layers/services/reference-layers.service.ts
+++ b/src/server/src/reference-layers/services/reference-layers.service.ts
@@ -18,7 +18,17 @@ export class ReferenceLayersService extends TypeOrmCrudService<ReferenceLayer> {
     return this.repo.save(layer);
   }
 
-  async getProjectReferenceLayers(projectId: string, userId?: UserId): Promise<IReferenceLayer[]> {
+  async getProjectReferenceLayers(projectId: string): Promise<ReferenceLayer[]> {
+    // Returns all reference layer data for a project
+    const builder = this.repo.createQueryBuilder("referenceLayer");
+    const data = await builder
+      .leftJoin("referenceLayer.project", "project")
+      .where("project.id = :projectId", { projectId: projectId })
+      .getMany();
+    return data;
+  }
+
+  async getPublicReferenceLayers(projectId: string, userId?: UserId): Promise<IReferenceLayer[]> {
     // Returns public data for organization screen
     const builder = this.repo.createQueryBuilder("referenceLayer");
     const data = await builder

--- a/src/server/src/users/controllers/users.controller.ts
+++ b/src/server/src/users/controllers/users.controller.ts
@@ -17,6 +17,10 @@ import { UsersService } from "../services/users.service";
         allow: ["slug", "name", "logoUrl"],
         eager: true
       },
+      adminOrganizations: {
+        allow: ["slug", "name", "logoUrl"],
+        eager: true
+      },
       "organizations.projectTemplates": {
         alias: "org_templates",
         exclude: ["districtsDefinition"],

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -278,6 +278,10 @@ export type IProjectTemplateWithProjects = IProjectTemplate & {
   readonly projects: readonly ProjectNest[];
 };
 
+export type CreateProjectTemplateData = Pick<IProjectTemplate, "description" | "details"> & {
+  readonly project: Pick<IProject, "id">;
+};
+
 export type ChamberId = string;
 
 export interface IChamber {

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -23,6 +23,7 @@ export interface IUser {
   readonly isEmailVerified: boolean;
   readonly hasSeenTour: boolean;
   readonly organizations: readonly OrganizationNest[];
+  readonly adminOrganizations: readonly OrganizationNest[];
 }
 
 export type UpdateUserData = Pick<IUser, "name" | "hasSeenTour">;


### PR DESCRIPTION
## Overview

Adds support to create templates from projects.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Capture](https://user-images.githubusercontent.com/4432106/153498077-7df1de10-d29a-4ebb-8b65-0a596e6fa76e.PNG)


## Testing Instructions

- Ensure that you are the admin of at least one organization
  - Create a new map in any region, and on the homescreen from the "..." menu for that project select "Copy to Template"
  - Using the modal should create a new template in the selected organization. Creating a new project from the template should copy districts, pinned fields and reference layers
- Log in as a user that is not an organization admin. You should not see the "Copy to Template" option

Closes #997 