### PR TITLE
Remove use of chokidar and add Vagrant plugin to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix lack of error message in the import page when selecting a chamber with too few districts [#1091](https://github.com/PublicMapping/districtbuilder/pull/1091)
 - Fix import performance on larger regions [#1100](https://github.com/PublicMapping/districtbuilder/pull/1100)
 - Only show All, VAP & CVAP options for population choice [#1122](https://github.com/PublicMapping/districtbuilder/pull/1122)
+- Fix hot reloading on environments using Vagrant [#1126](https://github.com/PublicMapping/districtbuilder/pull/1126)
 
 ## [1.13.0] - 2021-11-30
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ Once you've setup WSL and Docker, you can clone and setup this project from with
 
 ### Hot Reloading 🔥
 
-Next, run `scripts/server` to start the application:
+_Note:_ Environments that use Vagrant require the [Vagrant notification forwarder plugin](https://github.com/mhallin/vagrant-notify-forwarder) for hot reloading. To install, run
+
+```bash
+$ vagrant plugin install vagrant-notify-forwarder
+$ vagrant reload
+```
+
+Run `scripts/server` to start the application:
 
 ```bash
  $ ./scripts/server

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,11 @@
 
 Vagrant.require_version ">= 2.2"
 
+unless Vagrant.has_plugin?("vagrant-notify-forwarder")
+  $stderr.puts "\nERROR: vagrant-notify-forwarder not found; please run `vagrant plugin install vagrant-notify-forwarder`"
+  exit(1)
+end
+
 ANSIBLE_VERSION = "2.9.*"
 
 Vagrant.configure(2) do |config|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,6 @@ services:
     image: node:16-slim
     environment:
       - BASE_URL=${BASE_URL:-http://server:3005}
-      - CHOKIDAR_USEPOLLING=true
-      - CHOKIDAR_INTERVAL=250
       - PORT=3003
     volumes:
       - ./:/home/node/app

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "GENERATE_SOURCEMAP=false CHOKIDAR_USEPOLLING=true  react-scripts start",
+    "start": "GENERATE_SOURCEMAP=false  react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --testPathPattern=src/client",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## Overview

This PR replaces chokidar with vagrant-notify-forwarder plugin and adds a check for the plugin to the Vagrantfile as well as a note about installing the plugin to the README.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- From your project's root folder, run `vagrant plugin install vagrant-notify-forwarder`
- ssh into the VM and run `./scripts/update`, then `./scripts/server`
- Make a change to a file. Verify that the page hot reloads.

Closes #1125 
