### PR TITLE
Submit button tweaks / text changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added submit map button [#1179](https://github.com/PublicMapping/districtbuilder/pull/1179)
+- Added submit map button [#1179](https://github.com/PublicMapping/districtbuilder/pull/1179) & [#1201](https://github.com/PublicMapping/districtbuilder/pull/1201)
 - Added submitted column to the Organization admin projects table [#1192](https://github.com/PublicMapping/districtbuilder/pull/1192)
 - Added submission date and plan score url to organization map CSV export [#1193](https://github.com/PublicMapping/districtbuilder/pull/1193)
 - Added a lambda function to send DB server alarms to Slack [#1186](https://github.com/PublicMapping/districtbuilder/pull/1186)

--- a/src/client/components/HomeScreenProjectCard.tsx
+++ b/src/client/components/HomeScreenProjectCard.tsx
@@ -6,6 +6,8 @@ import { IProject } from "../../shared/entities";
 import ProjectListFlyout from "./ProjectListFlyout";
 import TimeAgo from "timeago-react";
 import ProjectDistrictsMap from "./map/ProjectDistrictsMap";
+import React from "react";
+import Icon from "./Icon";
 
 const style: Record<string, ThemeUIStyleObject> = {
   featuredProject: {
@@ -103,7 +105,15 @@ const HomeScreenProjectCard = ({
             fontSize: 1
           }}
         >
-          Last updated <TimeAgo datetime={project.updatedDt} />
+          {project.submittedDt ? (
+            <React.Fragment>
+              <Icon name="check" /> Submitted <TimeAgo datetime={project.submittedDt} />
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              Last updated <TimeAgo datetime={project.updatedDt} />
+            </React.Fragment>
+          )}
         </Text>
       </Box>
       <span sx={style.flyoutButton}>

--- a/src/client/components/map/SubmitMapButton.tsx
+++ b/src/client/components/map/SubmitMapButton.tsx
@@ -67,8 +67,7 @@ const SubmitMapButton = ({
             </React.Fragment>
           ) : (
             <React.Fragment>
-              Submitting will send your map to {organization.name}
-              <p sx={{ mt: 0 }}>The following things will happen:</p>
+              Submitting will send your map to {organization.name}, and the following will happen:
               <p>
                 <Icon name={"lock-locked"} /> Your map will be locked from making additional changes
               </p>
@@ -78,7 +77,7 @@ const SubmitMapButton = ({
               </p>
               <p>
                 <Icon name={"link"} /> If your map is private, it will be switched to “shared with
-                link” so the contest can see it
+                link” so the administrators can see it
               </p>
               <Button
                 disabled={saving === "saving"}

--- a/src/client/screens/ProjectScreen.tsx
+++ b/src/client/screens/ProjectScreen.tsx
@@ -124,7 +124,11 @@ const ProjectScreen = ({
   const wasSubmittedRef = useRef<boolean | undefined>();
 
   useEffect(() => {
-    if (wasSubmittedRef.current === false && wasSubmitted(project)) {
+    if (
+      wasSubmittedRef.current === false &&
+      wasSubmitted(project) &&
+      project?.projectTemplate?.contestNextSteps === ""
+    ) {
       toast.success(
         <span>
           <Icon name="check" /> Your map was submitted!

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -64,6 +64,7 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
           "project.numberOfDistricts",
           "project.updatedDt",
           "project.createdDt",
+          "project.submittedDt",
           "chamber.name",
           "regionConfig.name",
           "regionConfig.id",


### PR DESCRIPTION
## Overview

Some tweaks to the submit map process, plus a change to differentiate submitted maps on the home screen

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![Screenshot 2022-04-13 160836](https://user-images.githubusercontent.com/4432106/163264195-01b4a351-8481-449b-ab10-a2b21bcd275e.png)
![image](https://user-images.githubusercontent.com/4432106/163264260-fff757db-1f94-4c80-ba66-7becd8c76dbc.png)


## Testing Instructions

- `scripts/server`
- Submit a map connected to project template with an active contest and `contestNextSteps` text set
  - You should not see a toast message
- Submit a map connected to project template with an active contest and `contestNextSteps` text not set (you could run `UPDATE project_template SET contest_next_steps = '';` using `scripts/dbshell`)
  - You should see a toast message after submitting
- The home screen should show "✅Submitted" for your submitted projects instead of "Last updated"

Closes #1199 
