### PR TITLE
Submit map button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added submit map button [#1179](https://github.com/PublicMapping/districtbuilder/pull/1179)
 
 ### Changed
 

--- a/src/client/actions/projectData.ts
+++ b/src/client/actions/projectData.ts
@@ -126,3 +126,6 @@ export const exportGeoJsonFailure = createAction("Export project GeoJSON failure
 
 export const exportShp = createAction("Export project Shapefile")<IProject>();
 export const exportShpFailure = createAction("Export project Shapefile failure")<string>();
+
+export const projectSubmit = createAction("Project submit")();
+export const projectSubmitSuccess = createAction("Project submit success")<DynamicProjectData>();

--- a/src/client/actions/projectModals.ts
+++ b/src/client/actions/projectModals.ts
@@ -7,3 +7,4 @@ export const showAdvancedEditingModal = createAction(
 )<boolean>();
 export const showCopyMapModal = createAction("Show copy map modal")<boolean>();
 export const setImportFlagsModal = createAction("Show import flags modal")<boolean>();
+export const showSubmitMapModal = createAction("Show submit map modal")<boolean>();

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -61,6 +61,15 @@ function saveJWT(response: AxiosResponse<JWT>): JWT {
   return jwt;
 }
 
+function formatProject(project: IProject): IProject {
+  return {
+    ...project,
+    createdDt: new Date(project.createdDt),
+    updatedDt: new Date(project.updatedDt),
+    submittedDt: project.submittedDt ? new Date(project.submittedDt) : undefined
+  };
+}
+
 export async function authenticateUser(email: string, password: string): Promise<JWT> {
   return new Promise((resolve, reject) => {
     apiAxios
@@ -143,7 +152,7 @@ export async function createProject(data: CreateProjectData): Promise<IProject> 
   return new Promise((resolve, reject) => {
     apiAxios
       .post("/api/projects", data)
-      .then(response => resolve(response.data))
+      .then(response => resolve(formatProject(response.data)))
       .catch(error => reject(error.response?.data || error));
   });
 }
@@ -152,7 +161,7 @@ export async function copyProject(id: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
       .post(`/api/projects/${id}/duplicate`)
-      .then(response => resolve(response.data))
+      .then(response => resolve(formatProject(response.data)))
       .catch(error => reject(error.response?.data || error));
   });
 }
@@ -161,7 +170,7 @@ async function fetchProject(id: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
       .get(`/api/projects/${id}`)
-      .then(response => resolve(response.data))
+      .then(response => resolve(formatProject(response.data)))
       .catch(error =>
         reject({ errorMessage: error.response.data, statusCode: error.response.status })
       );
@@ -258,7 +267,7 @@ export async function patchProject(
   return new Promise((resolve, reject) => {
     apiAxios
       .patch(`/api/projects/${id}`, projectData)
-      .then(response => resolve(response.data))
+      .then(response => resolve(formatProject(response.data)))
       .catch(error => reject(error.response?.data || error));
   });
 }
@@ -495,7 +504,7 @@ export async function submitProject(projectId: ProjectId): Promise<IProject> {
   return new Promise((resolve, reject) => {
     apiAxios
       .post(`/api/projects/${projectId}/submit`)
-      .then(response => resolve(response.data))
+      .then(response => resolve(formatProject(response.data)))
       .catch(error => {
         reject(error.message);
       });

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -491,6 +491,17 @@ export async function saveProjectFeatured(project: ProjectNest): Promise<IOrgani
   });
 }
 
+export async function submitProject(projectId: ProjectId): Promise<IProject> {
+  return new Promise((resolve, reject) => {
+    apiAxios
+      .post(`/api/projects/${projectId}/submit`)
+      .then(response => resolve(response.data))
+      .catch(error => {
+        reject(error.message);
+      });
+  });
+}
+
 async function uploadToPlanScore(project: IProject): Promise<void> {
   return new Promise((resolve, reject) => {
     apiAxios

--- a/src/client/components/CopyMapButton.tsx
+++ b/src/client/components/CopyMapButton.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Button, jsx } from "theme-ui";
 import { Wrapper } from "react-aria-menubutton";
-import { style, invertStyles } from "./MenuButton.styles";
+import { style } from "./MenuButton.styles";
 import store from "../store";
 import { showCopyMapModal } from "../actions/projectModals";
 
@@ -14,9 +14,8 @@ const CopyMapButton = (props: CopyMapButtonProps) => {
     <Wrapper sx={{ position: "relative", pr: 1 }}>
       <Button
         sx={{
-          ...{ variant: "buttons.ghost", fontWeight: "light" },
-          ...style.menuButton,
-          ...invertStyles(props)
+          ...{ variant: props.invert ? "buttons.ghost" : "buttons.linkStyle", fontWeight: "light" },
+          ...style.menuButton
         }}
         className="copyMap-menu"
         onClick={() => {

--- a/src/client/components/ProjectHeader.tsx
+++ b/src/client/components/ProjectHeader.tsx
@@ -20,6 +20,7 @@ import { State } from "../reducers";
 import { UndoHistory } from "../reducers/undoRedo";
 
 import { style as menuButtonStyle } from "./MenuButton.styles";
+import SubmitMapButton from "./map/SubmitMapButton";
 
 const style: Record<string, ThemeUIStyleObject> = {
   undoRedo: {
@@ -53,6 +54,7 @@ const HeaderDivider = () => {
 interface StateProps {
   readonly evaluateMode: boolean;
   readonly undoHistory: UndoHistory;
+  readonly isOwnProject: boolean;
 }
 
 const EvaluateButton = ({ evaluateMode }: { readonly evaluateMode: boolean }) => (
@@ -60,7 +62,7 @@ const EvaluateButton = ({ evaluateMode }: { readonly evaluateMode: boolean }) =>
     <Button
       sx={{
         ...{
-          variant: "buttons.primary",
+          variant: "buttons.secondary",
           fontWeight: "light",
           maxHeight: "34px",
           borderBottom: evaluateMode ? "solid 3px" : "none",
@@ -86,12 +88,14 @@ const ProjectHeader = ({
   map,
   project,
   isArchived,
+  isOwnProject,
   isReadOnly,
   undoHistory
 }: {
   readonly map?: MapboxGL.Map;
   readonly project?: IProject;
   readonly isArchived: boolean;
+  readonly isOwnProject: boolean;
   readonly isReadOnly: boolean;
 } & StateProps) => (
   <Flex sx={style.projectHeader}>
@@ -134,12 +138,14 @@ const ProjectHeader = ({
           <SupportMenu invert={true} project={true} />
           {project ? <ExportMenu isArchived={isArchived} invert={true} project={project} /> : null}
           <EvaluateButton evaluateMode={evaluateMode} />
+          <SubmitMapButton project={project} />
         </React.Fragment>
       ) : (
         <React.Fragment>
           {!isArchived && <CopyMapButton invert={true} />}
           {project && <ExportMenu isArchived={isArchived} invert={true} project={project} />}
           <EvaluateButton evaluateMode={evaluateMode} />
+          {isOwnProject && <SubmitMapButton project={project} />}
         </React.Fragment>
       )}
     </Flex>
@@ -149,7 +155,11 @@ const ProjectHeader = ({
 function mapStateToProps(state: State): StateProps {
   return {
     evaluateMode: state.project.evaluateMode,
-    undoHistory: state.project.undoHistory
+    undoHistory: state.project.undoHistory,
+    isOwnProject:
+      "resource" in state.user &&
+      "resource" in state.project.projectData &&
+      state.user.resource.id === state.project.projectData.resource.project.user.id
   };
 }
 

--- a/src/client/components/ProjectSidebarHeader.tsx
+++ b/src/client/components/ProjectSidebarHeader.tsx
@@ -4,7 +4,7 @@ import { Button, Box, Flex, Heading, jsx, Spinner, Text, ThemeUIStyleObject } fr
 
 import { GeoUnits } from "../../shared/entities";
 import { SavingState } from "../types";
-import { areAnyGeoUnitsSelected, destructureResource } from "../functions";
+import { areAnyGeoUnitsSelected, isProjectReadOnly } from "../functions";
 import Icon from "./Icon";
 import Tooltip from "./Tooltip";
 
@@ -125,11 +125,8 @@ const ProjectSidebarHeader = ({
 };
 
 function mapStateToProps(state: State): StateProps {
-  const project = destructureResource(state.project.projectData, "project");
   return {
-    isReadOnly:
-      !("resource" in state.user) ||
-      (project !== undefined && state.user.resource.id !== project.user.id)
+    isReadOnly: isProjectReadOnly(state)
   };
 }
 

--- a/src/client/components/SubmitMapModal.tsx
+++ b/src/client/components/SubmitMapModal.tsx
@@ -1,0 +1,86 @@
+/** @jsx jsx */
+import AriaModal from "react-aria-modal";
+import { connect } from "react-redux";
+import { Box, Button, Flex, Heading, jsx, ThemeUIStyleObject } from "theme-ui";
+
+import { IProject } from "../../shared/entities";
+import { showSubmitMapModal } from "../actions/projectModals";
+import { State } from "../reducers";
+import store from "../store";
+
+const style: Record<string, ThemeUIStyleObject> = {
+  footer: {
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 5
+  },
+  header: {
+    mb: 5
+  },
+  heading: {
+    fontFamily: "heading",
+    fontWeight: "light",
+    fontSize: 4
+  },
+  modal: {
+    bg: "muted",
+    p: 5,
+    width: "small",
+    maxWidth: "90vw",
+    overflow: "visible"
+  }
+};
+
+const SubmitMapModal = ({
+  project,
+  showModal
+}: {
+  readonly project: IProject;
+  readonly showModal: boolean;
+}) => {
+  const hideModal = () => store.dispatch(showSubmitMapModal(false));
+
+  return showModal ? (
+    <AriaModal
+      titleId="submit-map-modal-header"
+      onExit={hideModal}
+      initialFocus="#cancel-submit-map-modal"
+      getApplicationNode={() => document.getElementById("root") as Element}
+      underlayStyle={{ paddingTop: "4.5rem" }}
+    >
+      <Box sx={style.modal}>
+        <Box sx={style.header}>
+          <Heading as="h1" sx={style.heading} id="submit-map-modal-header">
+            Next steps
+          </Heading>
+        </Box>
+        <Flex as="form" sx={{ flexDirection: "column" }}>
+          <Box
+            dangerouslySetInnerHTML={{
+              __html:
+                project?.projectTemplate?.contestNextSteps || "Thank you for submitting your form."
+            }}
+          ></Box>
+          <Flex sx={style.footer}>
+            <Button
+              id="cancel-submit-map-modal"
+              onClick={hideModal}
+              sx={{ variant: "buttons.primary", m: 0, mr: "auto" }}
+            >
+              Done
+            </Button>
+          </Flex>
+        </Flex>
+      </Box>
+    </AriaModal>
+  ) : null;
+};
+
+function mapStateToProps(state: State) {
+  return {
+    showModal: state.projectModals.showSubmitMapModal,
+    user: state.user
+  };
+}
+
+export default connect(mapStateToProps)(SubmitMapModal);

--- a/src/client/components/SubmitMapModal.tsx
+++ b/src/client/components/SubmitMapModal.tsx
@@ -57,8 +57,7 @@ const SubmitMapModal = ({
         <Flex as="form" sx={{ flexDirection: "column" }}>
           <Box
             dangerouslySetInnerHTML={{
-              __html:
-                project?.projectTemplate?.contestNextSteps || "Thank you for submitting your form."
+              __html: project?.projectTemplate?.contestNextSteps || ""
             }}
           ></Box>
           <Flex sx={style.footer}>

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -1179,8 +1179,8 @@ const DistrictsMap = ({
       </div>
       {!evaluateMode && isThisUsersMap && isArchived && (
         <Box sx={style.archivedMessage}>
-          <Icon name="alert-triangle" /> This map is using an archived region for the 2010 Census
-          and can no longer be edited.
+          <Icon name="alert-triangle" /> This map is using an archived region and can no longer be
+          edited.
         </Box>
       )}
       {evaluateMode && evaluateMetric && evaluateMetric.key === "countySplits" && (

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -126,9 +126,7 @@ function disableEditMode(
   });
 
   // Disable selection tools in evaluate mode
-  DefaultSelectionTool.disable(map);
-  RectangleSelectionTool.disable(map);
-  PaintBrushSelectionTool.disable(map);
+  disableAllTools(map);
 
   // Resize map after editing toolbar removed
   map.resize();
@@ -204,6 +202,13 @@ function enableSummaryEvaluateLayers(map: MapboxGL.Map) {
 
 function disableSummaryEvaluateLayers(map: MapboxGL.Map) {
   map.setLayoutProperty(DISTRICTS_LAYER_ID, "visibility", "none");
+}
+
+function disableAllTools(map: MapboxGL.Map) {
+  // Disable any existing selection tools
+  DefaultSelectionTool.disable(map);
+  RectangleSelectionTool.disable(map);
+  PaintBrushSelectionTool.disable(map);
 }
 
 const getRefLayerSourceId = (layerId: ReferenceLayerId) => `reference-source-${layerId}`;
@@ -1093,9 +1098,7 @@ const DistrictsMap = ({
     /* eslint-disable */
     if (map && !isReadOnly) {
       // Disable any existing selection tools
-      DefaultSelectionTool.disable(map);
-      RectangleSelectionTool.disable(map);
-      PaintBrushSelectionTool.disable(map);
+      disableAllTools(map);
       if (!evaluateMode && !isPanning) {
         // Enable appropriate tool
         if (selectionTool === SelectionTool.Default) {
@@ -1133,6 +1136,9 @@ const DistrictsMap = ({
           );
         }
       }
+    } else if (map) {
+      // Disable any existing selection tools
+      disableAllTools(map);
     }
     /* eslint-enable */
   }, [

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -101,6 +101,7 @@ import { Resource } from "../../resource";
 import { getColor } from "@theme-ui/color";
 import theme from "../../theme";
 import { getDemographicsGroups } from "../../../shared/functions";
+import CopyMapButton from "../CopyMapButton";
 
 function removeEvaluateMetricLayers(map: MapboxGL.Map) {
   map.setLayoutProperty(DISTRICTS_COMPACTNESS_CHOROPLETH_LAYER_ID, "visibility", "none");
@@ -1181,6 +1182,12 @@ const DistrictsMap = ({
         <Box sx={style.archivedMessage}>
           <Icon name="alert-triangle" /> This map is using an archived region and can no longer be
           edited.
+        </Box>
+      )}
+      {!evaluateMode && isThisUsersMap && project.submittedDt && (
+        <Box sx={style.archivedMessage}>
+          <Icon name="alert-triangle" /> This map is read-only because it was submitted to a
+          contest. {!isArchived && <CopyMapButton invert={false} />}
         </Box>
       )}
       {evaluateMode && evaluateMetric && evaluateMetric.key === "countySplits" && (

--- a/src/client/components/map/Map.tsx
+++ b/src/client/components/map/Map.tsx
@@ -1185,7 +1185,7 @@ const DistrictsMap = ({
         </svg>
       </div>
       {!evaluateMode && isThisUsersMap && isArchived && (
-        <Box sx={style.archivedMessage}>
+        <Box sx={{ ...style.archivedMessage, pb: 0 }}>
           <Icon name="alert-triangle" /> This map is using an archived region and can no longer be
           edited.
         </Box>

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -2,10 +2,11 @@
 import React from "react";
 import { Button as MenuButton, Menu, Wrapper } from "react-aria-menubutton";
 import { connect } from "react-redux";
-import { Box, Button, Heading, jsx } from "theme-ui";
+import { Box, Button, Heading, jsx, Themed } from "theme-ui";
 
 import { IProject } from "../../../shared/entities";
 import { projectSubmit } from "../../actions/projectData";
+import { showSubmitMapModal } from "../../actions/projectModals";
 import { State } from "../../reducers";
 import store from "../../store";
 import Icon from "../Icon";
@@ -41,33 +42,47 @@ const SubmitMapButton = ({
           "Submit"
         )}
       </MenuButton>
-      <Menu sx={{ ...menuButtonStyle.menu, width: "450px", p: 2 }}>
+      <Menu sx={{ ...menuButtonStyle.menu, width: project?.submittedDt ? "350px" : "450px", p: 2 }}>
         <Box>
           <Heading as="h3">Submit map</Heading>
-          Submitting will send your map to {organization.name}
-          <p sx={{ mt: 0 }}>The following things will happen:</p>
-          <p>
-            <Icon name={"lock-locked"} /> your map will be locked from making additional changes
-          </p>
-          <p>
-            <Icon name={"pencil"} /> If you want to revise the map after submitting it, you can copy
-            the map and make edits on the copy
-          </p>
-          <p>
-            <Icon name={"link"} /> If your map is private, it will be switched to “shared with link”
-            so the contest can see it
-          </p>
-          <Button
-            disabled={saving === "saving"}
-            sx={{
-              variant: "buttons.primary"
-            }}
-            onClick={() => {
-              store.dispatch(projectSubmit());
-            }}
-          >
-            Submit
-          </Button>
+          {project?.submittedDt ? (
+            <React.Fragment>
+              Your map was submitted to {organization.name} at{" "}
+              {project.submittedDt.toLocaleTimeString(undefined, { timeStyle: "short" })} on{" "}
+              {project.submittedDt.toLocaleDateString(undefined, { dateStyle: "long" })}. View{" "}
+              <Themed.a href="void:0" onClick={() => store.dispatch(showSubmitMapModal(true))}>
+                next steps
+              </Themed.a>
+              .
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              Submitting will send your map to {organization.name}
+              <p sx={{ mt: 0 }}>The following things will happen:</p>
+              <p>
+                <Icon name={"lock-locked"} /> your map will be locked from making additional changes
+              </p>
+              <p>
+                <Icon name={"pencil"} /> If you want to revise the map after submitting it, you can
+                copy the map and make edits on the copy
+              </p>
+              <p>
+                <Icon name={"link"} /> If your map is private, it will be switched to “shared with
+                link” so the contest can see it
+              </p>
+              <Button
+                disabled={saving === "saving"}
+                sx={{
+                  variant: "buttons.primary"
+                }}
+                onClick={() => {
+                  store.dispatch(projectSubmit());
+                }}
+              >
+                Submit
+              </Button>
+            </React.Fragment>
+          )}
         </Box>
       </Menu>
     </Wrapper>

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -53,8 +53,12 @@ const SubmitMapButton = ({
               {project.submittedDt.toLocaleDateString(undefined, { dateStyle: "long" })}.
               {project?.projectTemplate?.contestNextSteps ? (
                 <React.Fragment>
+                  {" "}
                   View{" "}
-                  <Themed.a href="void:0" onClick={() => store.dispatch(showSubmitMapModal(true))}>
+                  <Themed.a
+                    href="javascript:void(0)"
+                    onClick={() => store.dispatch(showSubmitMapModal(true))}
+                  >
                     next steps
                   </Themed.a>
                   .

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -1,0 +1,83 @@
+/** @jsx jsx */
+import React from "react";
+import { Button as MenuButton, Menu, Wrapper } from "react-aria-menubutton";
+import { connect } from "react-redux";
+import { Box, Button, Heading, jsx } from "theme-ui";
+
+import { IProject } from "../../../shared/entities";
+import { projectSubmit } from "../../actions/projectData";
+import { State } from "../../reducers";
+import store from "../../store";
+import Icon from "../Icon";
+import { style as menuButtonStyle } from "../MenuButton.styles";
+
+const SubmitMapButton = ({
+  project,
+  saving
+}: {
+  readonly project?: IProject;
+  readonly saving: string;
+}) => {
+  const organization = project?.projectTemplate?.organization;
+  const showButton = project?.submittedDt || project?.projectTemplate?.contestActive;
+  return organization && showButton ? (
+    <Wrapper sx={{ position: "relative", ml: 2 }}>
+      <MenuButton
+        sx={{
+          ...menuButtonStyle.menuButton,
+          ...{
+            variant: project?.submittedDt ? "buttons.success" : "buttons.primary",
+            fontWeight: "light",
+            maxHeight: "34px"
+          }
+        }}
+      >
+        {project?.submittedDt ? (
+          <React.Fragment>
+            <Icon name="check" />
+            Submitted
+          </React.Fragment>
+        ) : (
+          "Submit"
+        )}
+      </MenuButton>
+      <Menu sx={{ ...menuButtonStyle.menu, width: "450px", p: 2 }}>
+        <Box>
+          <Heading as="h3">Submit map</Heading>
+          Submitting will send your map to {organization.name}
+          <p sx={{ mt: 0 }}>The following things will happen:</p>
+          <p>
+            <Icon name={"lock-locked"} /> your map will be locked from making additional changes
+          </p>
+          <p>
+            <Icon name={"pencil"} /> If you want to revise the map after submitting it, you can copy
+            the map and make edits on the copy
+          </p>
+          <p>
+            <Icon name={"link"} /> If your map is private, it will be switched to “shared with link”
+            so the contest can see it
+          </p>
+          <Button
+            disabled={saving === "saving"}
+            sx={{
+              variant: "buttons.primary"
+            }}
+            onClick={() => {
+              store.dispatch(projectSubmit());
+            }}
+          >
+            Submit
+          </Button>
+        </Box>
+      </Menu>
+    </Wrapper>
+  ) : null;
+};
+
+function mapStateToProps(state: State) {
+  return {
+    saving: state.project.saving
+  };
+}
+
+export default connect(mapStateToProps)(SubmitMapButton);

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -21,6 +21,7 @@ const SubmitMapButton = ({
 }) => {
   const organization = project?.projectTemplate?.organization;
   const showButton = project?.submittedDt || project?.projectTemplate?.contestActive;
+
   return organization && showButton ? (
     <Wrapper sx={{ position: "relative", ml: 2 }}>
       <MenuButton
@@ -49,11 +50,16 @@ const SubmitMapButton = ({
             <React.Fragment>
               Your map was submitted to {organization.name} at{" "}
               {project.submittedDt.toLocaleTimeString(undefined, { timeStyle: "short" })} on{" "}
-              {project.submittedDt.toLocaleDateString(undefined, { dateStyle: "long" })}. View{" "}
-              <Themed.a href="void:0" onClick={() => store.dispatch(showSubmitMapModal(true))}>
-                next steps
-              </Themed.a>
-              .
+              {project.submittedDt.toLocaleDateString(undefined, { dateStyle: "long" })}.
+              {project?.projectTemplate?.contestNextSteps ? (
+                <React.Fragment>
+                  View{" "}
+                  <Themed.a href="void:0" onClick={() => store.dispatch(showSubmitMapModal(true))}>
+                    next steps
+                  </Themed.a>
+                  .
+                </React.Fragment>
+              ) : null}
             </React.Fragment>
           ) : (
             <React.Fragment>

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -70,7 +70,7 @@ const SubmitMapButton = ({
               Submitting will send your map to {organization.name}
               <p sx={{ mt: 0 }}>The following things will happen:</p>
               <p>
-                <Icon name={"lock-locked"} /> your map will be locked from making additional changes
+                <Icon name={"lock-locked"} /> Your map will be locked from making additional changes
               </p>
               <p>
                 <Icon name={"pencil"} /> If you want to revise the map after submitting it, you can

--- a/src/client/functions.ts
+++ b/src/client/functions.ts
@@ -16,8 +16,10 @@ import {
   IStaticMetadata,
   ReferenceLayerProperties,
   GroupTotal,
-  DemographicsGroup
+  DemographicsGroup,
+  IProject
 } from "../shared/entities";
+import { State } from "./reducers";
 
 import { Resource, WriteResource } from "./resource";
 import {
@@ -483,4 +485,14 @@ export function extractErrors<D, T>(
   return "errors" in resource && typeof resource.errors.message === "object"
     ? resource.errors.message[field]
     : undefined;
+}
+
+export function isProjectReadOnly(state: State) {
+  const project: IProject | undefined = destructureResource(state.project.projectData, "project");
+  return (
+    !("resource" in state.user) ||
+    (project !== undefined && state.user.resource.id !== project.user.id) ||
+    (project !== undefined && project.regionConfig.archived) ||
+    (project !== undefined && !!project.submittedDt)
+  );
 }

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -709,7 +709,10 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
           saving: "saved",
           projectData: { resource: action.payload }
         },
-        Cmd.action(showSubmitMapModal(true))
+        "resource" in state.projectData &&
+          state.projectData.resource.project.projectTemplate?.contestNextSteps
+          ? Cmd.action(showSubmitMapModal(true))
+          : Cmd.none
       );
     default:
       return state as never;

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -81,6 +81,7 @@ import {
 } from "../api";
 import { fetchAllStaticData } from "../s3";
 import { toast } from "react-toastify";
+import { showSubmitMapModal } from "../actions/projectModals";
 
 function fetchGeoJsonForProject(project: IProject) {
   return () => {
@@ -692,7 +693,7 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
                 geojson
               })),
             {
-              successActionCreator: updateProjectNameSuccess,
+              successActionCreator: projectSubmitSuccess,
               failActionCreator: updateProjectFailed
             }
           )
@@ -702,11 +703,14 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
       }
     }
     case getType(projectSubmitSuccess):
-      return {
-        ...state,
-        saving: "saved",
-        projectData: { resource: action.payload }
-      };
+      return loop(
+        {
+          ...state,
+          saving: "saved",
+          projectData: { resource: action.payload }
+        },
+        Cmd.action(showSubmitMapModal(true))
+      );
     default:
       return state as never;
   }

--- a/src/client/reducers/projectData.ts
+++ b/src/client/reducers/projectData.ts
@@ -52,7 +52,12 @@ import {
   projectSubmit,
   projectSubmitSuccess
 } from "../actions/projectData";
-import { clearSelectedGeounits, setSavingState, FindTool } from "../actions/districtDrawing";
+import {
+  clearSelectedGeounits,
+  setSavingState,
+  FindTool,
+  SelectionTool
+} from "../actions/districtDrawing";
 import { updateCurrentState } from "../reducers/undoRedo";
 import { IProject, IReferenceLayer } from "../../shared/entities";
 import { ProjectState, initialProjectState } from "./project";
@@ -707,12 +712,16 @@ const projectDataReducer: LoopReducer<ProjectState, Action> = (
         {
           ...state,
           saving: "saved",
-          projectData: { resource: action.payload }
+          projectData: { resource: action.payload },
+          selectionTool: SelectionTool.Default
         },
         "resource" in state.projectData &&
           state.projectData.resource.project.projectTemplate?.contestNextSteps
-          ? Cmd.action(showSubmitMapModal(true))
-          : Cmd.none
+          ? Cmd.list<Action>([
+              Cmd.action(clearSelectedGeounits(true)),
+              Cmd.action(showSubmitMapModal(true))
+            ])
+          : Cmd.action(clearSelectedGeounits(true))
       );
     default:
       return state as never;

--- a/src/client/reducers/projectModals.ts
+++ b/src/client/reducers/projectModals.ts
@@ -7,7 +7,8 @@ import {
   showAdvancedEditingModal,
   showCopyMapModal,
   setImportFlagsModal,
-  toggleKeyboardShortcutsModal
+  toggleKeyboardShortcutsModal,
+  showSubmitMapModal
 } from "../actions/projectModals";
 import { resetProjectState } from "../actions/root";
 
@@ -16,13 +17,15 @@ export interface ProjectModalsState {
   readonly showCopyMapModal: boolean;
   readonly showKeyboardShortcutsModal: boolean;
   readonly showImportFlagsModal: boolean;
+  readonly showSubmitMapModal: boolean;
 }
 
 export const initialProjectModalsState: ProjectModalsState = {
   showAdvancedEditingModal: false,
   showCopyMapModal: false,
   showImportFlagsModal: false,
-  showKeyboardShortcutsModal: false
+  showKeyboardShortcutsModal: false,
+  showSubmitMapModal: false
 };
 
 const districtDrawingReducer: LoopReducer<ProjectModalsState, Action> = (
@@ -54,6 +57,11 @@ const districtDrawingReducer: LoopReducer<ProjectModalsState, Action> = (
       return {
         ...state,
         showImportFlagsModal: action.payload
+      };
+    case getType(showSubmitMapModal):
+      return {
+        ...state,
+        showSubmitMapModal: action.payload
       };
     default:
       return state as never;

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -315,7 +315,8 @@ function mapStateToProps(state: State): StateProps {
     isReadOnly:
       !("resource" in state.user) ||
       (project !== undefined && state.user.resource.id !== project.user.id) ||
-      (project !== undefined && project.regionConfig.archived),
+      (project !== undefined && project.regionConfig.archived) ||
+      (project !== undefined && !!project.submittedDt),
     user: state.user
   };
 }

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -49,6 +49,7 @@ import AddReferenceLayerModal from "../components/AddReferenceLayerModal";
 import DeleteReferenceLayerModal from "../components/DeleteReferenceLayerModal";
 import ProjectDetailsModal from "../components/ProjectDetailsModal";
 import { ProjectOptionsState } from "../reducers/projectOptions";
+import SubmitMapModal from "../components/SubmitMapModal";
 
 interface StateProps {
   readonly project?: IProject;
@@ -278,6 +279,7 @@ const ProjectScreen = ({
                 />
                 <AddReferenceLayerModal project={project} />
                 <ProjectDetailsModal project={project} geojson={geojson} />
+                <SubmitMapModal project={project} />
                 <DeleteReferenceLayerModal />
                 <Flex id="tour-start" sx={style.tourStart}></Flex>
               </React.Fragment>

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -42,7 +42,7 @@ import ProjectSidebar from "../components/ProjectSidebar";
 import SiteHeader from "../components/SiteHeader";
 import SubmitMapModal from "../components/SubmitMapModal";
 import Tour from "../components/Tour";
-import { areAnyGeoUnitsSelected, destructureResource } from "../functions";
+import { areAnyGeoUnitsSelected, destructureResource, isProjectReadOnly } from "../functions";
 import { isUserLoggedIn } from "../jwt";
 import { State } from "../reducers";
 import { DistrictDrawingState } from "../reducers/districtDrawing";
@@ -333,11 +333,7 @@ function mapStateToProps(state: State): StateProps {
     projectNotFound:
       "statusCode" in state.project.projectData && state.project.projectData.statusCode === 404,
     isArchived: project !== undefined && project.regionConfig.archived,
-    isReadOnly:
-      !("resource" in state.user) ||
-      (project !== undefined && state.user.resource.id !== project.user.id) ||
-      (project !== undefined && project.regionConfig.archived) ||
-      (project !== undefined && !!project.submittedDt),
+    isReadOnly: isProjectReadOnly(state),
     user: state.user
   };
 }

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -194,7 +194,10 @@ const theme: Theme = {
   },
   space: [0, 4, 8, 12, 16, 24, 32, 48, 64, 128, 256],
   buttons: {
-    primary: appButtonStyles,
+    primary: {
+      ...appButtonStyles,
+      bg: "primary"
+    },
     secondary: {
       ...appButtonStyles,
       ...{
@@ -204,6 +207,18 @@ const theme: Theme = {
         },
         "&:active": {
           bg: "gray.7"
+        }
+      }
+    },
+    success: {
+      ...appButtonStyles,
+      ...{
+        bg: "success.4",
+        "&:hover:not([disabled]):not(:active)": {
+          bg: "success.5"
+        },
+        "&:active": {
+          bg: "success.6"
         }
       }
     },

--- a/src/manage/dev-data/azavea.yaml
+++ b/src/manage/dev-data/azavea.yaml
@@ -25,8 +25,10 @@ projectTemplates:
     description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     details:
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
       Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+    contestNextSteps: Great job! <a href="https://example.com">Follow-up here</a> for next steps in the contest.
+    contestActive: true
+
   - id: 9047ac5b-4837-4935-b3c8-2a5624b5aec8
     name: General Assembly
     regionConfig: 893a9538-3f14-4225-9c91-d54ba818ab0d

--- a/src/manage/src/commands/update-organization.ts
+++ b/src/manage/src/commands/update-organization.ts
@@ -19,6 +19,8 @@ interface TemplateConfig {
   readonly numberOfMembers: readonly number[];
   readonly description?: string;
   readonly details?: string;
+  readonly contestNextSteps?: string;
+  readonly contestActive?: boolean;
 }
 
 interface OrganizationConfig {
@@ -95,10 +97,13 @@ export default class UpdateOrganization extends Command {
       template.numberOfMembers = config.numberOfMembers.map(n => Number(n));
       template.description = config.description || "";
       template.details = config.details || "";
+      template.contestNextSteps = config.contestNextSteps || "";
+      template.contestActive = config.contestActive || false;
       // @ts-ignore
       await templateRepo.save(template);
     }
 
     this.log("Organization saved to database");
+    process.exit(0);
   }
 }

--- a/src/server/migrations/1648042252591-contest_fields.ts
+++ b/src/server/migrations/1648042252591-contest_fields.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class contestFields1648042252591 implements MigrationInterface {
+    name = 'contestFields1648042252591'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "submitted_dt" TIMESTAMP WITH TIME ZONE`);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD "contest_next_steps" character varying NOT NULL DEFAULT ''`);
+        await queryRunner.query(`ALTER TABLE "project_template" ADD "contest_active" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project_template" DROP COLUMN "contest_active"`);
+        await queryRunner.query(`ALTER TABLE "project_template" DROP COLUMN "contest_next_steps"`);
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "submitted_dt"`);
+    }
+
+}

--- a/src/server/src/project-templates/entities/project-template.entity.ts
+++ b/src/server/src/project-templates/entities/project-template.entity.ts
@@ -80,4 +80,10 @@ export class ProjectTemplate implements IProjectTemplateWithProjects {
 
   @Column({ name: "is_active", type: "boolean", default: true })
   isActive: boolean;
+
+  @Column({ type: "character varying", name: "contest_next_steps", default: "" })
+  contestNextSteps: string;
+
+  @Column({ type: "boolean", name: "contest_active", default: false })
+  contestActive: boolean;
 }

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -481,11 +481,11 @@ export class ProjectsController implements CrudController<Project> {
   ): Promise<Project> {
     const project = await this.getProject(req, projectId);
     if (!project.projectTemplate) {
-      throw new NotFoundException(`Project is not connected to an organization's template`);
+      throw new NotFoundException("Project is not connected to an organization's template");
     }
     const orgId = project.projectTemplate.organization.id;
     if (!orgId) {
-      throw new NotFoundException(`Project is not connected to an organization`);
+      throw new NotFoundException("Project is not connected to an organization");
     }
     const userId = req.parsed.authPersist.userId || null;
     const org = await this.organizationService.findOne({ id: orgId }, { relations: ["admin"] });
@@ -507,16 +507,42 @@ export class ProjectsController implements CrudController<Project> {
   }
 
   @UseInterceptors(CrudRequestInterceptor)
+  @Override()
+  @UseGuards(JwtAuthGuard)
+  @Post(":id/submit")
+  async submitProject(@Param("id") id: ProjectId, @ParsedRequest() req: CrudRequest) {
+    const existingProject = await this.getProject(req, id);
+    if (!existingProject.projectTemplate?.contestActive) {
+      throw new NotFoundException("Project is not connected to a template with an active contest");
+    }
+    // Submitted maps can't be private
+    const visibility =
+      existingProject.visibility !== ProjectVisibility.Private
+        ? existingProject.visibility
+        : ProjectVisibility.Visible;
+    const project = await this.service.updateOne(req, { submittedDt: new Date(), visibility });
+    // Make sure submitted plans have a PlanScore report ready for judges to review
+    if (!project.planscoreUrl) {
+      this.triggerPlanScoreUpload(req, id);
+    }
+    return project;
+  }
+
+  @UseInterceptors(CrudRequestInterceptor)
   @UseGuards(OptionalJwtAuthGuard)
   @Post(":id/plan-score")
   async sendToPlanScoreAPI(
     @ParsedRequest() req: CrudRequest,
     @Param("id") projectId: ProjectId
   ): Promise<void> {
-    const userId = req.parsed.authPersist.userId as string;
     // First clear out the existing planscore URL
     await this.service.updateOne(req, { planscoreUrl: "" });
-    // The rest of this function happens in a callback that we *don't* wait for
+    this.triggerPlanScoreUpload(req, projectId);
+  }
+
+  triggerPlanScoreUpload(req: CrudRequest, projectId: ProjectId) {
+    const userId = req.parsed.authPersist.userId as string;
+    // The body of this function happens in a callback that we *don't* wait for
     // The frontend will poll to find out when this is completed
     void this.getProjectWithDistricts(projectId, userId).then(project => {
       const uploadDistricts = async () => {

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -271,6 +271,7 @@ export class ProjectsController implements CrudController<Project> {
       user: undefined,
       createdDt: undefined,
       updatedDt: undefined,
+      submittedDt: undefined,
       isFeatured: undefined,
       // Overwrite the creator data from the original creator to match the new owner
       districts: project.districts?.metadata?.creator

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -131,6 +131,14 @@ export class Project implements IProject {
   })
   planscoreUrl: string;
 
+  @Column({
+    type: "timestamp with time zone",
+    name: "submitted_dt",
+    nullable: true,
+    default: null
+  })
+  submittedDt?: Date;
+
   // Strips out data that we don't want to have available in the read-only view in the UI
   getReadOnlyView(): Project {
     return { ...this, lockedDistricts: new Array(this.numberOfDistricts).fill(false) };

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -226,6 +226,7 @@ export type IProject = ProjectTemplateFields & {
   readonly visibility: ProjectVisibility;
   readonly archived: boolean;
   readonly planscoreUrl: string;
+  readonly submittedDt?: Date;
 };
 
 export type ProjectNest = Pick<
@@ -281,6 +282,8 @@ export type IProjectTemplate = ProjectTemplateFields & {
   readonly details: string;
   readonly referenceLayers?: readonly IReferenceLayer[];
   readonly isActive: boolean;
+  readonly contestNextSteps: string;
+  readonly contestActive: boolean;
 };
 
 export type IProjectTemplateWithProjects = IProjectTemplate & {


### PR DESCRIPTION
## Overview

Adds workflow for submitting a map for a contest.

Two new fields have been added to `ProjectTemplate`:
 - `contestActive`: controls whether the "Submit" button is shown for maps connected to this template
 - `contestNextSteps`: HTML to display in the Next steps modal displayed after submission (optional, modal not shown if not set)
 
 Submission date is tracked on a new `Project.submittedDt` field, which also causes the submitted map to become read-only.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Submitting a map w/o next steps HTML set:
![submit-no-next-steps](https://user-images.githubusercontent.com/4432106/159934876-4fd2d1ff-971f-4d90-82f9-21ddb24bfba8.gif)

Submitting a map with next steps HTML set:
![submit-next-steps](https://user-images.githubusercontent.com/4432106/159934924-fae92c0d-ad70-4633-8c76-d4b82fbba726.gif)

## Testing Instructions

- Use `scripts/load-dev-data` to reload your test data (it should make a contest active on the PA House of Representatives template for the Azavea organization), or use `scripts/dbshell` to set up contest fields for a project template of your choice.
- Create a map for that template
  - There should be a "Submit" button in the upper-right. Submitting your map should display a success toast and open the Next steps modal. Clicking the "Submitted" button should display a link to re-open the next steps modal.
  - Using `scripts/dbshell`, update your project template to set the next steps HTML to be empty: `UPDATE project_template SET contest_next_steps = '';`
  - Submit another map - you should still see the toast, but not the Next steps modal, and there should no longer be a link to it.
  - Using `scripts/dbshell`, update your project template to set the contest to be inactive: `UPDATE project_template SET contest_active = FALSE;`. You should still see the "Submitted" button for maps that were already submitted, but should no longer see a "Submit" button for maps that were not yet submitted.
- A few minutes after submitting a map, go to the Evaluate > Competitiveness detail. The "View on PlanScore" link should be present, not the "Upload to PlanScore" button.

Closes #1170 
