### PR TITLE
Revert "Create project indexes concurrently by disabling migration transactions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved caching setup more & lowered cache size [#1195](https://github.com/PublicMapping/districtbuilder/pull/1195)
+- Re-enable transactions for migrations [#1200](https://github.com/PublicMapping/districtbuilder/pull/1200)
 
 ### Fixed
 

--- a/src/server/migrations/1629680461750-project_index.ts
+++ b/src/server/migrations/1629680461750-project_index.ts
@@ -5,10 +5,10 @@ export class projectIndex1629680461750 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY "IDX_110113f7f5d7d3b08d0c12f5b0" ON "project" ("updated_dt", "user_id")`
+      `CREATE INDEX "IDX_110113f7f5d7d3b08d0c12f5b0" ON "project" ("updated_dt", "user_id")`
     );
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY "IDX_PUBLISHED_PROJECTS" ON "project" ("updated_dt" DESC, jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates'), "region_config_id") WHERE "archived" <> TRUE AND "visibility" = 'PUBLISHED'`
+      `CREATE INDEX "IDX_PUBLISHED_PROJECTS" ON "project" ("updated_dt" DESC, jsonb_array_length(project.districts->'features'->0->'geometry'->'coordinates'), "region_config_id") WHERE "archived" <> TRUE AND "visibility" = 'PUBLISHED'`
     );
   }
 

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -23,7 +23,7 @@
     "migration:generate": "yarn run typeorm migration:generate -n",
     "migration:create": "yarn run typeorm migration:create -n",
     "migration:revert": "yarn run typeorm migration:revert",
-    "migration:run": "yarn run typeorm migration:run -t=false"
+    "migration:run": "yarn run typeorm migration:run"
   },
   "dependencies": {
     "@drdgvhbh/postgres-error-codes": "0.0.6",


### PR DESCRIPTION
## Overview

We temporarily disabled transactions when running migrations a few releases ago in order to create some indexes concurrently (which cannot be done when in a transaction).
This reverts commit fd83d58028422aa2c5198a112af48cb5990f8dec, re-enabling transactions when running migrations.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Delete/recreate your database and run `scripts/migration` - it should succeed.

Closes #991 
