### PR TITLE
Fix error deleting reference layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix 404 error when deleting reference layers [#1119](https://github.com/PublicMapping/districtbuilder/pull/1119)
 - Fix Reference Layer copy on other user's maps to reflect map's readonly status [#1078](https://github.com/PublicMapping/districtbuilder/pull/1078)
 - Fix Equal Population status so red "X" doesn't show if within deviation threshold [#1084](https://github.com/PublicMapping/districtbuilder/pull/1084)
 - Fix disappearing user data on Community Maps page refresh [#1090](https://github.com/PublicMapping/districtbuilder/pull/1090)

--- a/src/server/src/reference-layers/controllers/reference-layers.controller.ts
+++ b/src/server/src/reference-layers/controllers/reference-layers.controller.ts
@@ -46,7 +46,6 @@ import { ProjectVisibility } from "../../../../shared/constants";
     },
     projectId: {
       type: "string",
-      primary: true,
       field: "id"
     }
   },


### PR DESCRIPTION
## Overview

Creates a fix for the reference layers DELETE endpoint so that the page no longer crashes and a reference layer can be successfully deleted. The `ReferenceLayersController` used the `deleteOneBase` method by the `@Crud()` decorator to generate a DELETE endpoint, which ultimately did not match the api call from the frontend:
```
server_1    | [Nest] 39  - 02/01/2022, 9:52:47 PM     LOG [RouterExplorer] Mapped {/api/reference-layer/:id/:projectId, DELETE} route
```
The inconsistency is most likely a regression error after recent Node updates. Attempting to call at this generated endpoint also incorrectly queries the database and still returns a 404 status error. The new DELETE endpoint now matches the frontend call as well as the expected params for the TypeORM entity:
```
server_1    | [Nest] 39  - 02/01/2022, 9:52:47 PM     LOG [RouterExplorer] Mapped {/api/reference-layer/:id, DELETE} route
```

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
Deleting a reference layer
![db_prdemo_deletereflayers_small](https://user-images.githubusercontent.com/36374797/152060829-a1f0583e-64a0-4220-a4cf-f391f0732d88.gif)

### Notes

I still decided to use the `deleteOneBase` method since that seemed like the easiest fix, but instead of overriding it I'm creating a new route that will in turn call it. However, this means there will still be a `/api/reference-layer/:id/:projectId` endpoint generated, just no longer used. If called, it will respond with a 404 status.

## Testing Instructions

- `scripts/update`
- Expand the reference layers section and add a csv/geojson file (I used this [geojson data](https://www.pasda.psu.edu/uci/DataSummary.aspx?dataset=1210))
- Toggle layers on, confirm they display, then select to remove layer from map using the "..." menu
- Confirm the layers are successfully deleted and the page does not crash

Closes #1106 
