### PR TITLE
Add submitted column to the Organization admin projects table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added submit map button [#1179](https://github.com/PublicMapping/districtbuilder/pull/1179)
+- Addded submitted column to the Organization admin projects table [#1192](https://github.com/PublicMapping/districtbuilder/pull/1192)
 
 ### Changed
 

--- a/src/client/components/OrganizationAdminProjectsTable.tsx
+++ b/src/client/components/OrganizationAdminProjectsTable.tsx
@@ -16,6 +16,7 @@ export interface ProjectRow extends ProjectNest {
   readonly project: { readonly name: string; readonly id: string };
   readonly updatedAgo: string;
   readonly templateName: string;
+  readonly submittedOn: string;
 }
 
 interface ProjectsTableProps {
@@ -46,7 +47,8 @@ const OrganizationAdminProjectsTable = ({ templates, organizationSlug }: Project
               ...p,
               project: { name: p.name, id: p.id },
               updatedAgo: formatDate(p.updatedDt),
-              templateName: pt.name
+              templateName: pt.name,
+              submittedOn: p.submittedDt ? formatDate(p.submittedDt) : "-"
             };
           });
         })
@@ -87,12 +89,18 @@ const OrganizationAdminProjectsTable = ({ templates, organizationSlug }: Project
           return <a href={`mailto:${p.value}`}>{p.value}</a>;
         }
       },
-
       {
         Header: "Updated on",
         accessor: "updatedDt" as const,
         Cell: (p: Cell<ProjectRow>) => {
           return p.row.original.updatedAgo;
+        }
+      },
+      {
+        Header: "Submitted on",
+        accessor: "submittedOn" as const,
+        Cell: (p: Cell<ProjectRow>) => {
+          return p.row.original.submittedOn;
         }
       },
       {

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -91,6 +91,7 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
         "projects.id",
         "projects.updatedDt",
         "projects.visibility",
+        "projects.submittedDt",
         "regionConfig.name",
         "user.name",
         "user.email"

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -239,6 +239,7 @@ export type ProjectNest = Pick<
   | "regionConfig"
   | "isFeatured"
   | "visibility"
+  | "submittedDt"
 > & {
   readonly regionConfig: Pick<IRegionConfig, "name">;
 };


### PR DESCRIPTION
## Overview

This PR adds the `Submitted on` sortable column to the Organization admin projects table.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screen Shot 2022-04-05 at 6 01 32 PM](https://user-images.githubusercontent.com/16109558/161857393-d154f99a-6dad-4a23-9a67-354dd943450a.png)

## Testing Instructions

- `./scripts/update`
- `./scripts/server`
- On the app frontend, log in, go to your organization, create a project from a template
- Submit the map from the map UI
- Go to your organization page, next to "Featured maps", click on "View All"
- Make sure you see a table view of the projects and make sure each record has a `Submitted on` column
- For the project submitted, it should show a timestamp; otherwise, it should show a `-`
- Click on `Submitted on` column- it should be sortable

Closes https://github.com/PublicMapping/districtbuilder/issues/1182
