### PR TITLE
Fix TopologyService health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Add modal to allow organization admins to create templates from projects [#1107](https://github.com/PublicMapping/districtbuilder/pull/1107)
 
 ### Changed
@@ -16,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change formatting of the PVI chart y-axis [#1136](https://github.com/PublicMapping/districtbuilder/pull/1136)
 
 ### Fixed
- - parameterize REINDEX rules so both staging and prod can exist [#1130](https://github.com/PublicMapping/districtbuilder/pull/1130)
 
+- parameterize REINDEX rules so both staging and prod can exist [#1130](https://github.com/PublicMapping/districtbuilder/pull/1130)
 - Duplicated maps keep reference layers [#1137](https://github.com/PublicMapping/districtbuilder/pull/1137)
-
 - Fix bounds for AK mini-map [#1145](https://github.com/PublicMapping/districtbuilder/pull/1145)
+- Fix TopologyService health check[#1148](https://github.com/PublicMapping/districtbuilder/pull/1148)
 
 ## [1.14.0] - 2022-02-09
 

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -59,7 +59,7 @@ export class TopologyService {
   constructor(@InjectRepository(RegionConfig) private readonly repo: Repository<RegionConfig>) {}
 
   public loadLayers() {
-    void this.repo.find().then(regionConfigs => {
+    void this.repo.find({ archived: false }).then(regionConfigs => {
       const getLayers = async () => {
         // eslint-disable-next-line functional/immutable-data
         this._layers = regionConfigs.reduce(
@@ -69,9 +69,8 @@ export class TopologyService {
           }),
           {}
         );
-        const unarchivedRegions = _.filter(regionConfigs, region => !region.archived);
         // Load largest states first
-        const sortedRegions = _.sortBy(unarchivedRegions, region => [
+        const sortedRegions = _.sortBy(regionConfigs, region => [
           !STATE_ORDER.includes(region.regionCode),
           STATE_ORDER.indexOf(region.regionCode)
         ]);


### PR DESCRIPTION
## Overview

`TopologyService` loads layers by first setting the default value of the key:value pair in `this._layers` to `null` for each region, which later updates to a promise to fetch layers. However, archived regions are filtered out before this loop so their values are left as the default `null`, which fails the health check and consequently broke staging. This PR updates the way in which `TopologyService` filters out regions with archived layers so that the initial regions that populate `this._layers` no longer contain archived regions.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- `scripts/server`
- Wait for all region data to download in the server
- Call the health check endpoint in the browser: `localhost:3005/healthcheck`
- Confirm successful health check

Closes #1147 
