### PR TITLE
Updates to data processing script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ $ ./scripts/manage update-region data/output-pa s3://previous/location/of/the/pu
 
 Note: when doing this, you will need to restart your server to see the new data, since it's cached on startup
 
+#### Acquiring custom data to upload to DistrictBuilder
+To create a custom region, you will need a GeoJSON for a state/region at the `county`, `blockgroup`, or `block` level of detail. The file should include the following properties for each geographic unit:
+
+ * geoid (a unique identifier for each geographic unit, eg. census geoid/FIPS)
+ * state
+ * county_identifier
+ * county_name
+ * blockgroup_identifier
+ * block_identifier
+ * population
+ * white
+ * black
+ * asian
+ * hispanic
+ * other
+ 
+We recommend acquiring data from the US Census Bureau, which typically distributes geographic and demographic files separately. Files for a state/region at the desired level of geographic detail (eg. blockgroup, block) should be acquired and then joined on the unique identifier field (eg. the census geoid/FIPS) into a single GeoJSON.
+
+When the GeoJSON is ready, use `process-geojson` to process the data and `publish-geojson` to publish the region to S3. In `process-geojson` the `--demographic` field specifies the columns to upload as demographic data, and multiple groups of demographic data can be uploaded (e.g. CVAP, etc.). The `--levels` field specifies what level of geographic detail (eg. blockgroup, block) contained in the GeoJSON should be processed. 
+
 ### Project Organization
 
 In order to allow for code-sharing across the frontend and backend in conjunction with an unejected Create React App (CRA), it was decided that the simplest and least error-prone way forward was to structure the code as such:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This section demonstrates how to format a GeoJSON to feed into the `process geoj
 ```
 ./scripts/manage precincts.geojson -d population,white,black,asian,hispanic,other -v republican,democrat,other_voters -l precinct,ward -o data/precinct-example
 ```
-Visit the [manage README](src/manage.README.md) further documentation of the `process-geojson` script.
+Visit the [manage README](src/manage/README.md#manage-process-geojson-file) further documentation of the `process-geojson` script.
 
 ### Project Organization
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Note: when doing this, you will need to restart your server to see the new data,
 
 #### How to format a custom GeoJSON to upload to DistrictBuilder
 
-This section demonstrates how to format a GeoJSON to feed into the `process geojson` script. DistrictBuilder is flexible and allows you to specify in a state/region one or more base geographic units to use to draw district boundaries in the user interface. The base geographic unit or units can be census boundaries (ie. `county`, `tract`,`blockgroup`, or `block`), voting boundaries (ie. `wards` or `precincts`) or any custom unit for which you have geographic boundaries and demographic data. The following examples demonstrate how to format the GeoJSON that you acquire or create in order to use `process-geojson` to prepare it to upload to DistrictBuilder:
+This section demonstrates how to format a GeoJSON to feed into the `process-geojson` script. DistrictBuilder is flexible and allows you to specify in a state/region one or more base geographic units to use to draw district boundaries in the user interface. The base geographic unit or units can be census boundaries (ie. `county`, `tract`,`blockgroup`, or `block`), voting boundaries (ie. `wards` or `precincts`) or any custom unit for which you have geographic boundaries and demographic data. The following examples demonstrate how to format the GeoJSON that you acquire or create in order to use `process-geojson` to prepare it to upload to DistrictBuilder:
 
 ##### Example 1: US Census & VAP Data
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ To create a custom region, you will need a GeoJSON for a state/region at the `co
  
 We recommend acquiring data from the US Census Bureau, which typically distributes geographic and demographic files separately. Files for a state/region at the desired level of geographic detail (eg. blockgroup, block) should be acquired and then joined on the unique identifier field (eg. the census geoid/FIPS) into a single GeoJSON.
 
-When the GeoJSON is ready, use `process-geojson` to process the data and `publish-geojson` to publish the region to S3. In `process-geojson` the `--demographic` field specifies the columns to upload as demographic data, and multiple groups of demographic data can be uploaded (e.g. CVAP, etc.). The `--levels` field specifies what level of geographic detail (eg. blockgroup, block) contained in the GeoJSON should be processed. 
+When the GeoJSON is ready, use `process-geojson` to process the data and `publish-geojson` to publish the region to S3. 
+
+In `process-geojson` the `--demographic` field specifies the columns to upload as demographic data, and multiple groups of demographic data can be uploaded (e.g. CVAP, etc.).
+
+The `--levels` field specifies properties in the GeoJSON containing identifiers for other levels of geographic details. For example `--levels block,blockgroup` should be used when the input GeoJSON is at the `block` level and you wish to generate a `blockgroup` layer in addition to the `block` layer by combining all Blocks w/ the same `blockgroup` ID. 
 
 ### Project Organization
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You will need a PlanScore API token to test the PlanScore integration in develop
 
 #### Processing your own data for custom regions
 
-To have data to work with, you'll need to do a two step process:
+To have data to work with, you'll need to do a three step process:
 
 1. Prepare or acquire a GeoJSON with boundaries and demographic data for your state/region (see next section for details on how to format this file)
 1. Process the GeoJSON (this outputs all the static files DistrictBuilder needs to work in a local directory)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ To create a custom region, you will need a GeoJSON for a state/region at the `co
  * hispanic
  * other
  
-We recommend acquiring data from the US Census Bureau, which typically distributes geographic and demographic files separately. Files for a state/region at the desired level of geographic detail (eg. blockgroup, block) should be acquired and then joined on the unique identifier field (eg. the census geoid/FIPS) into a single GeoJSON.
+For locations in the United States, we recommend acquiring data from the US Census Bureau, which typically distributes geographic and demographic files separately. Files for a state/region at the desired level of geographic detail (eg. blockgroup, block) should be acquired and then joined on the unique identifier field (eg. the census geoid/FIPS) into a single GeoJSON.
 
 When the GeoJSON is ready, use `process-geojson` to process the data and `publish-geojson` to publish the region to S3. 
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,10 @@ Note: when doing this, you will need to restart your server to see the new data,
 #### Acquiring custom data to upload to DistrictBuilder
 To create a custom region, you will need a GeoJSON for a state/region at the `county`, `blockgroup`, or `block` level of detail. The file should include the following properties for each geographic unit:
 
- * geoid (a unique identifier for each geographic unit, eg. census geoid/FIPS)
- * state
- * county_identifier
+ * block (a unique identifier for each geographic unit, eg. census block FIPS code)
+ * blockgroup
+ * county
  * county_name
- * blockgroup_identifier
- * block_identifier
  * population
  * white
  * black


### PR DESCRIPTION
## Overview

This PR adds documentation for how a person/group developing, forking or deploying DistrictBuilder in the future can create GeoJSONs that feed into the `process-geojson` script (the output of which can then be fed into the `publish-region` script). `process-region` is documented assuming you have input data in the correct format already - and the purpose of this PR is to document that format.

### Notes

Assuming the user understands GeoJSON, the key point these new docs emphasize is what fields to include as `properties` in the GeoJSON corresponding to each geographic unit. The properties do not need to be exactly as listed, because the `process-geojson` script allows the user to select a subset of fields and rename fields. 

## Testing Instructions

- Review updates in the [`Development Data`](https://github.com/PublicMapping/districtbuilder#development-data) section of the main repo docs ([`README.md`](https://github.com/PublicMapping/districtbuilder#districtbuilder)).

Closes #1242
