### PR TITLE
Run npm rebuild to rebuild native server deps during scripts/update

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -33,7 +33,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Update backend, Yarn dependencies and build server
         docker-compose \
             run --rm --no-deps --entrypoint "bash -c" server \
-            "yarn install && yarn build"
+            "yarn install && npm rebuild && yarn build"
 
         # Update manage, Yarn dependencies and build
         docker-compose \


### PR DESCRIPTION
## Overview

Run npm rebuild to rebuild native server deps during `scripts/update`.
Should fix issues running `server` code as part of `scripts/update`.

### Notes

I referenced https://stackoverflow.com/questions/66729013/why-is-importing-bcrypt-causing-a-cannot-find-module-napi-v3-bcrypt-lib-node-e and https://github.com/yarnpkg/yarn/issues/756 when trying to diagnose this

## Testing Instructions

 - See if CI passes?
