### PR TITLE
Update images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:3-postgres12.2-slim
+    image: quay.io/azavea/postgis:3-postgres12.4-slim
     environment:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder
@@ -46,7 +46,7 @@ services:
     command: start:dev
 
   client:
-    image: node:16-slim
+    image:  node:16-bullseye-slim
     environment:
       - BASE_URL=${BASE_URL:-http://server:3005}
       - PORT=3003

--- a/src/manage/Dockerfile
+++ b/src/manage/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim AS tippecanoe
+FROM node:16-bullseye-slim AS tippecanoe
 
 ENV TIPPECANOE_VERSION="1.35.0"
 

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:16-bullseye-slim
 
 RUN mkdir -p /home/node/app/server
 WORKDIR /home/node/app/server


### PR DESCRIPTION
## Overview

postgres minor bump 12.2 -> 12.4
node:16 now bumped to bullseye - this will likely happen with node:16-slim
images in the June timeframe anyway, but let's be explicit so no surprises

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions
Normal test cases should be fine.