### PR TITLE
Enable SSM to ec2 container hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ - Enable SSM to EC2 Hosts [#1259](https://github.com/PublicMapping/districtbuilder/pull/1259)
 
 ### Changed
 

--- a/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
+++ b/deployment/terraform/cloud-config/base-container-instance.yml.tmpl
@@ -5,3 +5,4 @@ bootcmd:
   - echo 'ECS_CLUSTER=${ecs_cluster_name}' >> /etc/ecs/ecs.config
   - echo 'vm.max_map_count=${vm_max_map_count}' > /etc/sysctl.d/99-max-memory-map-areas.conf
   - sysctl -p /etc/sysctl.d/99-max-memory-map-areas.conf
+  - sudo amazon-linux-extras install postgresql13

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -100,6 +100,12 @@ resource "aws_iam_role_policy" "scoped_email_sending_container_instance" {
   policy = data.aws_iam_policy_document.scoped_email_sending.json
 }
 
+# Enable SSM for EC2 instances
+resource "aws_iam_role_policy_attachment" "ssm_for_ec2" {
+  role       = "ecs${var.environment}ContainerInstanceRole"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 #
 # ALB IAM resources
 #


### PR DESCRIPTION
This allows us to move away from using the bastion and
to connect to a host by just pressing Connect on the instance in AWS WebUI.

Also installed psql on the host so we can connect to database too.

It should be noted that these hosts can get recycled as part of deployments -
so that's the only process change that needs to happen.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Notes

I didn't remember that some users will use PGAdmin - that it also [possible](https://manumagalhaes.medium.com/ssm-port-forwarding-connect-to-rds-in-a-private-subnet-with-no-ssh-bonus-with-pgadmin-eefc79d1e8bd) but I haven't tested that yet. 

I have confirmed that I can connect to the database using the psql command.

## Testing Instructions

- Try out how you usually use the bastion but connecting via SSM.

