### PR TITLE
Add API spec for globalProjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added API spec for `/api/globalProjects` [#1239](https://github.com/PublicMapping/districtbuilder/pull/1239)
 
 ### Changed
 

--- a/doc/spec/README.md
+++ b/doc/spec/README.md
@@ -46,7 +46,10 @@ Get a paginated list of global projects.
                             "voting": {
                                 "democrat16": 0,
                                 "republican16": 0,
-                                "other party16": 0
+                                "other party16": 0,
+                                "democrat20": 0,
+                                "republican20": 0,
+                                "other party20": 0
                             },
                             "contiguity": "",
                             "compactness": 0,

--- a/doc/spec/README.md
+++ b/doc/spec/README.md
@@ -8,7 +8,7 @@ Get a paginated list of global projects.
 
 **Method** : `GET`
 
-**Auth required** : YES
+**Auth required** : NO
 
 **Permissions required** : N/A
 

--- a/doc/spec/README.md
+++ b/doc/spec/README.md
@@ -1,0 +1,120 @@
+# API Spec
+
+## List global projects
+
+Get a paginated list of global projects.
+
+**URL** : `/api/globalProjects`
+
+**Method** : `GET`
+
+**Auth required** : YES
+
+**Permissions required** : N/A
+
+**Query Parameters** :
+- `page`: Integer; Page number; Default: `1`; Optional
+- `limit`: Integer; Number of global projects per page; Default: `10`; Optional
+- `completed`: Boolean; Filter to return completed projects or not; Default: `false`; Optional
+- `region`: String; Filter to the projects matching specified region code; Default: `undefined`; Optional
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content examples**
+
+```json
+{
+    "items": [
+        {
+            "id": "UUID of a global project",
+            "name": "Example project name",
+            "numberOfDistricts": 10,
+            "simplifiedDistricts": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "id": 0,
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "MultiPolygon",
+                            "coordinates": [...
+                            ]
+                        },
+                        "properties": {
+                            "voting": {
+                                "democrat16": 0,
+                                "republican16": 0,
+                                "other party16": 0
+                            },
+                            "contiguity": "",
+                            "compactness": 0,
+                            "demographics": {
+                                "VAP": 0,
+                                "CVAP": 0,
+                                "asian": 0,
+                                "black": 0,
+                                "white": 0,
+                                "native": 0,
+                                "pacific": 0,
+                                "hispanic": 0,
+                                "VAP Asian": 0,
+                                "VAP Black": 0,
+                                "VAP White": 0,
+                                "CVAP Asian": 0,
+                                "CVAP Black": 0,
+                                "CVAP White": 0,
+                                "VAP Native": 0,
+                                "population": 0,
+                                "CVAP Native": 0,
+                                "VAP Pacific": 0,
+                                "CVAP Pacific": 0,
+                                "VAP Hispanic": 0,
+                                "CVAP Hispanic": 0
+                            }
+                        }
+                    },
+                    ...
+                ],
+                "metadata": {
+                    "creator": {
+                        "id": "UUID of user",
+                        "name": "Example user name"
+                    },
+                    "completed": true,
+                    "regionConfig": {
+                        "id": "UUID of config",
+                        "name": "Example region config name",
+                        "s3URI": "s3://path/to/example/config/location",
+                        "regionCode": "Example region code",
+                        "countryCode": "Example country code"
+                    }
+                }
+            },
+            "createdDt": "2022-06-24T00:00:00.000Z",
+            "updatedDt": "2022-06-24T00:00:00.000Z",
+            "submittedDt": null,
+            "regionConfig": {
+                "id": "UUID of config",
+                "name": "Example region config name",
+                "s3URI": "s3://path/to/example/config/location",
+                "archived": false
+            },
+            "user": {
+                "id": "UUID of user",
+                "name": "Example user name"
+            },
+            "chamber": null
+        },
+        ...
+    ],
+    "meta": {
+        "totalItems": 70,
+        "itemCount": 8,
+        "itemsPerPage": 8,
+        "totalPages": 9,
+        "currentPage": 1
+    }
+}
+```

--- a/doc/spec/README.md
+++ b/doc/spec/README.md
@@ -24,6 +24,8 @@ Get a paginated list of global projects.
 
 **Content examples**
 
+**Note** the contents of the `voting` and `demographics` columns are dependent on the region the project is associated with. Not every region will have political data (some may have no data or only data for 2016) or the full range of demographic data available (though every region _will_ have `demographics.population` at the least).
+
 ```json
 {
     "items": [


### PR DESCRIPTION
## Overview

This PR adds a `README.md` file under `doc/spec/` that includes API spec for `/api/globalProjects`

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

~It seems this API endpoint is behind auth. I am wondering if there is a way to get a bearer token for authentication before calling the endpoint. If yes, whether it is an endpoint or a set of steps to get this token, I think maybe we should have docs for such a way so that the API spec consumer can follow, since I read from the issue description that this endpoint is designed for public consumption. If this is already documented somewhere, it would be great to guide me to it and have the link included in this doc.~

## Testing Instructions

- Make sure the API spec makes sense and the example response is sufficient.

Closes https://github.com/PublicMapping/districtbuilder/issues/1229