### PR TITLE
Fix worker timeout check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
- - Fixed typos in process-geojson & serialize-topojson commands [#1209](https://github.com/PublicMapping/districtbuilder/pull/1209)
+- Fixed typos in process-geojson & serialize-topojson commands [#1209](https://github.com/PublicMapping/districtbuilder/pull/1209)
+- Recreate workers when they time out [#1214](https://github.com/PublicMapping/districtbuilder/pull/1214)
 
 
 ## [1.17.1]
 ### Changed
- - Improved PlanScore error logging & double timeout [#1204](https://github.com/PublicMapping/districtbuilder/pull/1204)
- - Revert to using JSON for data serialization [#1206](https://github.com/PublicMapping/districtbuilder/pull/1206)
+- Improved PlanScore error logging & double timeout [#1204](https://github.com/PublicMapping/districtbuilder/pull/1204)
+- Revert to using JSON for data serialization [#1206](https://github.com/PublicMapping/districtbuilder/pull/1206)
 
 
 ## [1.17.0]


### PR DESCRIPTION
## Overview

With the timeout checking done outside of the queue, timed out tasks have their worker thread recreated, but no new tasks can be queued because the timed out task will never complete or be rejected.

By moving the timeout into the body of the `workerQueue` task, when we return an error that task will be removed from the queue, allowing future tasks to be run instead of blocking forever.


### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

Apply the following diff to cause attempts to edit projects to time out:
```diff
diff --git a/src/server/src/worker.ts b/src/server/src/worker.ts
index 817bcb8a..8110a701 100644
--- a/src/server/src/worker.ts
+++ b/src/server/src/worker.ts
@@ -248,6 +248,8 @@ async function merge({
   demographics,
   voting
 }: MergeArgs): Promise<DistrictsGeoJSON | null> {
+  await new Promise(r => setTimeout(r, 120_000));
+
   const [topology, hierarchy] = await getTopologyFromCache(regionConfig, staticMetadata);
 
   // mutableDistrictGeoms contains the individual geometries prior to being merged
```

- On `develop` with the above diff applied, attempting to export a CSV for a project should work, but attempting to save a change to the project should eventually time out. _After_ saving the project times out, CSV exports should also timeout.
- On this branch with the above diff applied, attempting to export a CSV for a project should work, but attempting to save a change to the project should eventually time out. _After_ saving the project times out, CSV exports should still work, and you should see in your server output that the worker was recreated.

Closes #1212 
