### PR TITLE
Fix adding regions to more than 1 worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed adding regions to more than 1 worker [#1217](https://github.com/PublicMapping/districtbuilder/pull/1217)
 
 
 ## [1.17.2]

--- a/src/server/src/common/constants.ts
+++ b/src/server/src/common/constants.ts
@@ -8,5 +8,6 @@ export const DEFAULT_FROM_EMAIL =
   process.env.DEFAULT_FROM_EMAIL || "no-reply@staging.districtbuilder.org";
 
 // One worker/CPU works well on AWS using memory-optimized units
-// For dev that's not the case, so just use a fixed amount
-export const NUM_WORKERS = DEBUG ? 2 : os.cpus().length;
+// For dev & CI that's not the case, so just use a fixed amount
+export const NUM_WORKERS =
+  ENVIRONMENT === "Development" || ENVIRONMENT === "test" ? 3 : os.cpus().length;

--- a/src/server/src/districts/services/worker-pool.service.spec.ts
+++ b/src/server/src/districts/services/worker-pool.service.spec.ts
@@ -1,0 +1,207 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { RegionConfig } from "../../region-configs/entities/region-config.entity";
+import { maxWorkerCacheSize, WorkerPoolService, WorkerThread } from "./worker-pool.service";
+
+describe("WorkerPoolService", () => {
+  let service: WorkerPoolService;
+
+  const regions = [
+    {
+      id: "1",
+      layerSizeInBytes: 100
+    },
+    {
+      id: "2",
+      layerSizeInBytes: 100
+    },
+    {
+      id: "3",
+      layerSizeInBytes: 100
+    }
+  ] as RegionConfig[];
+
+  beforeEach(async () => {
+    jest.mock("../../worker");
+    jest.setTimeout(10_000);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkerPoolService]
+    }).compile();
+
+    service = module.get<WorkerPoolService>(WorkerPoolService);
+  });
+
+  afterEach(async () => {
+    await service.terminatePool();
+  });
+
+  async function workerIndex(worker: WorkerThread) {
+    const workers = await Promise.all(service.workers);
+    return workers.indexOf(worker);
+  }
+  async function sleep(timeout: number) {
+    await new Promise(r => setTimeout(r, timeout));
+  }
+
+  it("WorkerPoolService - should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("queueWithTimeout", () => {
+    it("should route to a worker", async () => {
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+    });
+
+    it("should reroute back to the same worker for the same region", async () => {
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+    });
+
+    it("should route to MAX_PER_REGION workers for concurrent requests", async () => {
+      // Create all workers 1st using other regions
+
+      await Promise.all([
+        service.queueWithTimeout(regions[1], async () => sleep(10)),
+        service.queueWithTimeout(regions[1], async () => sleep(10)),
+        service.queueWithTimeout(regions[2], async () => sleep(10)),
+        service.queueWithTimeout(regions[2], async () => sleep(10))
+      ]);
+      // Even w/ more than MAX_PER_REGION concurrent requests we should still be
+      // limited in how many workers we load data onto
+      await Promise.all([
+        service.queueWithTimeout(regions[0], async worker => {
+          expect([0, 1]).toContain(await workerIndex(worker));
+        }),
+        service.queueWithTimeout(regions[0], async worker => {
+          expect([0, 1]).toContain(await workerIndex(worker));
+        }),
+        service.queueWithTimeout(regions[0], async worker => {
+          expect([0, 1]).toContain(await workerIndex(worker));
+        }),
+        service.queueWithTimeout(regions[0], async worker => {
+          expect([0, 1]).toContain(await workerIndex(worker));
+        })
+      ]);
+    });
+
+    it("should route to a new worker for the same region if existing is blocked", async () => {
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      const blockingRequest = service.queueWithTimeout(regions[0], async worker => {
+        // Sleep for a bit to ensure this is still busy for the 2nd request
+        await sleep(10);
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).not.toEqual(0);
+      });
+      await blockingRequest;
+    });
+
+    it("should route to a new worker for the same region if existing is blocked by a different region", async () => {
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      const blockingRequest = service.queueWithTimeout(regions[1], async worker => {
+        // Sleep for a bit to ensure this is still busy for the 2nd request
+        await sleep(10);
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).not.toEqual(0);
+      });
+      await blockingRequest;
+    });
+
+    it("should wait for a busy worker once # of workers = MAX_PER_REGION", async () => {
+      const first = service.queueWithTimeout(regions[0], async worker => {
+        // Sleep for a bit to ensure this is still busy for the next request
+        await sleep(10);
+
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      const second = service.queueWithTimeout(regions[0], async worker => {
+        // Sleep for a bit to ensure this is still busy for the next request
+        await sleep(10);
+
+        expect(await workerIndex(worker)).toEqual(1);
+      });
+      await service.queueWithTimeout(regions[0], async worker => {
+        const index = await workerIndex(worker);
+        expect([0, 1]).toContain(index);
+      });
+      await first;
+      await second;
+    });
+
+    it("should not double-count pending requests when routing to workers", async () => {
+      // Load testing region onto worker 0
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      // Block every worker with other regions
+      const otherRegionRequests = Promise.all([
+        service.queueWithTimeout(regions[1], async () => {
+          await sleep(10);
+        }),
+        service.queueWithTimeout(regions[1], async () => {
+          await sleep(10);
+        }),
+        service.queueWithTimeout(regions[2], async () => {
+          await sleep(10);
+        }),
+        service.queueWithTimeout(regions[2], async () => {
+          await sleep(10);
+        })
+      ]);
+      // This request should try to route to worker 1 and block
+      const pendingRequest = service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(1);
+      });
+
+      // With all workers blocked and one request pending for worker 0, this should
+      // route to worker 0
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      await otherRegionRequests;
+      await pendingRequest;
+    });
+
+    it("should terminate worker on OoM", async () => {
+      const spy = jest.spyOn(service, "terminateWorker");
+      const giantRegion = (id: string) =>
+        ({
+          id,
+          layerSizeInBytes: maxWorkerCacheSize - 1
+        } as RegionConfig);
+
+      // Fill each worker with a region that takes up the whole cache
+      await service.queueWithTimeout(giantRegion("A"), async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      expect(spy).toBeCalledWith(0, "");
+      await service.queueWithTimeout(giantRegion("B"), async worker => {
+        expect(await workerIndex(worker)).toEqual(1);
+      });
+      expect(spy).toBeCalledWith(1, "");
+      await service.queueWithTimeout(giantRegion("C"), async worker => {
+        expect(await workerIndex(worker)).toEqual(2);
+      });
+      expect(spy).toBeCalledWith(2, "");
+
+      // Adding a small region should cause an OoM error, terminating worker 0, the least recently used
+      await service.queueWithTimeout(regions[0], async worker => {
+        expect(await workerIndex(worker)).toEqual(0);
+      });
+      expect(spy).toBeCalledWith(0, "OoM");
+    });
+  });
+});

