### PR TITLE
Fix planscore errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
 ### Changed
+ - Improved PlanScore error logging & double timeout [#1204](https://github.com/PublicMapping/districtbuilder/pull/1204)
+
 ### Fixed
+
 
 ## [1.17.0]
 

--- a/src/server/src/projects/controllers/projects.controller.ts
+++ b/src/server/src/projects/controllers/projects.controller.ts
@@ -550,7 +550,7 @@ export class ProjectsController implements CrudController<Project> {
           const planscoreUrl = await this.uploadToPlanScore(project);
           void this.service.updateOne(req, { planscoreUrl });
         } catch (e) {
-          this.logger.error(`Error uploading to planscore: ${e}`);
+          this.logger.error(`Error uploading to planscore for project '${projectId}': ${e}`);
           void this.service.updateOne(req, { planscoreUrl: "error" });
         }
       };
@@ -619,13 +619,13 @@ export class ProjectsController implements CrudController<Project> {
           apiResponse.data.status
             ? resolve(void 0)
             : numTries >= PLANSCORE_POLL_MAX_TRIES
-            ? reject()
+            ? reject(new Error("Exceeded maximum number of retries"))
             : setTimeout(
                 () => resolve(this.pollPlanScoreProgress(indexUrl, numTries + 1)),
                 PLANSCORE_POLL_MS
               );
         })
-        .catch(() => reject());
+        .catch(e => reject(e));
     });
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -164,4 +164,4 @@ export const MAX_UPLOAD_FILE_SIZE = 25_000_000;
 export const MAX_IMPORT_ERRORS = 1_000;
 
 export const PLANSCORE_POLL_MAX_TRIES = 40;
-export const PLANSCORE_POLL_MS = 3000;
+export const PLANSCORE_POLL_MS = 6000;


### PR DESCRIPTION
## Overview

 - Improves Planscore error logging - we were catching some exceptions and not logging them, and we didn't define an error for timeouts
 - Assuming the error is being caused by timeouts, I've doubled the interval for checking results, which will double the amount of time before we consider the upload timed out

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions


- Apply the following diff to make most PlanScore uploads time out:
   ```diff
   diff --git a/src/shared/constants.ts b/src/shared/constants.ts
   index 63eeb753..3a5ba39a 100644
   --- a/src/shared/constants.ts
   +++ b/src/shared/constants.ts
   @@ -163,5 +163,5 @@ export const MAX_UPLOAD_FILE_SIZE = 25_000_000;
    
    export const MAX_IMPORT_ERRORS = 1_000;
    
   -export const PLANSCORE_POLL_MAX_TRIES = 40;
   +export const PLANSCORE_POLL_MAX_TRIES = 1;
    export const PLANSCORE_POLL_MS = 6000;
    ```
  - On `develop` you should see an error message logged to the console `Error uploading to planscore: undefined`
  - On this branch, the error message should be included w/ the log as well as the project ID

Closes #1194 
