### PR TITLE
Drop demographics and voting fields from the topology data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved caching setup more & lowered cache size [#1195](https://github.com/PublicMapping/districtbuilder/pull/1195)
+- Drop demographics and voting fields from TopoJSON [#1197](https://github.com/PublicMapping/districtbuilder/pull/1197)
 
 ### Fixed
 


### PR DESCRIPTION
## Overview

I noticed when adding VAP & CVAP to TX and FL that it increased the file size much more than I was expecting (from 888Mb to 1.5Gb).

The demographic fields don't actually get loaded by the server (it uses the typed array buffers for this data), so they're taking up memory for no real purpose.

Previously we didn't think this was a huge deal, as we assumed the demographic fields were small in comparison to the geographic data, but tripling the number of demographic fields made their size much more noticeable.

Incidentally, it turns out the size of the demographic fields differs from state to state, and while there _are_ some states, in particular _Pennsylvania_ which we often use for testing, that have proportionately much more geographic data than demographic data and adding VAP & CVAP didn't increase file size that much, in most of the regions I looked at adding VAP & CVAP led to a 50-100% increase in file size.
I'm not entirely sure why PA is such an outlier here, but that's probably a lesson to keep in mind on other projects when spot testing data results...

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

From my server logs locally - if you look in the staging logs the TX file is 888MB.
```
server_1    | [Nest] 41  - 04/12/2022, 6:55:20 PM   DEBUG [worker-0] Adding layer s3://global-districtbuilder-dev-us-east-1/regions/US/TX/2022-04-12T18:30:39.262Z/, size: 571.33 MB
server_1    | [Nest] 41  - 04/12/2022, 6:55:27 PM   DEBUG [TopologyService] downloaded data for s3URI s3://global-districtbuilder-dev-us-east-1/regions/US/TX/2022-04-12T18:30:39.262Z/
```

### Notes

As far as I can tell we've _never_ directly used the `demographics` or `voting` fields in the TopoJSON?

They're added in `process-geojson` when generating it so that they get aggregated up into the higher geolevels and vector tiles, but the server itself doesn't seem to need them.

## Testing Instructions
@dmcglone tested this already, so I don't think you need to be super thorough here

- Use `scripts/process-geojson` to process a region and `scripts/publish-region` to publish the files to S3 and add it to your local database
- Create a map for the region. There should be no regressions w/ creating a map, importing, exporting, or using the Evaluate page (operations that use topology data)

Connects to #1171 
