### PR TITLE
Fix process-geojson command

### DIFF
--- a/src/manage/Dockerfile
+++ b/src/manage/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16-bullseye-slim AS tippecanoe
 
-ENV TIPPECANOE_VERSION="1.35.0"
+ENV TIPPECANOE_VERSION="1.36.0"
 
 RUN set -ex \
   && deps=" \
@@ -20,7 +20,7 @@ RUN make -C /usr/local/src/tippecanoe-${TIPPECANOE_VERSION}
 RUN make -C /usr/local/src/tippecanoe-${TIPPECANOE_VERSION} install
 
 
-FROM node:16-slim
+FROM node:16-bullseye-slim
 
 RUN mkdir -p /home/node/app/manage
 WORKDIR /home/node/app/manage

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -300,6 +300,8 @@ it when necessary (file sizes ~1GB+).
       geoLevelHierarchyInfo,
       this.getDemographicsGroups(flags.demographics)
     );
+
+    process.exit(0);
   }
 
   renameProps(


### PR DESCRIPTION
## Overview

The update to the base Docker image in #1151 broke the `process-geojson` command, because it changed the base image of only the first stage of the multi-stage `src/manage/Dockerfile`, which caused `tippecanoe` to link against the wrong system libraries.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

While updating this, I also updated to the most recent version of `tippecanoe`, and fixed a problem with `process-geojson` where it could wait indefinitely after (successfully) finishing.

## Testing Instructions

- `docker-compose build manage`
- `scripts/manage process-geojson ...`

Connects to #1171 
