### PR TITLE
update to postgres 13 and postgis 3.1

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,18 @@
+name: Github CI
+
+on:
+  push:
+    branches:
+      - postgis_upgrade
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/cibuild

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,13 @@
 version: "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:3-postgres12.4-slim
+    image: postgis/postgis:13-3.1
     environment:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder
       - POSTGRES_DB=districtbuilder
     healthcheck:
-      test: pg_isready -U districtbuilder
-      interval: 3s
-      timeout: 3s
-      retries: 3
+      test: pg_isready -q -h database -U districtbuilder
 
   server:
     image: districtbuilder


### PR DESCRIPTION
## Overview

One of the downtime's today seemed to line up with an autovacuum.  Postgres 13 has improvements to autovacuuming (and other size improvements)

It also appears to "just work" - and should be a relatively painless upgrade.  Also switched to upstream postgis image.
