### PR TITLE
Fix excess memory usage on projects query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed create-random-projects for large number of states [#1232](https://github.com/PublicMapping/districtbuilder/pull/1232)
+- Fix excess memory usage on projects query [#1228](https://github.com/PublicMapping/districtbuilder/pull/1228)
 
 
 ## [1.17.3]

--- a/src/client/components/map/ProjectDistrictsMap.tsx
+++ b/src/client/components/map/ProjectDistrictsMap.tsx
@@ -4,7 +4,7 @@ import MapboxGL from "mapbox-gl";
 import React, { useEffect, useRef, useState } from "react";
 
 import { IStaticMetadata, ProjectNest } from "../../../shared/entities";
-import { DistrictGeoJSON } from "../../types";
+import { DistrictGeoJSON, SimplifiedDistrictsGeoJSON } from "../../types";
 import { getDistrictColor } from "../../constants/colors";
 import { fetchMemoizedStateBbox } from "../../api";
 
@@ -42,8 +42,9 @@ const ProjectDistrictsMap = ({
     });
 
   // TODO #179 - the districts property can't be defined in the shared/entities.d.ts right now
-  // @ts-ignore
-  const districts: DistrictsGeoJSON | undefined = project.districts;
+  const districts: SimplifiedDistrictsGeoJSON | undefined =
+    // @ts-ignore
+    project.simplifiedDistricts;
 
   useEffect(() => {
     if (mapRef.current === null || bounds === null) {

--- a/src/client/types.d.ts
+++ b/src/client/types.d.ts
@@ -20,6 +20,8 @@ export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictPropertie
   readonly metadata?: ProjectProperties;
 };
 
+export type SimplifiedDistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictProperties>;
+
 export interface DynamicProjectData {
   readonly project: IProject;
   readonly geojson: DistrictsGeoJSON;

--- a/src/manage/src/commands/create-random-projects.ts
+++ b/src/manage/src/commands/create-random-projects.ts
@@ -7,6 +7,7 @@ import _ from "lodash";
 import { connectionOptions } from "../lib/dbUtils";
 import { RegionConfig } from "../../../server/src/region-configs/entities/region-config.entity";
 import { Project } from "../../../server/src/projects/entities/project.entity";
+import { simplifyDistricts } from "../../../server/src/projects/controllers/projects.controller";
 import { TopologyService } from "../../../server/src/districts/services/topology.service";
 import { WorkerPoolService } from "../../../server/src/districts/services/worker-pool.service";
 import { User } from "../../../server/src/users/entities/user.entity";
@@ -37,6 +38,8 @@ export default class CreateRandomProjects extends Command {
     const regionConfigRepo = connection.getRepository(RegionConfig);
     const projectRepo = connection.getRepository(Project);
     const userRepo = connection.getRepository(User);
+
+    const boundSimplifyDistricts = simplifyDistricts.bind(this);
 
     const regions = await regionConfigRepo.find(
       args.region === "all"
@@ -97,6 +100,7 @@ export default class CreateRandomProjects extends Command {
       project.regionConfig = region;
       project.districtsDefinition = districtsDefinition;
       project.districts = districts;
+      project.simplifiedDistricts = boundSimplifyDistricts(districts);
       project.lockedDistricts = lockedDistricts;
       project.numberOfMembers = numberOfMembers;
       project.populationDeviation = 5;

--- a/src/manage/src/commands/vendor.d.ts
+++ b/src/manage/src/commands/vendor.d.ts
@@ -22,5 +22,5 @@ declare module "geojson2shp" {
 declare module "simplify-geojson" {
   import { GeoJSON } from "geojson";
 
-  export function simplify(feature: GeoJSON, tolerance?: number): void;
+  export default function simplify<G extends GeoJSON>(feature: G, tolerance?: number): G;
 }

--- a/src/manage/src/commands/vendor.d.ts
+++ b/src/manage/src/commands/vendor.d.ts
@@ -1,3 +1,26 @@
 declare module "JSONStream" {
   export function parse(path?: string): any;
 }
+
+declare module "geojson2shp" {
+  import { GeoJSON } from "geojson";
+  import * as stream from "stream";
+
+  interface ConvertOptions {
+    readonly layer?: string;
+    readonly sourceCrs?: number;
+    readonly targetCrs?: number;
+  }
+
+  export function convert(
+    input: string | GeoJSON,
+    output: string | stream.Writable,
+    options?: ConvertOptions
+  ): Promise<void>;
+}
+
+declare module "simplify-geojson" {
+  import { GeoJSON } from "geojson";
+
+  export function simplify(feature: GeoJSON, tolerance?: number): void;
+}

--- a/src/manage/src/test/create-random-projects.spec.ts
+++ b/src/manage/src/test/create-random-projects.spec.ts
@@ -22,7 +22,11 @@ jest.mock("../../../server/src/districts/services/worker-pool.service", () => {
   return {
     WorkerPoolService: jest.fn().mockImplementation(() => ({
       getTopologyProperties: () => Promise.resolve({ county: [] }),
-      merge: () => Promise.resolve({ type: "FeatureCollection", features: [] })
+      merge: () =>
+        Promise.resolve({
+          districts: { type: "FeatureCollection", features: [] },
+          simplifiedDistricts: { type: "FeatureCollection", features: [] }
+        })
     }))
   };
 });

--- a/src/server/global.d.ts
+++ b/src/server/global.d.ts
@@ -18,5 +18,5 @@ declare module "geojson2shp" {
 declare module "simplify-geojson" {
   import { GeoJSON } from "geojson";
 
-  export function simplify(feature: GeoJSON, tolerance?: number): void;
+  export default function simplify<G extends GeoJSON>(feature: G, tolerance?: number): G;
 }

--- a/src/server/migrations/1654279860639-create_simplified_districts_on_project.ts
+++ b/src/server/migrations/1654279860639-create_simplified_districts_on_project.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class createSimplifiedDistrictsOnProject1654279860639 implements MigrationInterface {
+    name = 'createSimplifiedDistrictsOnProject1654279860639'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" ADD "simplified_districts" jsonb`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "simplified_districts"`);
+    }
+
+}

--- a/src/server/migrations/1654551650115-update_simplified_districts.ts
+++ b/src/server/migrations/1654551650115-update_simplified_districts.ts
@@ -1,0 +1,29 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class updateSimplifiedDistricts1654551650115 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+          `UPDATE project SET simplified_districts = CASE
+            WHEN districts IS NULL THEN NULL
+            ELSE JSON_BUILD_OBJECT(
+                'type', 'FeatureCollection',
+                'features', ARRAY(
+                SELECT JSON_BUILD_OBJECT(
+                    'type', 'Feature',
+                    'properties', feature->'properties',
+                    'geometry', ST_AsGeoJSON(ST_Simplify(ST_GeomFromGeoJSON(feature->'geometry'), 0.001))::json
+                )
+                FROM jsonb_array_elements(districts->'features') feature
+                )
+            )
+            END`,
+          undefined
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE project SET simplified_districts = '{}'`, undefined);
+    }
+
+}

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -67,6 +67,7 @@
     "reflect-metadata": "0.1.13",
     "rollbar": "2.24.0",
     "rxjs": "7.5.5",
+    "simplify-geojson": "^1.0.5",
     "threads": "1.7.0",
     "topojson-client": "3.1.0",
     "typeorm": "0.2.41"

--- a/src/server/src/districts/entities/geo-unit-topology.entity.ts
+++ b/src/server/src/districts/entities/geo-unit-topology.entity.ts
@@ -6,7 +6,10 @@ import {
   TopologyProperties
 } from "../../../../shared/entities";
 import { Chamber } from "../../chambers/entities/chamber.entity";
-import { DistrictsGeoJSON } from "../../projects/entities/project.entity";
+import {
+  DistrictsGeoJSON,
+  SimplifiedDistrictsGeoJSON
+} from "../../projects/entities/project.entity";
 import { RegionConfig } from "../../region-configs/entities/region-config.entity";
 import { User } from "../../users/entities/user.entity";
 
@@ -40,7 +43,10 @@ export class GeoUnitTopology {
     readonly user: User;
     readonly chamber?: Chamber;
     readonly regionConfig: RegionConfig;
-  }): Promise<DistrictsGeoJSON | null> {
+  }): Promise<{
+    readonly districts: DistrictsGeoJSON;
+    readonly simplifiedDistricts: SimplifiedDistrictsGeoJSON;
+  } | null> {
     return this.workerService.merge({
       districtsDefinition,
       numberOfDistricts,

--- a/src/server/src/project-templates/services/project-templates.service.ts
+++ b/src/server/src/project-templates/services/project-templates.service.ts
@@ -14,7 +14,6 @@ import {
 } from "../../../../shared/entities";
 import { Organization } from "../../organizations/entities/organization.entity";
 import { Project } from "../../projects/entities/project.entity";
-import { selectSimplifiedDistricts } from "../../projects/services/projects.service";
 
 export type ProjectExportRow = {
   readonly userId: UserId;
@@ -108,25 +107,25 @@ export class ProjectTemplatesService extends TypeOrmCrudService<ProjectTemplate>
   async findOrgFeaturedProjects(slug: OrganizationSlug): Promise<ProjectTemplate[]> {
     // Returns public listing of all featured projects for an organization
     const builder = this.repo.createQueryBuilder("projectTemplate");
-    const data = await selectSimplifiedDistricts(
-      builder
-        .innerJoin("projectTemplate.organization", "organization")
-        .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
-        .leftJoin("projectTemplate.projects", "project", "project.isFeatured = TRUE")
-        .innerJoin("project.user", "user")
-        .where("organization.slug = :slug", { slug: slug })
-        .addSelect([
-          "projectTemplate.name",
-          "projectTemplate.numberOfDistricts",
-          "projectTemplate.id",
-          "project.name",
-          "project.isFeatured",
-          "project.id",
-          "project.updatedDt",
-          "user.name"
-        ])
-        .orderBy("project.name")
-    ).getMany();
+    const data = await builder
+      .innerJoin("projectTemplate.organization", "organization")
+      .innerJoinAndSelect("projectTemplate.regionConfig", "regionConfig")
+      .leftJoin("projectTemplate.projects", "project", "project.isFeatured = TRUE")
+      .innerJoin("project.user", "user")
+      .where("organization.slug = :slug", { slug: slug })
+      .addSelect([
+        "projectTemplate.name",
+        "projectTemplate.numberOfDistricts",
+        "projectTemplate.id",
+        "project.name",
+        "project.isFeatured",
+        "project.id",
+        "project.updatedDt",
+        "project.simplifiedDistricts",
+        "user.name"
+      ])
+      .orderBy("project.name")
+      .getMany();
     return data;
   }
 

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -66,6 +66,13 @@ export class Project implements IProject {
   })
   districts?: DistrictsGeoJSON;
 
+  @Column({
+    type: "jsonb",
+    name: "simplified_districts",
+    nullable: true
+  })
+  simplifiedDistricts?: DistrictsGeoJSON;
+
   @ManyToOne(() => User, { nullable: false, eager: true })
   @JoinColumn({ name: "user_id" })
   user: User;

--- a/src/server/src/projects/entities/project.entity.ts
+++ b/src/server/src/projects/entities/project.entity.ts
@@ -22,6 +22,8 @@ export type DistrictsGeoJSON = FeatureCollection<MultiPolygon, DistrictPropertie
   readonly metadata?: ProjectProperties;
 };
 
+export type SimplifiedDistrictsGeoJSON = FeatureCollection<MultiPolygon>;
+
 @Entity()
 @Index("IDX_PUBLISHED_PROJECTS", { synchronize: false })
 @Index(["updatedDt", "user"])
@@ -71,7 +73,7 @@ export class Project implements IProject {
     name: "simplified_districts",
     nullable: true
   })
-  simplifiedDistricts?: DistrictsGeoJSON;
+  simplifiedDistricts?: SimplifiedDistrictsGeoJSON;
 
   @ManyToOne(() => User, { nullable: false, eager: true })
   @JoinColumn({ name: "user_id" })

--- a/src/server/src/projects/services/projects.service.ts
+++ b/src/server/src/projects/services/projects.service.ts
@@ -6,39 +6,12 @@ import { Repository, SelectQueryBuilder, DeepPartial } from "typeorm";
 import { Project } from "../entities/project.entity";
 import { ProjectVisibility } from "../../../../shared/constants";
 import { paginate, Pagination, IPaginationOptions } from "nestjs-typeorm-paginate";
-import { ProjectTemplate } from "../../project-templates/entities/project-template.entity";
 
 type AllProjectsOptions = IPaginationOptions & {
   readonly completed?: boolean;
   readonly region?: string;
   readonly userId?: string;
 };
-
-export function selectSimplifiedDistricts<P extends Project | ProjectTemplate>(
-  builder: SelectQueryBuilder<P>
-): SelectQueryBuilder<P> {
-  // Replace the districts column with a simplified one to save on response size
-  //
-  // Note that we're doing a bit of a trick here to replace the contents of the districts column,
-  // we need to select it first, and then give an alias that will override that selection
-  return builder.addSelect("project.districts").addSelect(
-    `CASE
-       WHEN districts IS NULL THEN NULL
-       ELSE JSON_BUILD_OBJECT(
-         'type', 'FeatureCollection',
-         'features', ARRAY(
-           SELECT JSON_BUILD_OBJECT(
-             'type', 'Feature',
-             'properties', feature->'properties',
-             'geometry', ST_AsGeoJSON(ST_Simplify(ST_GeomFromGeoJSON(feature->'geometry'), 0.001))::json
-           )
-           FROM jsonb_array_elements(districts->'features') feature
-         )
-       )
-     END`,
-    "project_districts"
-  );
-}
 
 @Injectable()
 export class ProjectsService extends TypeOrmCrudService<Project> {
@@ -52,29 +25,28 @@ export class ProjectsService extends TypeOrmCrudService<Project> {
   }
 
   getProjectsBase(): SelectQueryBuilder<Project> {
-    return selectSimplifiedDistricts(
-      this.repo
-        .createQueryBuilder("project")
-        .innerJoin("project.regionConfig", "regionConfig")
-        .innerJoin("project.user", "user")
-        .leftJoin("project.chamber", "chamber")
-        .select([
-          "project.id",
-          "project.name",
-          "project.numberOfDistricts",
-          "project.updatedDt",
-          "project.createdDt",
-          "project.submittedDt",
-          "chamber.name",
-          "regionConfig.name",
-          "regionConfig.id",
-          "regionConfig.archived",
-          "regionConfig.s3URI",
-          "user.id",
-          "user.name"
-        ])
-        .orderBy("project.updatedDt", "DESC")
-    );
+    return this.repo
+      .createQueryBuilder("project")
+      .innerJoin("project.regionConfig", "regionConfig")
+      .innerJoin("project.user", "user")
+      .leftJoin("project.chamber", "chamber")
+      .select([
+        "project.id",
+        "project.name",
+        "project.numberOfDistricts",
+        "project.updatedDt",
+        "project.createdDt",
+        "project.submittedDt",
+        "project.simplifiedDistricts",
+        "chamber.name",
+        "regionConfig.name",
+        "regionConfig.id",
+        "regionConfig.archived",
+        "regionConfig.s3URI",
+        "user.id",
+        "user.name"
+      ])
+      .orderBy("project.updatedDt", "DESC");
   }
 
   async findAllPublishedProjectsPaginated(

--- a/src/server/yarn.lock
+++ b/src/server/yarn.lock
@@ -2641,6 +2641,15 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concat-stream@~1.4.1:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.4.11.tgz#1dc9f666f2621da9c618b1e7f8f3b2ff70b5f76f"
+  integrity sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "~1.1.9"
+    typedarray "~0.0.5"
+
 consola@^2.15.0:
   version "2.15.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
@@ -5675,7 +5684,7 @@ minimist@1.2.5, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minimist@^1.2.6:
+minimist@1.2.6, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -6656,7 +6665,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-readable-stream@1.1.x:
+readable-stream@1.1.x, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
@@ -7049,6 +7058,20 @@ signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simplify-geojson@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/simplify-geojson/-/simplify-geojson-1.0.5.tgz#3497d61497d323105297dc2a9d4e54c1b2926279"
+  integrity sha512-02l1W4UipP5ivNVq6kX15mAzCRIV1oI3tz0FUEyOsNiv1ltuFDjbNhO+nbv/xhbDEtKqWLYuzpWhUsJrjR/ypA==
+  dependencies:
+    concat-stream "~1.4.1"
+    minimist "1.2.6"
+    simplify-geometry "0.0.2"
+
+simplify-geometry@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/simplify-geometry/-/simplify-geometry-0.0.2.tgz#63797e676eae96835ace02bcd27d3e1af544f49c"
+  integrity sha1-Y3l+Z26uloNazgK80n0+GvVE9Jw=
 
 sisteransi@^1.0.3:
   version "1.0.4"
@@ -7717,7 +7740,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedarray@^0.0.6:
+typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=


### PR DESCRIPTION
## Overview

The production database was shutdown by AWS due to excess memory usage, with the potential cause being frequent queries that result in large temporary files being created, as described in [the issue comment](https://github.com/PublicMapping/districtbuilder/issues/1225#issuecomment-1137657992). In order to replicate this, I created ~1500 projects of a little over 50 regions and found similar queries resulting in a large amount of temporary files using `pgbadger` logging. While the temporary files in my local instance were noticeably smaller than those related to the production outage, the query is unique to simplifying the geojson districts on read and of similar frequency. It's assumed that multiple calls from users with a lot of projects of more complex geometries would log temporary file sizes closer to those that were created before the outage. In order to fix this, we decided to denormalize the `project` table to include a `simplified_districts` column, which would be set with the simplified geojson on create rather than read. After implementing, there are no more temporary files created after querying for a user's paginated projects.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

- The `pgbadger` .html "before" and "after" files are included in this PR for viewing with the intent to take them back out before merge. I created the logs for `pgbadger` by selecting the last page of the user maps screen with 1,467 projects of a little over 50 regions. The query durations are different for the "before" and "after" files, since I tested "before" with a couple other actions to compare (creating a new project, duplicating, navigating site, etc) vs just selecting through to the last page where large temporary files were expected. Below are screenshots of the changes between temporary files creation:
Before implementing changes:
<img width="1131" alt="Screen Shot 2022-06-07 at 8 57 12 AM" src="https://user-images.githubusercontent.com/36374797/172444348-f40dea79-6138-451b-8857-e959aec9296d.png">
<img width="1135" alt="Screen Shot 2022-06-07 at 8 57 02 AM" src="https://user-images.githubusercontent.com/36374797/172444368-9f29af2c-81a5-4665-a6a4-9d3745cfb272.png">

After implementing changes:
<img width="1133" alt="Screen Shot 2022-06-07 at 8 38 24 AM" src="https://user-images.githubusercontent.com/36374797/172444174-edb65f7c-885c-4614-bbb9-64a8436daf3b.png">
<img width="1132" alt="Screen Shot 2022-06-07 at 8 38 36 AM" src="https://user-images.githubusercontent.com/36374797/172444196-03d1b8b4-3d20-4854-a6ef-cab176f5343f.png">

- Since we moved the action of simplifying the geojson from the database back into js, we expect more CPU time dedicated to simplification than before. To evaluate wether it made sense to move this into a worker process, we tested creating various regions, including block level districts, and found simplification didn't take longer than ~26ms for those scenarios. For now it seems worth skipping and reevaluating if it becomes an issue.

## Testing Instructions

- `scripts/update`
- `scripts/server`
- Confirm mini maps display as before
- Create a new project via template and import and confirm each functions as expected and mini map displays
- On updating districts, confirm mini map updates to display new districts
- Create a handful of new projects using `scripts/manage create-random-projects` and confirm new projects have `simplified_districts` field and mini maps display

Closes #1225 
