### PR TITLE
parameterize rules so both staging and prod can exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - parameterize REINDEX rules so both staging and prod can exist [#1130](https://github.com/PublicMapping/districtbuilder/pull/1130)
 
 ## [1.14.0] - 2022-02-09
 

--- a/deployment/terraform/scheduled_tasks.tf
+++ b/deployment/terraform/scheduled_tasks.tf
@@ -1,11 +1,11 @@
 resource "aws_cloudwatch_event_rule" "reindex_task" {
-  name                = "reindex-scheduled-ecs-event-rule"
+  name                = "reindex-scheduled-ecs-event-rule-${var.environment}"
   // Run monthly at 5AM UTC (midnight EST)
   schedule_expression = "cron(0 5 1 * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "reindex_task" {
-  target_id = "reindex-scheduled-ecs-event-rule"
+  target_id = "reindex-scheduled-ecs-event-rule-${var.environment}"
   rule      = aws_cloudwatch_event_rule.reindex_task.name
   arn       = aws_ecs_cluster.app.arn
   role_arn  = aws_iam_role.ecs_task_role.arn


### PR DESCRIPTION

## Overview

This should allow us to tell the difference between prod and staging for reindexing.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- this has to just be deployed everywhere?

Closes: #1129
