### PR TITLE
Fix manage scripts typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - Fixed typos in process-geojson & serialize-topojson commands [#1209](https://github.com/PublicMapping/districtbuilder/pull/1209)
 
 
 ## [1.17.1]

--- a/src/manage/src/commands/process-geojson.ts
+++ b/src/manage/src/commands/process-geojson.ts
@@ -522,8 +522,8 @@ it when necessary (file sizes ~1GB+).
   ) {
     const filteredTopojson = this.filterTopoJson(topology, demographics, voting);
     this.log("Writing topojson file");
-    const path = join(dir, "topo.buf");
-    const output = createWriteStream(path, { encoding: "binary" });
+    const path = join(dir, "topo.json");
+    const output = createWriteStream(path, { encoding: "utf-8" });
     output.write(JSON.stringify(filteredTopojson));
     output.close();
   }

--- a/src/manage/src/commands/serialize-topojson.ts
+++ b/src/manage/src/commands/serialize-topojson.ts
@@ -43,7 +43,7 @@ export default class SerializeTopojson extends Command {
       cli.action.start(`Reading base TopoJSON: ${s3URI}`);
       const baseTopojson = await (flags.input === "json"
         ? this.readJson(s3URI)
-        : flags.output === "buf"
+        : flags.input === "buf"
         ? this.readBuf(s3URI)
         : this.readPbf(s3URI));
       cli.action.stop();


### PR DESCRIPTION
## Overview

When deploying the CVAP data last night, I realized I needed to reprocess Florida.

This then revealed a few small typos w/ the wrong file extension in our processing scripts, which this PR fixes.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

You can use this file for testing: 
[ri_vap_cvap_1620.zip](https://github.com/PublicMapping/districtbuilder/files/8640088/ri_vap_cvap_1620.zip)

Unzip and move it to `src/manage/data/ri_vap_cvap_1620.geojson`, and run the following commands:

 - `mkdir -p src/manage/data/output-ri`
  - `./scripts/manage process-geojson data/ri_vap_cvap_1620.geojson -d "population:population,white:white,black:black,hispanic:hispanic,asian:asian,native:native,pacific:pacific" -d "vap:VAP,vapwhite:VAP White,vapblack:VAP Black,vaphispanic:VAP Hispanic,vapasian:VAP Asian,vapnatam:VAP Native,vappacisl:VAP Pacific"  -d "cvap:CVAP,cvap_nh_white:CVAP White,cvap_nh_black:CVAP Black,cvap_hispanic:CVAP Hispanic,cvap_nh_asian:CVAP Asian,cvap_nh_amind:CVAP Native,cvap_nh_pacisl:CVAP Pacific" -v "voterep16:republican16,votedem16:democrat16,voteoth16:other party16,voterep20:republican20,votedem20:democrat20,voteoth20:other party20" -l block:block,blockgroup:blockgroup,county:county -n 12,4,4 -o data/output-ri -x 12,12,12`
  - `./scripts/manage publish-region data/output-ri US RI "Rhode Island"`

After doing the above, you should be able to create RI maps in your local dev environment.

Round trip the published data above using `serialize-topojson` from json -> another format -> back to json to test the changes to `serialize-topojson`:
  - `./scripts/manage serialize-topojson -i json -o buf <The S3 URI output from publish-region>`
  - `./scripts/manage serialize-topojson -i buf -o json <The S3 URI output from publish-region>`
