### PR TITLE
Reduce max cache and fix max workers / region check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+ - Reduce max cache size [#1213](https://github.com/PublicMapping/districtbuilder/pull/1213)
 
 ### Fixed
 

--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -25,11 +25,10 @@ const dockerMemLimit = existsSync("/sys/fs/cgroup/memory.max")
 const hostmem = os.totalmem();
 const totalmem = Math.min(hostmem, dockerMemLimit);
 // Targets:
-// 1.5Gb of cache for 12Gb total (dev)
-//   3Gb of cache for 15Gb total (16Gb instance w/ ~1Gb ECS agent)
-//  11Gb of cache for 31Gb total (32Gb instance w/ ~1Gb ECS agent)
-//  27Gb of cache for 63Gb total (64Gb instance w/ ~1Gb ECS agent)
-export const cacheSize = totalmem * 0.5 - 4.5 * 1024 * 1024 * 1024;
+// 1.8Gb of cache for 12Gb total (dev)
+// 3.0Gb of cache for 15Gb total (16Gb instance w/ ~1Gb ECS agent)
+// 9.5Gb of cache for 31Gb total (32Gb instance w/ ~1Gb ECS agent)
+export const cacheSize = totalmem * 0.4 - 3 * 1024 * 1024 * 1024;
 const maxWorkerCacheSize = Math.ceil(cacheSize / NUM_WORKERS);
 
 // Not that important to limit small regions, but large regions in every worker will eat up our cache

--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -202,7 +202,7 @@ export class WorkerPoolService {
         const [workerIndex, addedToRegion] = this.findQueue(regionConfig);
         const task = this.workerQueues[workerIndex].add(() =>
           this.workers[workerIndex]
-            .then((worker: undefined | WorkerThread | Promise<WorkerThread>) => {
+            .then(async (worker: WorkerThread | undefined) => {
               // If this region wasn't already in this workers cache, update the worker size
               // This may trigger recreating the worker thread if we would exceed the max size
               if (addedToRegion) {
@@ -212,7 +212,7 @@ export class WorkerPoolService {
 
                 if (this.workerSizes[workerIndex] + size > maxWorkerCacheSize) {
                   // eslint-disable-next-line no-param-reassign
-                  worker = this.createWorker(workerIndex, "OoM");
+                  worker = await this.createWorker(workerIndex, "OoM");
                   // Reset tracking info for this worker (any pending data stays the same)
                   this.workerSizes[workerIndex] = 0;
                   this.workersByRegion = _.mapValues(this.workersByRegion, workers =>

--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -96,7 +96,10 @@ export class WorkerPoolService {
       (!this.pendingWorkersByRegion[regionConfig.id] ||
         !this.pendingWorkersByRegion[regionConfig.id].includes(worker));
     const availableWorkerIndexes = [...this.workerQueues.keys()].filter(workerLacksRegion);
-    const lastUsed = this.workersByRegion[regionConfig.id] || [];
+    const lastUsed = [
+      ...(this.workersByRegion[regionConfig.id] || []),
+      ...(this.pendingWorkersByRegion[regionConfig.id] || [])
+    ];
 
     const lastUsedSettled = getSettledQueues(this.workerQueues, lastUsed);
     const settledQueues = getSettledQueues(this.workerQueues, availableWorkerIndexes);


### PR DESCRIPTION
## Overview

Reduces the worker max cache size, to prevent OoM issues currently being encountered on production.

Since we seemed to be operating fine as-is on other instances sizes I tried to adjust the way we determine cache size to leave the amounts for development & staging roughly the same while reducing the production server cache size.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

![image](https://user-images.githubusercontent.com/4432106/167499991-5f3adc1b-88f1-47cb-a750-688c4118de0c.png)

### Notes

The purpose of https://github.com/PublicMapping/districtbuilder/commit/6f0b96abeba39f39bf75d799db75c686202de0c2 was to improve our logging when terminating workers:
https://github.com/PublicMapping/districtbuilder/blob/6f0b96abeba39f39bf75d799db75c686202de0c2/src/server/src/districts/services/worker-pool.service.ts#L172-L176
Without this change the `workerSize` for that worker index will have already been reduced by the time we recreate the worker.

We were also being overly aggressive in loading new regions - only checking regions that were fully loaded and not pending regions when determining if we can add another region. This showed up in my load tests log output as the following (we should max out at 2 workers w/ PA data, but we create 3):
![image](https://user-images.githubusercontent.com/4432106/167496592-4e485e23-283b-453e-b715-a864bbe0512a.png)
This is fixed by https://github.com/PublicMapping/districtbuilder/commit/dcce52eae6fc4a2ff24d511b8df5197cf337c228

## Testing Instructions

Ensure you can start your local server and create/edit maps.

I already load tested staging and the `rss` rose up to a high of 29.5Gb using code on the `develop` branch and maxed out at 27.75Gb on this branch.

Closes #1211 
