### PR TITLE
Add district type to project cards on 'My Maps' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add color picker to reference layer flyout [#1150](https://github.com/PublicMapping/districtbuilder/pull/1150)
 
+- Add district type to project cards on 'My Maps' page [#1162](https://github.com/PublicMapping/districtbuilder/pull/1162)
+
 ### Changed
 
 ### Fixed

--- a/src/client/components/HomeScreenProjectCard.tsx
+++ b/src/client/components/HomeScreenProjectCard.tsx
@@ -93,7 +93,8 @@ const HomeScreenProjectCard = ({
             {project.name}
           </Heading>
           <Text sx={{ fontSize: 2, color: "gray.7" }}>
-            {project.regionConfig.name} · {project.numberOfDistricts} districts
+            {project.regionConfig.name} · {project.numberOfDistricts} districts ·
+            {project.chamber ? ` ${project.chamber.name} ` : " Custom "}
           </Text>
         </Box>
         <Text

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -64,6 +64,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
           "project.numberOfDistricts",
           "project.updatedDt",
           "project.createdDt",
+          "chamber.name",
           "regionConfig.name",
           "regionConfig.id",
           "regionConfig.archived",


### PR DESCRIPTION
## Overview

This PR allows users to quickly see the type of districts, e.g. Alabama State Senate, US House of Representatives, etc, of each of their maps.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-03-02 at 10 04 19 AM](https://user-images.githubusercontent.com/77936689/156388962-e0c53972-8bad-4849-b9ae-ded3e40ccdab.png)

## Testing Instructions

- Start the server and go to the 'My Maps' page
- Verify that each of your maps' district type is now being displayed on the same line as the number of districts

Closes #1005 
