### PR TITLE
Fix incorrect majority race assignment in map and evaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix import performance on larger regions [#1100](https://github.com/PublicMapping/districtbuilder/pull/1100)
 - Only show All, VAP & CVAP options for population choice [#1122](https://github.com/PublicMapping/districtbuilder/pull/1122)
 - Fix hot reloading on environments using Vagrant [#1126](https://github.com/PublicMapping/districtbuilder/pull/1126)
+- Fix incorrect assignment of majority race on majority-minority evaluate screen [#1127](https://github.com/PublicMapping/districtbuilder/pull/1127)
 
 ## [1.13.0] - 2021-11-30
 

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -586,7 +586,7 @@ const DistrictsMap = ({
           )
         );
         const majorityRace = maxBy(
-          percents.filter(([, val]) => val > 0.5),
+          percents.filter(([, val]) => val > 50),
           ([, val]) => val
         );
         if (!majorityRace) {
@@ -595,7 +595,7 @@ const DistrictsMap = ({
           const whiteSplit =
             feature.properties.demographics.white / feature.properties.demographics.population;
           // eslint-disable-next-line
-          feature.properties.majorityRaceSplit = 1 - whiteSplit;
+          feature.properties.majorityRaceSplit = (1 - whiteSplit) * 100;
         } else {
           // eslint-disable-next-line
           feature.properties.majorityRace = majorityRace[0];

--- a/src/client/components/map/index.ts
+++ b/src/client/components/map/index.ts
@@ -153,7 +153,7 @@ export function getEqualPopulationStops(popThresholdNum: number): ChoroplethStep
 export function getMajorityRaceSplitFill(majorityRace: string, majorityRaceSplit: number): string {
   const fills = getMajorityRaceFills();
   return fills[majorityRace]
-    ? majorityRaceSplit > 0.65
+    ? majorityRaceSplit > 65
       ? fills[majorityRace][0]
       : fills[majorityRace][1]
     : "#ffffff";


### PR DESCRIPTION
## Overview

The Majority-Minority evaluate screen was identifying and drawing the map choropleth incorrectly for the majority race. This issue was also seen in the `ProjectSidebar` when majority race was pinned.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-02-08 at 9 55 30 AM](https://user-images.githubusercontent.com/77936689/153012670-7eeb898b-861b-4bd6-ba61-5e70cedf3da8.png)
The screen now correctly identifies that the first two districts listed are minority-coalition districts over 65%, rather than a majority Hispanic county. It also correctly identifies that the Asian populations in districts 3 and 4 make up less than 65% and are therefore filled with a lighter color.

## Testing Instructions

- Start the server and navigate to a project screen
- Create a few new districts or use existing districts that match the following criteria: one with a majority race of over 65%, one with a majority race of under 65%, one with a majority-minority coalition over 65%, one with a majority-minority coalition that does not exceed 65%
- Navigate the project evaluate screen and verify that all 4 districts are displaying the proper majority race and that the choropleth matches the percentage of that race
- Change the population to CVAP or VAP and navigate to the project evaluate screen to verify it still assigns as expected

Closes #1111 
