### PR TITLE
Fix organization mini maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.15.1] - 2022-03-03
+
+### Fixed
+
+- Fixed mini-map display on organization feature maps page [#1161](https://github.com/PublicMapping/districtbuilder/pull/1161)
+
 ## [1.15.0] - 2022-02-28
 
 ### Added

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../../shared/entities";
 import { Organization } from "../../organizations/entities/organization.entity";
 import { Project } from "../../projects/entities/project.entity";
+import { selectSimplifiedDistricts } from "../../projects/services/projects.service";
 
 export type ProjectExportRow = {
   readonly userId: UserId;
@@ -101,25 +102,25 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
   async findOrgFeaturedProjects(slug: OrganizationSlug): Promise<ProjectTemplate[]> {
     // Returns public listing of all featured projects for an organization
     const builder = this.repo.createQueryBuilder("projectTemplate");
-    const data = await builder
-      .innerJoin("projectTemplate.organization", "organization")
-      .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
-      .leftJoin("projectTemplate.projects", "projects", "projects.isFeatured = TRUE")
-      .innerJoin("projects.user", "user")
-      .where("organization.slug = :slug", { slug: slug })
-      .addSelect([
-        "projectTemplate.name",
-        "projectTemplate.numberOfDistricts",
-        "projectTemplate.id",
-        "projects.name",
-        "projects.isFeatured",
-        "projects.id",
-        "projects.updatedDt",
-        "projects.districts",
-        "user.name"
-      ])
-      .orderBy("projects.name")
-      .getMany();
+    const data = await selectSimplifiedDistricts(
+      builder
+        .innerJoin("projectTemplate.organization", "organization")
+        .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
+        .leftJoin("projectTemplate.projects", "project", "project.isFeatured = TRUE")
+        .innerJoin("project.user", "user")
+        .where("organization.slug = :slug", { slug: slug })
+        .addSelect([
+          "projectTemplate.name",
+          "projectTemplate.numberOfDistricts",
+          "projectTemplate.id",
+          "project.name",
+          "project.isFeatured",
+          "project.id",
+          "project.updatedDt",
+          "user.name"
+        ])
+        .orderBy("project.name")
+    ).getMany();
     return data;
   }
 

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -102,12 +102,12 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
     // Returns public listing of all featured projects for an organization
     const builder = this.repo.createQueryBuilder("projectTemplate");
     const data = await builder
-      .innerJoinAndSelect("projectTemplate.organization", "organization")
+      .innerJoin("projectTemplate.organization", "organization")
       .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
-      .leftJoinAndSelect("projectTemplate.projects", "projects", "projects.isFeatured = TRUE")
-      .innerJoinAndSelect("projects.user", "user")
+      .leftJoin("projectTemplate.projects", "projects", "projects.isFeatured = TRUE")
+      .innerJoin("projects.user", "user")
       .where("organization.slug = :slug", { slug: slug })
-      .select([
+      .addSelect([
         "projectTemplate.name",
         "projectTemplate.numberOfDistricts",
         "projectTemplate.id",
@@ -116,7 +116,6 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
         "projects.id",
         "projects.updatedDt",
         "projects.districts",
-        "regionConfig.name",
         "user.name"
       ])
       .orderBy("projects.name")


### PR DESCRIPTION
## Overview

Display of the mini-map for featured maps on the organization page was broken by the fix for #992 - which added a need for the `RegionConfig.url` column, which we weren't querying for the Organization screen.

While I was fixing the mini-maps, I also refactored our code so that we're employing the same `districts` simplification that we were already applying to the queries used for the community maps and home page to the query for the organization page as well.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![localhost_3003_o_azavea](https://user-images.githubusercontent.com/4432106/156249042-c30dc50e-6b1a-4b6f-8088-87cf248a32c4.png)

## Testing Instructions
- Ensure that an organization in your development environment has at last one featured map
- On `develop` you won't be able to load the mini-map for featured maps on the organization screen
- On the branch from this PR, the mini-maps should load
- When loading the organization screen, look at the log output from `scripts/server` to verify that the SQL query is now using simplification when selecting the districts column

Closes #1160 


