### PR TITLE
Upgrade terraform to 0.12-> 1.0.0

### DIFF
--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = var.aws_region
-  version = "~> 3.10.0"
 }
 
 terraform {

--- a/deployment/terraform/scheduled_tasks.tf
+++ b/deployment/terraform/scheduled_tasks.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "reindex_task" {
-  name                = "reindex-scheduled-ecs-event-rule-${var.environment}"
+  name = "reindex-scheduled-ecs-event-rule-${var.environment}"
   // Run monthly at 5AM UTC (midnight EST)
   schedule_expression = "cron(0 5 1 * ? *)"
 }
@@ -14,9 +14,9 @@ resource "aws_cloudwatch_event_target" "reindex_task" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.app.arn
     // Reindex task doesn't load TopoJSON, so we can run it on Fargate
-    launch_type         = "FARGATE"
+    launch_type = "FARGATE"
     network_configuration {
-      subnets         = module.vpc.private_subnet_ids
+      subnets = module.vpc.private_subnet_ids
       // TODO: check if thi is really necessary
       assign_public_ip = true
       security_groups  = [aws_security_group.app.id]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -355,6 +355,7 @@ variable "typeorm_health_check_timeout" {
 
 variable "jwt_secret" {
   type = string
+  sensitive = true
 }
 
 variable "jwt_expiration_in_ms" {
@@ -367,10 +368,12 @@ variable "client_url" {
 
 variable "rollbar_access_token" {
   type = string
+  sensitive = true
 }
 
 variable "plan_score_api_token" {
   type = string
+  sensitive = true
 }
 
 variable "app_port" {
@@ -400,4 +403,5 @@ variable "aws_lambda_service_role_policy_arn" {
 
 variable "slack_bot_webhook_url" {
   type = string
+  sensitive = true
 }

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -1,3 +1,12 @@
 terraform {
-  required_version = ">= 0.12.13"
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.53.0"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -23,7 +23,7 @@ services:
     working_dir: /usr/local/src
 
   terraform:
-    image: quay.io/azavea/terraform:0.12.29
+    image: quay.io/azavea/terraform:1.0.0
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
Bump AWS provider version to 3.53.0 which is the highest we can
go without replacing some of the modules (terraform 1.1 apparently makes this
easier to do).

Also mark some variables sensitive so they don't show up in output which
would help if we move from Jenkins to Github actions.

Closes: #917

## Testing Instructions

- Confirm that everything is still working on both staging and prod
- View the nicely shorter infra plan changes view

