### PR TITLE
Switch PGAdmin setup guide to use aws ssm (Systems Manager)

### DIFF
--- a/deployment/configure_pgadmin.md
+++ b/deployment/configure_pgadmin.md
@@ -3,43 +3,46 @@
 ### Requirements
 
 - [PG Admin](https://www.pgadmin.org/)
-- VPN Access
 - AWS credentials
 
-### Configuration
+The configuration file is written referring to the staging database; however, the same process applies to the production database. Just follow the same instructions, replacing the word "staging" with "production" or Staging with Production.
 
-The configuration file is written referring to the staging database; however, the same process applies to the production database. Just follow the same instructions, replacing the word "staging" with "production".
+
+### Connecting
+1. Find an ec2 instance id like i-0e2796c2ebbfbb048 (not the bastion) either via the console or a command like 
+
+```
+aws ec2 describe-instances --query Reservations[*].Instances[*].[InstanceId,Tags] --filters "Name=tag:Environment,Values=Staging"
+```
+
+2. Then enable port 5432 locally to be connect to the database on the same port.
+
+```
+aws ssm start-session     --target i-0e2796c2ebbfbb048     --document-name AWS-StartPortForwardingSessionToRemoteHost     --parameters '{"host":["database.service.districtbuilder.internal"],"portNumber":["5432"], "localPortNumber":["5432"]}'
+```
+
+3. Connect to PGAdmin with the host set as localhost.
+
+### Configure PGAdmin
 
 To begin, right click "Servers" &#8594; "Create" &#8594; "Server". In the dialog that appears, complete the following:
+
 
 **General Tab**
 
 _Name_<br>
 Give your new server a name. The name can be whatever you choose; however, remember that you need to be able to distinguish between production and staging.
 
+
 **Connection Tab**
 
-_Host Name_<br>
-Locate the Host Name in AWS: All Services &#8594; RDS &#8594; Databases (in the left sidebar) &#8594; districtbuilder-staging &#8594; Connectivity & Security &#8594; Copy link under Endpoint.
+_Host Name_ localhost
 
-_Username and Password_<br>
+_Username, Password and Database Name_<br>
 Return to the AWS management console &#8594; All Services &#8594; S3 &#8594; districtbuilder-staging-config-us-east-1 &#8594; Terraform &#8594; download `terraform.tfvars`. Open the `tfvars` file (it can be opened by a text editor) and find `rds_database_username` and `rds_database_password`.
-
-**SSH Tunnel Tab**
-
-Turn on "Use SSH Tunneling".
-
-_Tunnel Host_<br>
-Return to the AWS management console &#8594; All Services &#8594; EC2 &#8594; Instances (left sidebar) &#8594; select the Staging Bastion. Copy and paste the bastion's public IPv4 address as your tunnel host. Note: If you don't see environment name in your instance table, click on the gear icon to the right and add "environment" as a tag column.
-
-_Username_<br>
-Username is `ec2-user`.
-
-_Authentication_<br>
-Select "Identity File". To find this file, connect to the VPN and navigate to the following location on the fileshare: `fileshare.internal.azavea.com/company/documents_systems_admin/marriagez-rings/DistrictBuilder/AWS`. Note: on MacOS, the documents_systems_admin folder may be hidden. To show hidden files, press and hold Command + shift + dot.
-
-From the fileshare location, save the `districtbuilder-stg.pem` file to somewhere PG Admin can be configured to find it, such as the `.ssh` folder in your home folder. Then return to PG Admin and use the file browser popup to find it.
 
 ---
 
 Click save on the Database Configuration dialog. If you've successfully connected, you'll see metrics appear on your database dashboard.
+
+If you need to troubleshoot you can always do ```aws ssm start-session     --target i-0e2796c2ebbfbb048``` will give you a shell on the ec2 instance. You can also press Connect on the instance in the console.


### PR DESCRIPTION
This just requires AWS credentials - no more keys/VPN.

This is also the last blocker from keeping us moving away from the bastions.

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Confirm you can get PGAdmin connected using the instructions.

