### PR TITLE
Fix archived layers crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Updated tippecanoe & fix process-geojson [#1173](https://github.com/PublicMapping/districtbuilder/pull/1173)
+- Fixed crash when loading regions, don't show inactive templates / templates w/ archived regions [#1185](https://github.com/PublicMapping/districtbuilder/pull/1185)
 
 ## [1.15.1] - 2022-03-03
 

--- a/src/client/screens/ImportProjectScreen.tsx
+++ b/src/client/screens/ImportProjectScreen.tsx
@@ -289,7 +289,10 @@ function filterProjectTemplates<O extends OrganizationNest | IOrganization>(
   stateAbbrev: string
 ) {
   const projectTemplates = org.projectTemplates.filter(
-    template => template.regionConfig.regionCode === stateAbbrev
+    template =>
+      template.regionConfig.regionCode === stateAbbrev &&
+      template.isActive &&
+      !template.regionConfig.archived
   );
   return projectTemplates.length > 0 ? { ...org, projectTemplates } : undefined;
 }

--- a/src/manage/src/commands/create-random-projects.ts
+++ b/src/manage/src/commands/create-random-projects.ts
@@ -61,7 +61,7 @@ export default class CreateRandomProjects extends Command {
         this.exit(1);
         return;
       }
-      const geoCollection = await topologyService.get(region.s3URI);
+      const geoCollection = await topologyService.get(region);
       if (!geoCollection || !("merge" in geoCollection)) {
         this.log(`No active topology for region`);
         this.exit(1);

--- a/src/server/src/districts/controllers/districts.controller.ts
+++ b/src/server/src/districts/controllers/districts.controller.ts
@@ -73,7 +73,7 @@ export class DistrictsController {
             archived: false
           }
     );
-    const geoCollection = regionConfig && (await this.topologyService.get(regionConfig.s3URI));
+    const geoCollection = regionConfig && (await this.topologyService.get(regionConfig));
     if (!geoCollection) {
       throw new InternalServerErrorException();
     }

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -99,20 +99,20 @@ export class TopologyService {
     return this._layers && Object.freeze({ ...this._layers });
   }
 
-  public async get(s3URI: S3URI): Promise<GeoUnitTopology | undefined> {
+  public async get(regionConfig: RegionConfig): Promise<GeoUnitTopology | undefined> {
     if (!this._layers) {
       return;
     }
-    if (!(s3URI in this._layers)) {
+    if (!(regionConfig.s3URI in this._layers)) {
       // If we encounter a new layer (i.e. one added after the service has started),
       // then store the results in the `_layers` object.
-      // @ts-ignore
       // eslint-disable-next-line functional/immutable-data
-      this._layers[s3URI] = this.fetchLayer(s3URI).catch(err => {
+      this._layers[regionConfig.s3URI] = this.fetchLayer(regionConfig).catch(err => {
         this.logger.error(err);
+        return undefined;
       });
     }
-    const layer = this._layers[s3URI];
+    const layer = this._layers[regionConfig.s3URI];
     if (layer !== null) {
       return layer;
     }

--- a/src/server/src/organizations/services/organizations.service.ts
+++ b/src/server/src/organizations/services/organizations.service.ts
@@ -35,7 +35,8 @@ export class OrganizationsService extends TypeOrmCrudService<Organization> {
         "projectTemplates.name",
         "projectTemplates.numberOfDistricts",
         "projectTemplates.description",
-        "projectTemplates.details"
+        "projectTemplates.details",
+        "projectTemplates.isActive"
       ])
       .leftJoinAndSelect("projectTemplates.regionConfig", "regionConfig")
       .where("organization.slug = :slug", { slug: slug })

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -711,14 +711,12 @@ export class ProjectsController implements CrudController<Project> {
       validateNumberOfMembers(dto, dto.numberOfDistricts);
     }
 
-    // This is in a lambda bc prettier kept moving my @ts-ignore
-    const findTemplate = (id: ProjectTemplateId) =>
-      this.templateService.findOne(
-        // @ts-ignore
-        { id },
-        { relations: ["regionConfig", "referenceLayers", "chamber"] }
-      );
-    const template = dto.projectTemplate ? await findTemplate(dto.projectTemplate.id) : undefined;
+    const template = dto.projectTemplate
+      ? await this.templateService.findOne(
+          { id: dto.projectTemplate.id, isActive: true, regionConfig: { archived: false } },
+          { relations: ["regionConfig", "referenceLayers", "chamber"] }
+        )
+      : undefined;
     if (dto.projectTemplate && !template) {
       throw new NotFoundException(`Project template for id '${dto.projectTemplate?.id}' not found`);
     }

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -48,10 +48,8 @@ import {
   ProjectId,
   PublicUserProperties,
   UserId,
-  ProjectTemplateId,
   IUser,
-  IChamber,
-  IRegionConfig
+  IChamber
 } from "../../../../shared/entities";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
@@ -348,12 +346,12 @@ export class ProjectsController implements CrudController<Project> {
     return project;
   }
 
-  // Helper for obtaining a topology for a given S3 URI, throws exception if not found
-  async getGeoUnitTopology(s3URI: string): Promise<GeoUnitTopology> {
-    const geoCollection = await this.topologyService.get(s3URI);
+  // Helper for obtaining a topology for a given region config, throws exception if not found
+  async getGeoUnitTopology(regionConfig: RegionConfig): Promise<GeoUnitTopology> {
+    const geoCollection = await this.topologyService.get(regionConfig);
     if (!geoCollection) {
       throw new NotFoundException(
-        `Topology ${s3URI} not found`,
+        `Topology ${regionConfig.s3URI} not found`,
         MakeDistrictsErrors.TOPOLOGY_NOT_FOUND
       );
     }
@@ -371,9 +369,9 @@ export class ProjectsController implements CrudController<Project> {
     readonly numberOfDistricts: number;
     readonly user: IUser;
     readonly chamber?: IChamber;
-    readonly regionConfig: IRegionConfig;
+    readonly regionConfig: RegionConfig;
   }): Promise<DistrictsGeoJSON> {
-    const geoCollection = await this.getGeoUnitTopology(regionConfig.s3URI);
+    const geoCollection = await this.getGeoUnitTopology(regionConfig);
     const geojson = await geoCollection.merge({
       districtsDefinition,
       numberOfDistricts,
@@ -463,7 +461,7 @@ export class ProjectsController implements CrudController<Project> {
     @Param("id") projectId: ProjectId
   ): Promise<string> {
     const project = await this.getProject(req, projectId);
-    const geoCollection = await this.getGeoUnitTopology(project.regionConfig.s3URI);
+    const geoCollection = await this.getGeoUnitTopology(project.regionConfig);
     const baseGeoLevel = geoCollection.definition.groups.slice().reverse()[0];
     const csvRows = await geoCollection.exportToCSV(project.districtsDefinition);
 
@@ -642,7 +640,7 @@ export class ProjectsController implements CrudController<Project> {
     }
     validateNumberOfMembers(dto, existingProject.numberOfDistricts);
 
-    const staticMetadata = (await this.getGeoUnitTopology(existingProject.regionConfig.s3URI))
+    const staticMetadata = (await this.getGeoUnitTopology(existingProject.regionConfig))
       .staticMetadata;
     const allowedDemographicFields = getDemographicsMetricFields(staticMetadata).map(
       ([, field]) => field
@@ -740,7 +738,7 @@ export class ProjectsController implements CrudController<Project> {
       throw new NotFoundException(`Unable to find region config: ${dto.regionConfig?.id}`);
     }
 
-    const geoCollection = await this.topologyService.get(regionConfig.s3URI);
+    const geoCollection = await this.topologyService.get(regionConfig);
     if (!geoCollection) {
       throw new NotFoundException(
         `Topology ${regionConfig.s3URI} not found`,

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -63,7 +63,7 @@ export class RegionConfigsController implements CrudController<RegionConfig> {
   ): Promise<readonly RegionLookupProperties[]> {
     const regionConfig = await this.service.findOne({ id: regionId });
 
-    const geoCollection = regionConfig && (await this.topologyService.get(regionConfig.s3URI));
+    const geoCollection = regionConfig && (await this.topologyService.get(regionConfig));
     if (!geoCollection) {
       throw new InternalServerErrorException();
     }

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -280,6 +280,7 @@ export type IProjectTemplate = ProjectTemplateFields & {
   readonly description: string;
   readonly details: string;
   readonly referenceLayers?: readonly IReferenceLayer[];
+  readonly isActive: boolean;
 };
 
 export type IProjectTemplateWithProjects = IProjectTemplate & {


### PR DESCRIPTION
## Overview

This fixes a multi-part bug:
 - We were incorrectly displaying inactive project templates / templates for archived regions on the Create & Import screens
 - If you tried to create a project for an archived region, we would not detect or validate that (we do for import)
 - Causing the server to try and load a region after application startup would instead cause it to crash, which was triggered by the previous bug, since trying to use the template would then cause it to try and load the archived region

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

We had a `// @ts-ignore` above one of the offending lines I had to change in https://github.com/PublicMapping/districtbuilder/pull/1185/commits/64c378ce0887f03ec29b74dd02b2794cebfb8137, which had that line not been ignored would have revealed the type error. 😡 

## Testing Instructions

- Using `scripts/dbshell`, set one of your project template regions to be archived (from the `scripts/load-dev-data` regions I used PA).
  - On `develop`, if you attempt to create a project using that template, it will cause your server to crash
  - On this PR it should not be shown, and if you attempt to use the API to create a project for that template (to test, load the page with the region unarchived, then archive the region after the page loads) it should return an error and not crash the server
- Using `scripts/dbshell`, set the project template whose region you archived to be inactive
  - On `develop` you will still see an option to create a template using this project on both the Import & Create project screens. Attempting to create a project using the template from the Create project screen should cause your server to crash
  - On this PR, you should not see the template as an option
- Using `scripts/dbshell`, set _all_ of an organization's project templates to be inactive
  - On `develop` you should still see that organization as an option to create/import a project with
  - On this PR it should be filtered out
- After starting your server, use `scripts/dbshell` to add a new project region. Then try to create a project for this region.
   - On `develop` this should cause your server to crash
   - On this PR this should succeed

Closes #1176 
