### PR TITLE
Hide last page button on Community Maps screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+ - Hid last page button on Community Maps screen [#1208](https://github.com/PublicMapping/districtbuilder/pull/1208)
 
 ### Fixed
 

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -45,7 +45,10 @@ const PaginationFooter = ({
 
   // We show a set of pages around the current page, as well as links for first & last page
   const startingPage = Math.max(1, currentPage - MAX_PAGES_AROUND_CURRENT);
-  const endingPage = Math.min(totalPages, currentPage + MAX_PAGES_AROUND_CURRENT);
+  const endingPage = Math.min(
+    showLastPageButton ? totalPages : totalPages + 1,
+    currentPage + MAX_PAGES_AROUND_CURRENT
+  );
   const pageNumbers = range(startingPage, endingPage);
 
   const PageLink = ({ number }: { readonly number: number }) => (

--- a/src/client/components/PaginationFooter.tsx
+++ b/src/client/components/PaginationFooter.tsx
@@ -7,6 +7,7 @@ import { range } from "lodash";
 interface StateProps {
   readonly currentPage: number;
   readonly totalPages: number;
+  readonly showLastPageButton?: boolean;
   // eslint-disable-next-line
   readonly setPage: (number: number) => void;
 }
@@ -34,7 +35,12 @@ const style = {
 
 const MAX_PAGES_AROUND_CURRENT = 3;
 
-const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
+const PaginationFooter = ({
+  currentPage,
+  totalPages,
+  setPage,
+  showLastPageButton = true
+}: StateProps) => {
   // This component is to be used for server-side pagination with a list of elements rendered separately.
 
   // We show a set of pages around the current page, as well as links for first & last page
@@ -66,14 +72,15 @@ const PaginationFooter = ({ currentPage, totalPages, setPage }: StateProps) => {
           {pageNumbers.map(number => (
             <PageLink number={number} key={number} />
           ))}
-          {pageNumbers[pageNumbers.length - 1] === totalPages || (
-            <React.Fragment>
-              {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
-                <span sx={{ px: 2, fontWeight: "800" }}>·</span>
-              )}
-              <PageLink number={totalPages} />
-            </React.Fragment>
-          )}
+          {showLastPageButton &&
+            (pageNumbers[pageNumbers.length - 1] === totalPages || (
+              <React.Fragment>
+                {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+                  <span sx={{ px: 2, fontWeight: "800" }}>·</span>
+                )}
+                <PageLink number={totalPages} />
+              </React.Fragment>
+            ))}
         </ul>
       )}
     </Box>

--- a/src/client/screens/PublishedMapsListScreen.tsx
+++ b/src/client/screens/PublishedMapsListScreen.tsx
@@ -176,6 +176,7 @@ const PublishedMapsListScreen = ({
                   <PaginationFooter
                     currentPage={pagination.currentPage}
                     totalPages={pagination.totalPages}
+                    showLastPageButton={false}
                     setPage={number => store.dispatch(globalProjectsFetchPage(number))}
                   />
                 </Box>


### PR DESCRIPTION
## Overview

This PR adds a prop to the `PaginationFooter` component so that we configure the community maps UI to not show the last page button.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

Note that the linked issue's original scope was changed in the first comment.

## Testing Instructions

- Spin up app servers and frontend
- Log in to the home screen. Make sure the pagination footer shows the last page button
- Navigate to the "Community maps" page. Make sure the pagination footer does not show the last page button

Closes #1205 
