### PR TITLE
Use separate node_modules cache per executor in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duplicated maps keep reference layers [#1137](https://github.com/PublicMapping/districtbuilder/pull/1137)
 - Fix bounds for AK mini-map [#1145](https://github.com/PublicMapping/districtbuilder/pull/1145)
 - Fix TopologyService health check[#1148](https://github.com/PublicMapping/districtbuilder/pull/1148)
+ - Fix concurrent Jenkins builds breaking node dependencies [#1146](https://github.com/PublicMapping/districtbuilder/pull/1146)
 
 ## [1.14.0] - 2022-02-09
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,9 +2,19 @@ version: "2.4"
 services:
   server:
     image: "districtbuilder:${GIT_COMMIT:-latest}"
+    volumes:
+      - "/var/cache/district-builder-${EXECUTOR_NUMBER}-server-node-modules:/home/node/app/server/node_modules"
+
+  client:
+    image: node:16-slim
+    volumes:
+      - "/var/cache/district-builder-${EXECUTOR_NUMBER}-client-node-modules:/home/node/app/node_modules"
 
   manage:
     image: "districtbuilder-manage:${GIT_COMMIT:-latest}"
+    volumes:
+      - "/var/cache/district-builder-${EXECUTOR_NUMBER}-server-node-modules:/home/node/app/server/node_modules"
+      - "/var/cache/district-builder-${EXECUTOR_NUMBER}-manage-node-modules:/home/node/app/manage/node_modules"
 
   shellcheck:
     image: koalaman/shellcheck:stable

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,52 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Ensure container images are current
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            build --pull
-
-        # Clean dist directory
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            run --rm --no-deps server \
-            clean
-
-        # Update frontend, Yarn dependencies and build static asset bundle
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            run --rm --no-deps client \
-            bash -c "yarn install && yarn compile && yarn build"
-
-        # Update backend, Yarn dependencies and build server
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            run --rm --no-deps --entrypoint "bash -c" server \
-            "yarn install && npm rebuild && yarn build"
-
-        # Update manage, Yarn dependencies and build
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            run --rm --no-deps manage \
-            bash -c "yarn install && yarn build"
-
-        # Bring up PostgreSQL and NestJS in a way that respects
-        # configured service health checks.
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            up -d database server
-
-        docker-compose \
-            -f docker-compose.yml \
-            -f docker-compose.ci.yml \
-            run --rm server \
-            migration:run
+        CI=1 ./scripts/update
 
         # Build tagged container images
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,7 +23,52 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        ./scripts/update
+        # Ensure container images are current
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            build --pull
+
+        # Clean dist directory
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm --no-deps server \
+            clean
+
+        # Update frontend, Yarn dependencies and build static asset bundle
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm --no-deps client \
+            bash -c "yarn install && yarn compile && yarn build"
+
+        # Update backend, Yarn dependencies and build server
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm --no-deps --entrypoint "bash -c" server \
+            "yarn install && npm rebuild && yarn build"
+
+        # Update manage, Yarn dependencies and build
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm --no-deps manage \
+            bash -c "yarn install && yarn build"
+
+        # Bring up PostgreSQL and NestJS in a way that respects
+        # configured service health checks.
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            up -d database server
+
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm server \
+            migration:run
 
         # Build tagged container images
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \

--- a/scripts/update
+++ b/scripts/update
@@ -17,32 +17,37 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        if [[ -n "${CI}" ]]; then
+            CONFIG_ARGS=( "-f" "docker-compose.yml" "-f" "docker-compose.ci.yml" )
+        else
+            CONFIG_ARGS=( "-f" "docker-compose.yml" )
+        fi
         # Ensure container images are current
-        docker-compose build --pull
+        docker-compose "${CONFIG_ARGS[@]}" build --pull
 
         # Clean dist directory
-        docker-compose \
+        docker-compose "${CONFIG_ARGS[@]}" \
             run --rm --no-deps server \
             clean
 
         # Update frontend, Yarn dependencies and build static asset bundle
-        docker-compose \
+        docker-compose "${CONFIG_ARGS[@]}" \
             run --rm --no-deps client \
             bash -c "yarn install && yarn compile && yarn build"
 
         # Update backend, Yarn dependencies and build server
-        docker-compose \
+        docker-compose "${CONFIG_ARGS[@]}" \
             run --rm --no-deps --entrypoint "bash -c" server \
             "yarn install && npm rebuild && yarn build"
 
         # Update manage, Yarn dependencies and build
-        docker-compose \
+        docker-compose "${CONFIG_ARGS[@]}" \
             run --rm --no-deps manage \
             bash -c "yarn install && yarn build"
 
         # Bring up PostgreSQL and NestJS in a way that respects
         # configured service health checks.
-        docker-compose \
+        docker-compose "${CONFIG_ARGS[@]}" \
             -f docker-compose.yml \
             up -d database server
 

--- a/scripts/yarn
+++ b/scripts/yarn
@@ -17,12 +17,28 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [[ "${1:-}" == "--help" ]] || [[ ! "${1}" == "client" && ! "${1}" == "server" && ! "${1}" == "manage" ]]; then
         usage
     elif [[ "${1}" == "server" ]]; then
-        docker-compose \
-            run --rm "${1}" \
-            "${@:2}"
+        if [[ -n "${CI}" ]]; then
+            docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.ci.yml \
+                run --rm "${1}" \
+                "${@:2}"
+        else
+            docker-compose \
+                run --rm "${1}" \
+                "${@:2}"
+        fi
     else
-        docker-compose \
-            run --rm --no-deps "${1}" \
-            bash -c "yarn ${*:2}"
+        if [[ -n "${CI}" ]]; then
+            docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.ci.yml \
+                run --rm --no-deps "${1}" \
+                bash -c "yarn ${*:2}"
+        else
+            docker-compose \
+                run --rm --no-deps "${1}" \
+                bash -c "yarn ${*:2}"
+        fi
     fi
 fi


### PR DESCRIPTION
## Overview

This aims to fix perennial issues where concurrent builds would cause mysterious Jenkins failures where dependencies that had been installed would then go "missing" later in the build

I believe our issue was caused by caching `node_modules` as a Docker volume on the host to enable faster re-builds.
In development this was fine, but on CI any concurrent builds could stomp on each others NPM dependencies. 

Using the `EXECUTOR_NUMBER` as part of the volume path is intended to avoid this, by giving each executor it's own set of `node_modules` folders to use.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

I'm going to `ssh` into Jenkins after it builds this PR, and check to see if the new cache directory has the executor number in it.

I'm not going to try to recreate the concurrent build issue, because that sounds like more trouble than it's worth for a simple fix like this - just going to keep an 👀 out in case this doesn't fix it.

Closes #979
