### PR TITLE
Add Github Release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -23,7 +23,7 @@ $ git commit -m "X.Y.Z"
 $ git flow release publish X.Y.Z
 ```
 - [ ] Test the release branch on staging
-- [ ] Start a new [release pipeline job](http://urbanappsci.internal.azavea.com/job/DistrictBuilder%20Release%20Pipeline/build?delay=0sec) with the SHA (see command below) of `release/X.Y.Z` that was tested on staging
+- [ ] Start a new [release workflow](https://github.com/PublicMapping/districtbuilder/actions/workflows/release.yml) with the SHA (see command below) of `release/X.Y.Z` that was tested on staging
 ```bash
 $ git rev-parse --short HEAD
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # TODO Variables to change for production
-      #- run: |
-      #    echo "DB_SETTINGS_BUCKET=districtbuilder-production-config-us-east-1" >> $GITHUB_ENV
-      #    echo "DB_DEPLOYMENT_ENVIRONMENT=production" >> $GITHUB_ENV
-      #    NODE_ENV right below
-
       - name: CI Build
         run: ./scripts/cibuild
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_commit:
+        description: 'Short Git commit hash to deploy to production'
+        required: true
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      GIT_COMMIT: ${{ github.event.inputs.git_commit }}
+      DB_SETTINGS_BUCKET: districtbuilder-production-config-us-east-1
+      DB_DEPLOYMENT_ENVIRONMENT: "production"
+      NODE_ENV: production
+      DB_ROLLBAR_ACCESS_TOKEN: ${{ secrets.DB_ROLLBAR_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+
+      - run: |
+          docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform -c "
+            unset AWS_PROFILE
+            ./scripts/infra plan"
+          


### PR DESCRIPTION
This was done in the same way to match other Azavea projects (not public)
and to match the way Jenkins works for the project thus far as well.

Entering a sha with a valid image in ECR is therefore required.

This adds a release workflow that can only plan a production change.

### Notes

Was considering having it be automated, but all projects I've come across require manual process for release.

## Testing Instructions

Will be tested as part of this plan:

1.     Review and commit it with it just doing a terraform plan
2.     Test the pipeline to make sure it does what we expect
3.     Do a trivial other PR to add terraform apply
4.     Run release using same hash as before to confirm it works
5.     Deploy bugfix to production

Closes #1237
