### PR TITLE
Add Creation and Login Dates to User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Creation and Login Dates to User [#1159](https://github.com/PublicMapping/districtbuilder/pull/1159)
+
 ### Changed
 
 ### Fixed

--- a/src/server/migrations/1646168889613-userCreationAndLoginDates.ts
+++ b/src/server/migrations/1646168889613-userCreationAndLoginDates.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class userCreationAndLoginDates1646168889613 implements MigrationInterface {
+    name = 'userCreationAndLoginDates1646168889613'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "created_dt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()`);
+        await queryRunner.query(`ALTER TABLE "user" ADD "last_login_dt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "last_login_dt"`);
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "created_dt"`);
+    }
+
+}

--- a/src/server/src/auth/controllers/auth.controller.ts
+++ b/src/server/src/auth/controllers/auth.controller.ts
@@ -30,6 +30,7 @@ import { RegisterDto } from "../entities/register.dto";
 import { ResetPasswordDto } from "../entities/reset-password.dto";
 import { AuthService } from "../services/auth.service";
 import { Organization } from "../../organizations/entities/organization.entity";
+import { User } from "../../users/entities/user.entity";
 
 /*
  * Authentication service that handles logins, account activiation and
@@ -63,7 +64,9 @@ export class AuthController {
           message: { password: ["Invalid password"] }
         } as Errors<LoginDto>);
       }
-      return this.authService.generateJwt(userOrError);
+      const user: User = userOrError;
+      await this.authService.updateLastLogin(user.id);
+      return this.authService.generateJwt(user);
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;

--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -58,6 +58,10 @@ export class AuthService {
     return LoginErrors.INVALID_PASSWORD;
   }
 
+  async updateLastLogin(userId: UserId): Promise<void> {
+    return await this.usersService.updateLastLogin(userId);
+  }
+
   generateJwt(user: User): JWT {
     const payload: IUser & { sub: UserId } = {
       sub: user.id,

--- a/src/server/src/users/entities/user.entity.ts
+++ b/src/server/src/users/entities/user.entity.ts
@@ -38,6 +38,20 @@ export class User implements IUser {
   @Exclude()
   passwordHash: string;
 
+  @Column({
+    type: "timestamp with time zone",
+    name: "created_dt",
+    default: () => "NOW()"
+  })
+  createdDt: Date;
+
+  @Column({
+    type: "timestamp with time zone",
+    name: "last_login_dt",
+    default: () => "NOW()"
+  })
+  lastLoginDt: Date;
+
   constructor(params?: { id?: string; email: string; name: string; passwordHash?: string }) {
     if (!params) {
       return;

--- a/src/server/src/users/services/users.service.ts
+++ b/src/server/src/users/services/users.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
 import { Repository } from "typeorm";
 
-import { Register, OrganizationSlug } from "../../../../shared/entities";
+import { Register, OrganizationSlug, UserId } from "../../../../shared/entities";
 import { User } from "../entities/user.entity";
 
 @Injectable()
@@ -28,5 +28,16 @@ export class UsersService extends TypeOrmCrudService<User> {
       .createQueryBuilder("user")
       .innerJoin("user.organizations", "organization", "slug = :slug", { slug })
       .getMany();
+  }
+
+  async updateLastLogin(userId: UserId): Promise<void> {
+    await this.repo
+      .createQueryBuilder("user")
+      .update(User)
+      .set({ lastLoginDt: () => "NOW()" })
+      .where("id = :userId", { userId })
+      .execute();
+
+    return;
   }
 }


### PR DESCRIPTION
## Overview

Adds a date to the database when a user first creates their account as well as a date for when the user last logs in. The `lastLoginDt` column updates at each log in.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- `scripts/update`
- Create an account, log out, and then run `scripts/dbshell`
- Confirm new columns `createdDt` and `lastLoginDt` are part of the `user` table and populated with default date values (now) for your account
- Wait a few minutes then log back in
- Run `scripts/dbshell` again and confirm that the `lastLoginDt` column has an updated timestamp and `createdDt` remains unchanged

Closes #520 
