### PR TITLE
Enhance formatting of PVI chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Stop loading archived topology [#1132](https://github.com/PublicMapping/districtbuilder/pull/1132) 
+- Stop loading archived topology [#1132](https://github.com/PublicMapping/districtbuilder/pull/1132)
+- Change formatting of the PVI chart y-axis [#1136](https://github.com/PublicMapping/districtbuilder/pull/1136)
 
 ### Fixed
 

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -39,6 +39,7 @@ const CompetitivenessChart = ({
           const yMax = parent.height - margin.top - margin.bottom;
 
           const leftAxisWidth = 30;
+          const leftTickLabelsOffset = 10;
 
           // accessors
           const x = (d: PviBucket) => d.name;
@@ -89,6 +90,13 @@ const CompetitivenessChart = ({
                 left={leftAxisWidth}
                 orientation="left"
                 numTicks={yValueMax}
+                labelOffset={leftTickLabelsOffset + 5}
+                tickFormat={yScale.tickFormat(1)}
+                tickLabelProps={() => ({
+                  verticalAnchor: "middle",
+                  dx: -leftTickLabelsOffset,
+                  fontSize: 9
+                })}
               />
             </svg>
           );

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -43,6 +43,7 @@ const CompetitivenessChart = ({
           // accessors
           const x = (d: PviBucket) => d.name;
           const y = (d: PviBucket) => (d.count ? +d.count : 0);
+          const yValueMax = Math.max(...chartData.map(y));
 
           const xScale = scaleBand({
             range: [leftAxisWidth, xMax],
@@ -54,7 +55,7 @@ const CompetitivenessChart = ({
           const yScale = scaleLinear({
             range: [yMax, 10],
             round: true,
-            domain: [0, Math.max(...chartData.map(y))]
+            domain: [0, yValueMax]
           });
 
           const xPoint = (data: PviBucket) => xScale(x(data));
@@ -87,7 +88,7 @@ const CompetitivenessChart = ({
                 label="# of districts"
                 left={leftAxisWidth}
                 orientation="left"
-                numTicks={4}
+                numTicks={yValueMax}
               />
             </svg>
           );

--- a/src/client/components/evaluate/detail/CompetitivenessChart.tsx
+++ b/src/client/components/evaluate/detail/CompetitivenessChart.tsx
@@ -36,7 +36,7 @@ const CompetitivenessChart = ({
           const margin = { top: 0, bottom: 50, left: 0, right: 0 };
 
           const xMax = parent.width - margin.left - margin.right;
-          const yMax = parent.height - margin.top - margin.bottom;
+          const yMax = parent.height ? parent.height - margin.top - margin.bottom : 10;
 
           const leftAxisWidth = 30;
           const leftTickLabelsOffset = 10;


### PR DESCRIPTION
## Overview

The PVI chart needed some stylistic enhancements. Along the way, I also found that charts with `yMax` values of less than 3 were displaying y ticks with decimal intervals that made those charts confusing to look at. This PR makes these changes, as well as addressing negative height errors that were appearing in the console during generation of the chart.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-02-14 at 7 20 30 AM](https://user-images.githubusercontent.com/77936689/153863364-a29b9320-b76e-499e-8531-6441fff5d315.png)
The chart with non-decimal labels that are to the left of the ticks, rather than above.


![Screen Shot 2022-02-14 at 7 20 16 AM](https://user-images.githubusercontent.com/77936689/153863376-d0cb9101-7490-4d30-9227-5dca13d181ff.png)
Charts with a `yMax` less than 3, such as this one, are now given `numTicks` equal to `yMax`, rather than a static 4.

### Notes

The location and spacing of the tick labels has been set to be 10 pixels from the axis and the label to be 5 pixels from the labels using a variable called `leftTickLabelsOffset` that is declared alongside `leftAxisWidth`. This was done so that the two always are placed in relationship to each other and the axis, rather than independently.

## Testing Instructions

- Start the server and open a project that has more than one completed districts
- Go to the Competitiveness Evaluate page and verify that the labels do not have decimals and are to the left of the tick marks
- Open the console and verify that you are not seeing any "negative values are not valid" errors
- Open a project with one or two completed districts; verify that the competitiveness chart only has tick marks for integers, rather than decimal values

Closes #1069 
