### PR TITLE
Write topojson in legacy format in addition to binary format

### DIFF
--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -251,6 +251,7 @@ it when necessary (file sizes ~1GB+).
     }
 
     this.writeTopoJson(flags.outputDir, topoJsonHierarchy);
+    await this.writeTopoJsonLegacy(flags.outputDir, topoJsonHierarchy);
 
     this.addGeoLevelIndices(topoJsonHierarchy, geoLevelIds);
 
@@ -536,6 +537,15 @@ it when necessary (file sizes ~1GB+).
     const output = createWriteStream(path, { encoding: "binary" });
     output.write(serialize(topology));
     output.close();
+  }
+
+  writeTopoJsonLegacy(dir: string, topology: Topology<Objects<{}>>): Promise<void> {
+    this.log("Writing topojson file");
+    const path = join(dir, "topo.json");
+    const output = createWriteStream(path, { encoding: "utf8" });
+    return new Promise(resolve =>
+      new JsonStreamStringify(topology).pipe(output).on("finish", () => resolve())
+    );
   }
 
   // Makes an appropriately-sized typed array containing the data


### PR DESCRIPTION
## Overview

This PR contains changes I made to fix the Puerto Rico region deployed by @dmcglone on Friday.

This writes out the topojson data in both the legacy text format as well as the new binary `v8` format, to support deploying new region data to production before we deploy the new code to production capable of loading the `v8` format.

### Notes

This PR is in draft form because I don't intend to merge it - I'm leaving it open in case we need to use this again before the next production deploy, but otherwise we won't need it after that.