### PR TITLE
Update to Postgres 13 with PostGIS 3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
 version: "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:3-postgres12.4-slim
+    image: postgis/postgis:13-3.1
     environment:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder
       - POSTGRES_DB=districtbuilder
     healthcheck:
-      test: pg_isready -U districtbuilder
+      test: pg_isready -q -h database -U districtbuilder
       interval: 3s
       timeout: 3s
       retries: 3
+      start_period: 5s
 
   server:
     image: districtbuilder


### PR DESCRIPTION
## Overview

This is the version we've been mostly standardizing on. (Same versions that are in Debian stable)

## Testing Instructions

- Any more intensive database tests before we consider it good to move on to staging next.

Related to #1234
