### PR TITLE
Restrict population options on map selection menu to all, vap & cvap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix disappearing user data on Community Maps page refresh [#1090](https://github.com/PublicMapping/districtbuilder/pull/1090)
 - Fix lack of error message in the import page when selecting a chamber with too few districts [#1091](https://github.com/PublicMapping/districtbuilder/pull/1091)
 - Fix import performance on larger regions [#1100](https://github.com/PublicMapping/districtbuilder/pull/1100)
+- Only show All, VAP & CVAP options for population choice [#1122](https://github.com/PublicMapping/districtbuilder/pull/1122)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/client/components/MapSelectionOptionsFlyout.tsx
+++ b/src/client/components/MapSelectionOptionsFlyout.tsx
@@ -66,7 +66,9 @@ const MapSelectionOptionsFlyout = ({
   const hasMultipleElections =
     votingIds.some(id => id.endsWith("16")) && votingIds.some(id => id.endsWith("20"));
   const populations =
-    metadata?.demographicsGroups?.flatMap(group => (group.total ? [group.total] : [])) || [];
+    metadata?.demographicsGroups?.flatMap(group =>
+      group.total && Object.keys(POPULATION_LABELS).includes(group.total) ? [group.total] : []
+    ) || [];
   const hasMultiplePopulationTotals = populations.length > 1;
   return (
     <Wrapper closeOnSelection={false}>
@@ -132,7 +134,7 @@ const MapSelectionOptionsFlyout = ({
                       store.dispatch(setPopulationKey(key));
                     }}
                   />
-                  {POPULATION_LABELS[key] || key}
+                  {POPULATION_LABELS[key]}
                 </Label>
               ))}
             </li>


### PR DESCRIPTION
## Overview

PR https://github.com/PublicMapping/districtbuilder/pull/1085 added support for picking which demographic group to use for the race chart & majority/minority metric, but we were too broad in allowing any demographic group to be selected - we'd like to restrict this to known groups of VAP / CVAP / "All population" (the default).

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Add a region to the `region_config` table for Alhambra (s3://global-districtbuilder-dev-us-east-1/regions/US/CA/2021-10-15T19:36:24.429Z/)
- Create a map for that region
- On `develop` you should see a large number of options in the ⚙️ menu under "Districts" > "Population".
- On this branch it should be just All Population, VAP, and CVAP

Closes #1121 
