### PR TITLE
Add scrolling to map config modal for viewing multiMember list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add instructions on configuring PG Admin and on releasing new region data [#1081](https://github.com/PublicMapping/districtbuilder/pull/1081)
 - Add blog link to Resource menu [#1083](https://github.com/PublicMapping/districtbuilder/pull/1083)
 - Added cron task to REINDEX project table monthly [#1101](https://github.com/PublicMapping/districtbuilder/pull/1101)
+- Add scrolling to Map configuration modal for best viewing multi-member district list [#1110](https://github.com/PublicMapping/districtbuilder/pull/1110)
 
 ### Changed
 

--- a/src/client/components/ProjectDetailsModal.tsx
+++ b/src/client/components/ProjectDetailsModal.tsx
@@ -56,6 +56,10 @@ const style: ThemeUIStyleObject = {
     maxWidth: "90vw",
     overflow: "visible"
   },
+  modalBodyContainer: {
+    maxHeight: "calc(100vh - 16rem)",
+    overflow: "auto"
+  },
   customInputContainer: {
     width: "100%",
     mb: 5
@@ -63,12 +67,14 @@ const style: ThemeUIStyleObject = {
   multiMemberContainer: {
     overflow: "hidden",
     maxHeight: "calc(100vh - 42rem)",
+    minHeight: "10rem",
     width: "100%",
     "> div": {
       overflow: "auto",
       width: "100%",
       flex: "0 0 auto",
-      maxHeight: "inherit"
+      maxHeight: "inherit",
+      minHeight: "10rem"
     },
     thead: {
       position: "sticky",
@@ -198,7 +204,7 @@ const ProjectDetailModal = ({
               }
             }}
           >
-            <Box>
+            <Box sx={style.modalBodyContainer}>
               <Flex sx={{ flexWrap: "wrap" }}>
                 <Box sx={style.customInputContainer}>
                   <FormError resource={projectDetailsResource} />
@@ -293,7 +299,6 @@ const ProjectDetailModal = ({
                 </Box>
               </Flex>
             </Box>
-
             <Divider />
             <Flex sx={style.footer}>
               <Button

--- a/src/client/components/ProjectDetailsModal.tsx
+++ b/src/client/components/ProjectDetailsModal.tsx
@@ -65,21 +65,7 @@ const style: ThemeUIStyleObject = {
     mb: 5
   },
   multiMemberContainer: {
-    overflow: "hidden",
-    maxHeight: "calc(100vh - 42rem)",
-    minHeight: "10rem",
-    width: "100%",
-    "> div": {
-      overflow: "auto",
-      width: "100%",
-      flex: "0 0 auto",
-      maxHeight: "inherit",
-      minHeight: "10rem"
-    },
-    thead: {
-      position: "sticky",
-      top: 0
-    }
+    width: "100%"
   }
 };
 
@@ -251,16 +237,14 @@ const ProjectDetailModal = ({
                   </Label>
                   {formData.isMultiMember ? (
                     <Box sx={style.multiMemberContainer}>
-                      <Box>
-                        <MultiMemberForm
-                          errors={extractErrors(projectDetailsResource, "numberOfMembers")}
-                          totalPopulation={totalPopulation}
-                          numberOfMembers={formData.numberOfMembers}
-                          onChange={numberOfMembers => {
-                            setProjectDetailsResource({ data: { ...formData, numberOfMembers } });
-                          }}
-                        />
-                      </Box>
+                      <MultiMemberForm
+                        errors={extractErrors(projectDetailsResource, "numberOfMembers")}
+                        totalPopulation={totalPopulation}
+                        numberOfMembers={formData.numberOfMembers}
+                        onChange={numberOfMembers => {
+                          setProjectDetailsResource({ data: { ...formData, numberOfMembers } });
+                        }}
+                      />
                     </Box>
                   ) : null}
                 </Box>


### PR DESCRIPTION
## Overview

The list of multi-member districts was not appearing in the Map configuration modal when the screen height was too short. This PR adds a minimum height to the `multiMemberContainer` to ensure that it always displays regardless of screen size and adds scrolling to the modal body while leaving the title and save/cancel buttons in place.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
![Screen Shot 2022-01-26 at 10 19 50 AM](https://user-images.githubusercontent.com/77936689/151192128-937428a1-5849-472d-b0d8-7e05f8cc96e7.png)

Screenshot taken from a 1280x680 window zoomed to 100% in Chrome.

### Notes

The added `modalBodyContainer` was given a max height of 100vh-16rem; this amount was determined via experimentation to be what looked best in conjunction with the modal styling when both a normal size and when too short. 

## Testing Instructions

- Run `./scripts/server` and navigate to one of your map project pages.
- Open the Map Configuration modal and shrink the screen to be shorter than the modal's height. It should resize to fit the new height and a scroll bar should appear that allows you to see the modal's body.
- Select "Use Multi-member Districts". The list should appear without changing the dimensions of the modal. 
- Verify the scrolling works as expected.

Closes #1089 