--- a/src/server/src/districts/services/worker-pool.service.spec.ts
+++ b/src/server/src/districts/services/worker-pool.service.spec.ts
@@ -203,5 +203,31 @@ describe("WorkerPoolService", () => {
       });
       expect(spy).toBeCalledWith(0, "OoM");
     });
+
+    it("should return an error and terminate worker on timeouts", async () => {
+      const spy = jest.spyOn(service, "terminateWorker");
+      await expect(
+        service.queueWithTimeout(
+          regions[0],
+          async () => {
+            await sleep(100);
+            return;
+          },
+          10
+        )
+      ).rejects.toMatch("Worker request timed out");
+      expect(spy).toBeCalledWith(0, "error");
+    });
+
+    it("should return an error and terminate worker on errors", async () => {
+      const spy = jest.spyOn(service, "terminateWorker");
+      await expect(
+        service.queueWithTimeout(regions[0], async () => {
+          await sleep(1);
+          throw new Error("Horrors");
+        })
+      ).rejects.toMatchObject({ message: "Horrors" });
+      expect(spy).toBeCalledWith(0, "error");
+    });
   });
 });

--- a/src/server/src/districts/services/worker-pool.service.spec.ts
+++ b/src/server/src/districts/services/worker-pool.service.spec.ts
@@ -22,7 +22,6 @@ describe("WorkerPoolService", () => {
 
   beforeEach(async () => {
     jest.mock("../../worker");
-    jest.setTimeout(10_000);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [WorkerPoolService]
@@ -88,7 +87,7 @@ describe("WorkerPoolService", () => {
           expect([0, 1]).toContain(await workerIndex(worker));
         })
       ]);
-    });
+    }, 10_000);
 
     it("should route to a new worker for the same region if existing is blocked", async () => {
       await service.queueWithTimeout(regions[0], async worker => {
@@ -103,7 +102,7 @@ describe("WorkerPoolService", () => {
         expect(await workerIndex(worker)).not.toEqual(0);
       });
       await blockingRequest;
-    });
+    }, 10_000);
 
     it("should route to a new worker for the same region if existing is blocked by a different region", async () => {
       await service.queueWithTimeout(regions[0], async worker => {
@@ -118,7 +117,7 @@ describe("WorkerPoolService", () => {
         expect(await workerIndex(worker)).not.toEqual(0);
       });
       await blockingRequest;
-    });
+    }, 10_000);
 
     it("should wait for a busy worker once # of workers = MAX_PER_REGION", async () => {
       const first = service.queueWithTimeout(regions[0], async worker => {
@@ -139,7 +138,7 @@ describe("WorkerPoolService", () => {
       });
       await first;
       await second;
-    });
+    }, 10_000);
 
     it("should not double-count pending requests when routing to workers", async () => {
       // Load testing region onto worker 0
@@ -173,7 +172,7 @@ describe("WorkerPoolService", () => {
       });
       await otherRegionRequests;
       await pendingRequest;
-    });
+    }, 10_000);
 
     it("should terminate worker on OoM", async () => {
       const spy = jest.spyOn(service, "terminateWorker");
@@ -202,7 +201,7 @@ describe("WorkerPoolService", () => {
         expect(await workerIndex(worker)).toEqual(0);
       });
       expect(spy).toBeCalledWith(0, "OoM");
-    });
+    }, 10_000);
 
     it("should return an error and terminate worker on timeouts", async () => {
       const spy = jest.spyOn(service, "terminateWorker");

--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -255,12 +255,14 @@ export class WorkerPoolService {
           new Promise((resolve, reject) => {
             task
               .then(result => {
-                // Clear out any timeouts after the task completes
-                this.clearQueueTimeout(workerIndex);
                 resolve(result);
               })
               .catch(error => {
                 this.terminateWorker(workerIndex, "error").finally(() => reject(error));
+              })
+              .finally(() => {
+                // Clear out any timeouts after the task completes
+                this.clearQueueTimeout(workerIndex);
               });
           })
         );


### PR DESCRIPTION
## Overview

#1206 introduced a bug that meant that we no longer limited regions to a subset of workers.

I attempted to fix this in #1213, but this fix prevented us from adding a region to more than a single worker (i.e. the server never attempts to load more regions after the initial application startup).

The actual fix here was quite simple, but since this has proved relatively tricky to test manually I spent some time writing up a test suite for the expected behavior, which also uncovered one other small bug (not cleaning up lingering `setTimeout` timers after a worker returns an error).

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo
Test output:

```shell
$ ./scripts/yarn server test
[+] Running 1/0
 ⠿ Container districtbuilder-database-1  Running                                                                             0.0s
yarn run v1.22.18
$ jest

 PASS  src/districts/services/worker-pool.service.spec.ts (27.989 s)
  WorkerPoolService
    ✓ WorkerPoolService - should be defined (13 ms)
    queueWithTimeout
      ✓ should route to a worker (1174 ms)
      ✓ should reroute back to the same worker for the same region (1011 ms)
      ✓ should route to MAX_PER_REGION workers for concurrent requests (1418 ms)
      ✓ should route to a new worker for the same region if existing is blocked (2158 ms)
      ✓ should route to a new worker for the same region if existing is blocked by a different region (2122 ms)
      ✓ should wait for a busy worker once # of workers = MAX_PER_REGION (1351 ms)
      ✓ should not double-count pending requests when routing to workers (2444 ms)
      ✓ should terminate worker on OoM (4305 ms)
      ✓ should return an error and terminate worker on timeouts (1115 ms)
      ✓ should return an error and terminate worker on errors (1897 ms)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        28.063 s, estimated 29 s
Ran all test suites matching /\/home\/mike\/src\/districtbuilder\/src\/server\/src\/districts\/services\/worker-pool.service.spec.ts/i.
```

## Testing Instructions

Run the full test suite, it should pass:
`./scripts/yarn server test`

Apply the following diff to this branch to revert the fix for loading additional regions:
```diff
diff --git a/src/server/src/districts/services/worker-pool.service.ts b/src/server/src/districts/services/worker-pool.service.ts
index db78b33e..64e265b4 100644
--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -137,11 +137,11 @@ export class WorkerPoolService {
     if (addingRegion) {
       // eslint-disable-next-line functional/immutable-data
       this.pendingWorkerSizes[workerToUse] += size;
-
-      // Add this worker to the list of workers for this region
-      this.addToRegionMap(this.pendingWorkersByRegion, regionConfig, workerToUse);
     }
 
+    // Add this worker to the list of workers for this region
+    this.addToRegionMap(this.pendingWorkersByRegion, regionConfig, workerToUse);
+
     // eslint-disable-next-line functional/immutable-data
     this.workersByRecency = [
       workerToUse,
```
Running this test should now fail:
```shell
$ jest  /home/mike/src/districtbuilder/src/server/src/districts/services/worker-pool.service.spec.ts
$ ./scripts/yarn server test -t 'WorkerPoolService queueWithTimeout should route to a new worker for the same region if existing is blocked'
[+] Running 1/0
 ⠿ Container districtbuilder-database-1  Running                                                                             0.0s
yarn run v1.22.18
$ jest -t 'WorkerPoolService queueWithTimeout should route to a new worker for the same region if existing is blocked'          
 FAIL  src/districts/services/worker-pool.service.spec.ts (19.047 s)
  WorkerPoolService
    ✓ WorkerPoolService - should be defined (11 ms)
    queueWithTimeout
      ✓ should route to a worker (678 ms)
      ✓ should reroute back to the same worker for the same region (637 ms)
      ✓ should route to MAX_PER_REGION workers for concurrent requests (771 ms)
      ✕ should route to a new worker for the same region if existing is blocked (659 ms)
      ✓ should route to a new worker for the same region if existing is blocked by a different region (1421 ms)
      ✓ should wait for a busy worker once # of workers = MAX_PER_REGION (697 ms)
      ✓ should not double-count pending requests when routing to workers (1433 ms)
      ✓ should terminate worker on OoM (2629 ms)
      ✓ should return an error and terminate worker on timeouts (681 ms)
      ✓ should return an error and terminate worker on errors (710 ms)

  ● WorkerPoolService › queueWithTimeout › should route to a new worker for the same region if existing is blocked

    expect(received).not.toEqual(expected) // deep equality

    Expected: not 0

      100 |       });
      101 |       await service.queueWithTimeout(regions[0], async worker => {
    > 102 |         expect(await workerIndex(worker)).not.toEqual(0);
          |                                               ^
      103 |       });
      104 |       await blockingRequest;
      105 |     }, 10_000);

      at districts/services/worker-pool.service.spec.ts:102:47

Test Suites: 1 failed, 1 total
Tests:       1 failed, 10 passed, 11 total
Snapshots:   0 total
Time:        19.108 s, estimated 27 s
Ran all test suites matching /\/home\/mike\/src\/districtbuilder\/src\/server\/src\/districts\/services\/worker-pool.service.spec.ts/i.
```

Reset your repository, and apply the following diff to this branch to revert the fix clearing timeouts:
```diff
diff --git a/src/server/src/districts/services/worker-pool.service.ts b/src/server/src/districts/services/worker-pool.service.ts
index db78b33e..dadc6dae 100644
--- a/src/server/src/districts/services/worker-pool.service.ts
+++ b/src/server/src/districts/services/worker-pool.service.ts
@@ -255,14 +255,12 @@ export class WorkerPoolService {
           new Promise((resolve, reject) => {
             task
               .then(result => {
+                // Clear out any timeouts after the task completes
+                this.clearQueueTimeout(workerIndex);
                 resolve(result);
               })
               .catch(error => {
                 this.terminateWorker(workerIndex, "error").finally(() => reject(error));
-              })
-              .finally(() => {
-                // Clear out any timeouts after the task completes
-                this.clearQueueTimeout(workerIndex);
               });
           })
         );
```

Running this test case should cause `jest` to not exit after all tests are run
```
$ ./scripts/yarn server test -t 'WorkerPoolService queueWithTimeout should return an error and terminate worker on errors'
[+] Running 1/0
 ⠿ Container districtbuilder-database-1  Running                                                                             0.0s
yarn run v1.22.18
$ jest -t 'WorkerPoolService queueWithTimeout should return an error and terminate worker on errors'
 PASS  src/districts/services/worker-pool.service.spec.ts (12.126 s)
  WorkerPoolService
    ○ skipped WorkerPoolService - should be defined
    queueWithTimeout
      ✓ should return an error and terminate worker on errors (1097 ms)
      ○ skipped should route to a worker
      ○ skipped should reroute back to the same worker for the same region
      ○ skipped should route to MAX_PER_REGION workers for concurrent requests
      ○ skipped should route to a new worker for the same region if existing is blocked
      ○ skipped should route to a new worker for the same region if existing is blocked by a different region
      ○ skipped should wait for a busy worker once # of workers = MAX_PER_REGION
      ○ skipped should not double-count pending requests when routing to workers
      ○ skipped should terminate worker on OoM
      ○ skipped should return an error and terminate worker on timeouts

Test Suites: 1 passed, 1 total
Tests:       10 skipped, 1 passed, 11 total
Snapshots:   0 total
Time:        12.182 s
Ran all test suites with tests matching "WorkerPoolService queueWithTimeout should return an error and terminate worker on errors".
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
Done in 102.16s.
```
