### PR TITLE
Fix bounds for AK mini-map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix bounds for AK mini-map [#1145](https://github.com/PublicMapping/districtbuilder/pull/1145)
+
 ## [1.14.0] - 2022-02-09
 
 ### Added

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { saveAs } from "file-saver";
+import memoize from "memoizee";
 
 import {
   CreateProjectData,
@@ -22,7 +23,8 @@ import {
   ReferenceLayerId,
   CreateReferenceLayerData,
   IProjectTemplate,
-  CreateProjectTemplateData
+  CreateProjectTemplateData,
+  IStaticMetadata
 } from "../shared/entities";
 import {
   DistrictsGeoJSON,
@@ -402,6 +404,16 @@ export async function fetchOrganizationFeaturedProjects(
       });
   });
 }
+
+export const fetchMemoizedStateBbox = memoize(
+  async (region: IRegionConfig): Promise<IStaticMetadata["bbox"]> => {
+    const staticMetadata = await fetchStaticMetadata(region.s3URI);
+    return staticMetadata.bbox;
+  },
+  {
+    normalizer: (args: [region: IRegionConfig]) => JSON.stringify(args[0].id)
+  }
+);
 
 export async function exportOrganizationProjectsCsv(slug: OrganizationSlug): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -41,6 +41,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
           "regionConfig.name",
           "regionConfig.id",
           "regionConfig.archived",
+          "regionConfig.s3URI",
           "user.id",
           "user.name"
         ])


### PR DESCRIPTION
## Overview

This PR fixes the incorrect bounds generated for the Alaska mini-map displayed on the home screen. This error was initially caused by an issue with the `@turf/bbox` module—the output for `bbox` included incorrect longitudes coordinates for Alaska’s bounding box, assumed to be an issue with the geojson spanning the anti-meridian. For a more reliable fix, this PR instead uses the static bounds specified in `static-metadata.json`, similar to the main map for a project.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

<img width="526" alt="Screen Shot 2022-02-16 at 11 39 46 AM" src="https://user-images.githubusercontent.com/36374797/154316998-54966d2d-7dc4-420f-88a8-fda7e51594dc.png">


### Notes

The notes of Issue #992 mention that, since the `static-metadata.json` is available in-memory as part of `TopologyService`, it might be worth creating a `bounds` property that can be sent back for mini-map generation. However, we recently got rid of archived topology layers within `TopologyService`, which means this would not be an available option for any projects with archived regions. To accommodate archived projects, the `s3URI` property is attached to the data returned to project list pages instead, which is then used by `fetchStaticMetadata` in a memoized function for each project. While `static-metadata.json` is small, if we want to free up some space we could potentially create the `bounds` property using `TopologyService` by default and return `s3URI` instead for projects that are archived?


## Testing Instructions

- `scripts/server`
- Create a project for `AK`
- Confirm the mini-map bounds are correct on home screen and the community maps page

Closes #992 
