### PR TITLE
Lower cache size and improve strategy for choosing workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added submit map button [#1179](https://github.com/PublicMapping/districtbuilder/pull/1179)
 
 ### Changed
+- Improved caching setup more & lowered cache size [#1195](https://github.com/PublicMapping/districtbuilder/pull/1195)
 
 ### Fixed
 

--- a/src/server/migrations/1649083635651-region_config_layer_size.ts
+++ b/src/server/migrations/1649083635651-region_config_layer_size.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class regionConfigLayerSize1649083635651 implements MigrationInterface {
+    name = 'regionConfigLayerSize1649083635651'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "region_config" ADD "layer_size_in_bytes" integer NOT NULL DEFAULT '0'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "region_config" DROP COLUMN "layer_size_in_bytes"`);
+    }
+
+}

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint 'src/**/*.{ts,tsx,json}'",
     "fix": "eslint 'src/**/*.{ts,tsx,json}' --fix",
     "reindex": "node dist/server/src/commands/reindex",
+    "set-topology-size": "node dist/server/src/commands/set-topology-size",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/server/src/commands/set-topology-size.ts
+++ b/src/server/src/commands/set-topology-size.ts
@@ -1,0 +1,51 @@
+import { Logger } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import S3 from "aws-sdk/clients/s3";
+import Queue from "promise-queue";
+
+import { AppModule } from "../app.module";
+import { DEBUG } from "../common/constants";
+import { formatBytes, getTopology, getTopologyLayerSize } from "../common/functions";
+import { RegionConfigsModule } from "../region-configs/region-configs.module";
+import { RegionConfigsService } from "../region-configs/services/region-configs.service";
+
+async function bootstrap(): Promise<void> {
+  const logger = new Logger();
+  if (process.argv.includes("--help")) {
+    logger.log("set-topology-size [-f | --force]");
+    process.exit(0);
+  }
+  const app = await NestFactory.create(AppModule, {
+    logger: DEBUG ? ["debug", "verbose", "log", "warn", "error"] : ["log", "warn", "error"]
+  });
+
+  const regionConfigsService = app
+    .select(RegionConfigsModule)
+    .get(RegionConfigsService, { strict: true });
+
+  const s3 = new S3();
+  const queue = new Queue(4);
+  const findOpts =
+    process.argv.includes("-f") || process.argv.includes("--force")
+      ? {}
+      : ({ layerSizeInBytes: 0 } as const);
+  const regionConfigs = await regionConfigsService.find(findOpts);
+  logger.log(`Found ${regionConfigs.length} regions`);
+  await Promise.all(
+    regionConfigs.map(regionConfig =>
+      queue.add(async () => {
+        const topology = await getTopology(regionConfig, s3);
+        // eslint-disable-next-line functional/immutable-data
+        regionConfig.layerSizeInBytes = getTopologyLayerSize(topology);
+        // @ts-ignore
+        await regionConfigsService.repo.save(regionConfig);
+        logger.log(
+          `Set ${regionConfig.s3URI} size to ${formatBytes(regionConfig.layerSizeInBytes)}`
+        );
+      })
+    )
+  );
+
+  await app.close();
+}
+bootstrap(); // eslint-disable-line @typescript-eslint/no-floating-promises

--- a/src/server/src/common/functions.ts
+++ b/src/server/src/common/functions.ts
@@ -3,6 +3,13 @@ import { Request } from "aws-sdk/lib/request";
 import { AWSError } from "aws-sdk/lib/error";
 
 import { S3URI } from "../../../shared/entities";
+import { RegionConfig } from "../region-configs/entities/region-config.entity";
+import { existsSync } from "fs";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import sizeof from "object-sizeof";
+import { join } from "path";
+import { Topology } from "topojson-specification";
+import { deserialize } from "v8";
 
 export function s3Options(path: S3URI, fileName: string): GetObjectRequest {
   const url = new URL(path);
@@ -29,4 +36,37 @@ export function formatBytes(bytes: number, decimals = 2) {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+// Gets the specified topology, downloading it from S3 and caching it locally if it is not already cached
+export async function getTopology(regionConfig: RegionConfig, s3: S3): Promise<Topology> {
+  const cacheDir = process.env.TOPOLOGY_CACHE_DIRECTORY || "/tmp";
+  const folderPath = join(cacheDir, regionConfig.id);
+  const filePath = join(folderPath, "topo.buf");
+
+  let buffer;
+  if (!existsSync(filePath)) {
+    const topojsonResponse = await getObject(s3, s3Options(regionConfig.s3URI, "topo.buf"));
+    buffer = topojsonResponse.Body as Buffer;
+    // Save file to disk for speedier access later
+    if (!existsSync(folderPath)) {
+      await mkdir(folderPath, { recursive: true });
+    }
+    await writeFile(filePath, buffer, "binary");
+  } else {
+    buffer = await readFile(filePath);
+  }
+  return deserialize(buffer) as Topology;
+}
+
+export function getTopologyLayerSize(topology: Topology) {
+  const numFeatures = Object.values(topology.objects)
+    .map(gc => (gc.type === "GeometryCollection" ? gc.geometries.length : 0))
+    .reduce((sum, length) => sum + length, 0);
+  const topoSize = sizeof(topology);
+  // Hierarchy size:
+  // 1 node per feature, each node has 1 geom pointer (8 bytes) + 1 array (16 bytes)
+  //  Each node is pointed to by its parent node (8 bytes)
+  const hierarchySize = numFeatures * 32;
+  return topoSize + hierarchySize;
 }

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -3,19 +3,19 @@ import {
   IStaticMetadata,
   TypedArrays,
   DistrictsDefinition,
-  IRegionConfig,
-  IUser,
-  IChamber,
   TopologyProperties
 } from "../../../../shared/entities";
+import { Chamber } from "../../chambers/entities/chamber.entity";
 import { DistrictsGeoJSON } from "../../projects/entities/project.entity";
+import { RegionConfig } from "../../region-configs/entities/region-config.entity";
+import { User } from "../../users/entities/user.entity";
 import { merge, exportToCSV, getTopologyProperties, importFromCSV } from "../../worker-pool";
 
 export class GeoUnitTopology {
   constructor(
     public readonly definition: GeoUnitDefinition,
     public readonly staticMetadata: IStaticMetadata,
-    public readonly regionConfig: IRegionConfig,
+    public readonly regionConfig: RegionConfig,
     public readonly demographics: TypedArrays,
     public readonly voting: TypedArrays,
     public readonly geoLevels: TypedArrays,
@@ -35,9 +35,9 @@ export class GeoUnitTopology {
   }: {
     readonly districtsDefinition: DistrictsDefinition;
     readonly numberOfDistricts: number;
-    readonly user: IUser;
-    readonly chamber?: IChamber;
-    readonly regionConfig: IRegionConfig;
+    readonly user: User;
+    readonly chamber?: Chamber;
+    readonly regionConfig: RegionConfig;
   }): Promise<DistrictsGeoJSON | null> {
     return merge({
       districtsDefinition,

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -160,7 +160,7 @@ export class TopologyService {
   // For most regions, this is the number of counties in the state
   private async getDistrictsDefLength(regionConfig: RegionConfig, staticMetadata: IStaticMetadata) {
     const topGeoLevel = staticMetadata.geoLevelHierarchy.slice().reverse()[0].id;
-    const properties = await getTopologyProperties(regionConfig, staticMetadata);
+    const properties = await getTopologyProperties(regionConfig, staticMetadata, 0);
     return properties[topGeoLevel] ? properties[topGeoLevel].length : 0;
   }
 

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -6,13 +6,7 @@ import _ from "lodash";
 import { cpus } from "os";
 import { Repository } from "typeorm";
 
-import {
-  TypedArrays,
-  IStaticFile,
-  IStaticMetadata,
-  S3URI,
-  IRegionConfig
-} from "../../../../shared/entities";
+import { TypedArrays, IStaticFile, IStaticMetadata, S3URI } from "../../../../shared/entities";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { GeoUnitTopology } from "../entities/geo-unit-topology.entity";
 import { getObject, s3Options } from "../../common/functions";
@@ -119,7 +113,7 @@ export class TopologyService {
   }
 
   private async fetchLayer(
-    regionConfig: IRegionConfig,
+    regionConfig: RegionConfig,
     numRetries = 0
   ): Promise<GeoUnitTopology | undefined> {
     try {
@@ -179,10 +173,7 @@ export class TopologyService {
 
   // Computes the length of the districtsDefinition array
   // For most regions, this is the number of counties in the state
-  private async getDistrictsDefLength(
-    regionConfig: IRegionConfig,
-    staticMetadata: IStaticMetadata
-  ) {
+  private async getDistrictsDefLength(regionConfig: RegionConfig, staticMetadata: IStaticMetadata) {
     const topGeoLevel = staticMetadata.geoLevelHierarchy.slice().reverse()[0].id;
     const properties = await getTopologyProperties(regionConfig, staticMetadata);
     return properties[topGeoLevel] ? properties[topGeoLevel].length : 0;

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -47,9 +47,7 @@ import {
   DistrictsDefinition,
   ProjectId,
   PublicUserProperties,
-  UserId,
-  IUser,
-  IChamber
+  UserId
 } from "../../../../shared/entities";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { GeoUnitTopology } from "../../districts/entities/geo-unit-topology.entity";
@@ -74,6 +72,7 @@ import { ProjectTemplatesService } from "../../project-templates/services/projec
 import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
 import { ReferenceLayersService } from "../../reference-layers/services/reference-layers.service";
 import { ChambersService } from "../../chambers/services/chambers";
+import { Chamber } from "../../chambers/entities/chamber.entity";
 import { ReferenceLayer } from "../../reference-layers/entities/reference-layer.entity";
 
 function validateNumberOfMembers(
@@ -368,8 +367,8 @@ export class ProjectsController implements CrudController<Project> {
   }: {
     readonly districtsDefinition: DistrictsDefinition;
     readonly numberOfDistricts: number;
-    readonly user: IUser;
-    readonly chamber?: IChamber;
+    readonly user: User;
+    readonly chamber?: Chamber;
     readonly regionConfig: RegionConfig;
   }): Promise<DistrictsGeoJSON> {
     const geoCollection = await this.getGeoUnitTopology(regionConfig);

--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -52,4 +52,7 @@ export class RegionConfig implements IRegionConfig {
 
   @Column({ type: "enum", enum: CensusDate, default: CensusDate.Census2020 })
   census: CensusDate;
+
+  @Column({ name: "layer_size_in_bytes", type: "integer", default: 0 })
+  layerSizeInBytes: number;
 }

--- a/src/server/src/region-configs/services/region-configs.service.ts
+++ b/src/server/src/region-configs/services/region-configs.service.ts
@@ -7,7 +7,7 @@ import { RegionConfig } from "../entities/region-config.entity";
 
 @Injectable()
 export class RegionConfigsService extends TypeOrmCrudService<RegionConfig> {
-  constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
+  constructor(@InjectRepository(RegionConfig) public repo: Repository<RegionConfig>) {
     super(repo);
   }
 }

--- a/src/server/src/worker-pool.ts
+++ b/src/server/src/worker-pool.ts
@@ -102,12 +102,12 @@ async function findQueue(regionConfig: RegionConfig): Promise<number> {
       // than be forced to terminate a thread to make room
       lastUsed.length < MAX_PER_REGION && availableWorkerIndexes.some(willFit)
       ? getBestFit(availableWorkerIndexes)
+      : // If nothing will fit use the least recently used worker, which wil get terminated
+      lastUsed.length < MAX_PER_REGION
+      ? // eslint-disable-next-line functional/immutable-data
+        workersByRecency.pop()
       : // If there are no settled workers and we hit the limit on adding more, use the most recent for this region
-      lastUsed.length > 0
-      ? lastUsed[0]
-      : // Lastly if nothing will fit use the least recently used worker, which wil get terminated
-        // eslint-disable-next-line functional/immutable-data
-        workersByRecency.pop()) || 0;
+        lastUsed[0]) || 0;
 
   // If this region wasn't already in this workers cache, update the worker size
   // This may trigger recreating the worker thread if we would exceed the max size

--- a/src/server/src/worker-pool.ts
+++ b/src/server/src/worker-pool.ts
@@ -14,7 +14,7 @@ import { Functions, MergeArgs } from "./worker";
 // Timeout after which we kill/recreate the worker thread
 const TASK_TIMEOUT_MS = 90_000;
 
-// Reserve 6Gb + 35% of memory for responding to requests and loading topology data from disk
+// Reserve about 50% of memory for responding to requests and loading topology data from disk
 // Remaining amount is split amongst each worker for topology data
 // This strategy seems to work for any amount of host memory and targets total memory
 // in use maxing out at around 80%
@@ -23,7 +23,11 @@ const dockerMemLimit = Number(
 );
 const hostmem = os.totalmem();
 const totalmem = Math.min(hostmem, dockerMemLimit);
-const reservedMem = 6 * 1024 * 1024 * 1024 + totalmem * 0.35;
+// Targets:
+// 9Gb reserved for 12Gb total (dev)
+// 18Gb reserved for 31Gb total (32Gb instance w/ ~1Gb for ECS agent)
+// 29Gb reserved for 63Gb total (64Gb instance w/ ~1Gb ECS agent)
+const reservedMem = 3 * 1024 * 1024 * 1024 + totalmem * 0.5;
 const maxCacheSize = Math.ceil((totalmem - reservedMem) / NUM_WORKERS);
 
 const logger = new Logger("worker-pool");


### PR DESCRIPTION
## Overview

Since releasing `1.16.1` our production tasks have become much better at utilizing worker cache - _too_ good in fact, as we've seen several tasks run out of memory and get killed.

I determined a cache level that should always be safe from workers running out of memory and is able to hold all 50 states (13Gb on a 32Gb instance), however while this was only a few GB lower than the previous amount I found it was no longer able to reliably start the application without at least one worker running out of memory and needing to be recreated.

After some research (see https://en.wikipedia.org/wiki/Bin_packing_problem#Offline_algorithms) I determined the best way to ensure full cache utilization on startup would require knowing the region size ahead of time, so I added a new `layer_size_in_bytes` field to `RegionConfig` that stores the size instead of calculating it on the fly, and added a command to set it that we can run for production (I already ran it on staging when testing this branch).

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

Cache size logged:
![image](https://user-images.githubusercontent.com/4432106/162100929-911ccc84-bd76-403d-8572-b313d18597da.png)

After loading all 50 states, loading a 2nd CA region was enough to tip us over the edge and cause the 1st worker to be recreated - but note that for 2 / 4 workers we have _exactly_ `3.12Gb` of space being used - the maximum.
![image](https://user-images.githubusercontent.com/4432106/162101210-b79e8dfe-13e9-43d5-a3e2-1f9a8eafd2a9.png)


### Notes

I'm hopeful the changes in https://github.com/PublicMapping/districtbuilder/commit/d50c88485b4c5955b5e1fa267bf7ec32024866c6 will also address #1189 but I'm not sure

## Testing Instructions

- `scripts/update`
- You should be able to start your server locally
