### PR TITLE
Upgrade to VPC that drops bastion and remove other related bits

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -58,10 +58,6 @@ r53_private_hosted_zone = "districtbuilder.internal"
 
 external_access_cidr_block = "127.0.0.1/32"
 
-bastion_ami           = "ami-0fc61db8544a617ed"
-bastion_instance_type = "t3.nano"
-bastion_ebs_optimized = true
-
 rds_database_identifier = districtbuilder-staging
 rds_database_name       = districtbuilder
 rds_database_username   = districtbuilder

--- a/deployment/configure_pgadmin.md
+++ b/deployment/configure_pgadmin.md
@@ -12,7 +12,7 @@ The configuration file is written referring to the staging database; however, th
 ### Connecting
 1. `export AWS_PROFILE=district-builder`
 
-2. Find an ec2 instance id like i-0e2796c2ebbfbb048 (not the bastion) either via the console or a command like 
+2. Find an ec2 instance id like i-0e2796c2ebbfbb048 either via the console or a command like
 
 ```
 aws ec2 describe-instances --query "Reservations[*].Instances[*].[InstanceId,Tags]" --filters "Name=tag:Environment,Values=Staging"

--- a/deployment/terraform/certificate.tf
+++ b/deployment/terraform/certificate.tf
@@ -2,7 +2,7 @@
 # ACM resources
 #
 module "cert" {
-  source = "github.com/azavea/terraform-aws-acm-certificate?ref=3.0.0"
+  source = "github.com/azavea/terraform-aws-acm-certificate?ref=4.0.0"
 
   providers = {
     aws.acm_account     = aws

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -30,14 +30,6 @@ resource "aws_route53_zone" "external" {
   name = var.r53_public_hosted_zone
 }
 
-resource "aws_route53_record" "bastion" {
-  zone_id = aws_route53_zone.external.zone_id
-  name    = "bastion.${var.r53_public_hosted_zone}"
-  type    = "CNAME"
-  ttl     = "300"
-  records = [module.vpc.bastion_hostname]
-}
-
 resource "aws_route53_record" "origin" {
   zone_id = aws_route53_zone.external.zone_id
   name    = "origin.${var.r53_public_hosted_zone}"

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,59 +1,4 @@
 #
-# Bastion security group resources
-#
-resource "aws_security_group_rule" "bastion_ssh_ingress" {
-  type        = "ingress"
-  from_port   = 22
-  to_port     = 22
-  protocol    = "tcp"
-  cidr_blocks = [var.external_access_cidr_block]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-resource "aws_security_group_rule" "bastion_rds_egress" {
-  type      = "egress"
-  from_port = module.database.port
-  to_port   = module.database.port
-  protocol  = "tcp"
-
-  security_group_id        = module.vpc.bastion_security_group_id
-  source_security_group_id = module.database.database_security_group_id
-}
-
-resource "aws_security_group_rule" "bastion_ecs_egress" {
-  type      = "egress"
-  from_port = var.app_port
-  to_port   = var.app_port
-  protocol  = "tcp"
-
-  security_group_id        = module.vpc.bastion_security_group_id
-  source_security_group_id = aws_security_group.app.id
-}
-
-resource "aws_security_group_rule" "bastion_http_egress" {
-  type             = "egress"
-  from_port        = 80
-  to_port          = 80
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-resource "aws_security_group_rule" "bastion_https_egress" {
-  type             = "egress"
-  from_port        = 443
-  to_port          = 443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-#
 # App ALB security group resources
 #
 resource "aws_security_group_rule" "alb_https_ingress" {
@@ -75,19 +20,6 @@ resource "aws_security_group_rule" "alb_ecs_egress" {
 
   security_group_id        = aws_security_group.alb.id
   source_security_group_id = aws_security_group.app.id
-}
-
-#
-# RDS security group resources
-#
-resource "aws_security_group_rule" "rds_bastion_ingress" {
-  type      = "ingress"
-  from_port = module.database.port
-  to_port   = module.database.port
-  protocol  = "tcp"
-
-  security_group_id        = module.database.database_security_group_id
-  source_security_group_id = module.vpc.bastion_security_group_id
 }
 
 resource "aws_security_group_rule" "rds_ecs_ingress" {
@@ -131,14 +63,4 @@ resource "aws_security_group_rule" "ecs_alb_ingress" {
 
   security_group_id        = aws_security_group.app.id
   source_security_group_id = aws_security_group.alb.id
-}
-
-resource "aws_security_group_rule" "ecs_bastion_ingress" {
-  type      = "ingress"
-  from_port = var.app_port
-  to_port   = var.app_port
-  protocol  = "tcp"
-
-  security_group_id        = aws_security_group.app.id
-  source_security_group_id = module.vpc.bastion_security_group_id
 }

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,17 +1,13 @@
 module "vpc" {
-  source = "github.com/azavea/terraform-aws-vpc?ref=6.0.1"
+  source = "git::github.com/azavea/terraform-aws-vpc?ref=7.0.0"
 
   name                       = "vpc${var.project}${var.environment}"
   region                     = var.aws_region
-  key_name                   = var.aws_key_name
   cidr_block                 = var.vpc_cidr_block
   private_subnet_cidr_blocks = var.vpc_private_subnet_cidr_blocks
   public_subnet_cidr_blocks  = var.vpc_public_subnet_cidr_blocks
   availability_zones         = var.aws_availability_zones
-  bastion_ami                = var.bastion_ami
-  bastion_instance_type      = var.bastion_instance_type
-  bastion_ebs_optimized      = var.bastion_ebs_optimized
-
+  
   project     = var.project
   environment = var.environment
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -53,20 +53,6 @@ variable "vpc_public_subnet_cidr_blocks" {
   type    = list(string)
 }
 
-variable "bastion_ami" {
-  type = string
-}
-
-variable "bastion_instance_type" {
-  default = "t3.nano"
-  type    = string
-}
-
-variable "bastion_ebs_optimized" {
-  default = true
-  type    = bool
-}
-
 variable "rds_allocated_storage" {
   default = "32"
   type    = string

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.53.0"
+      version = "~> 3.75.1"
     }
     template = {
       source = "hashicorp/template"


### PR DESCRIPTION
The bastion has been replaced by using AWS SSM and the use of PGadmin was confirmed to work in an earlier commit.

As part of upgrading to the new VPC we had to upgrade Azavea providers and cert versions so that AWS providers versions didn't conflict.

Note from deploying: had to manually remove the bastion security group from the inbound one


### Checklist

Not an app change... (change from SSM is already in Changelog)
- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

- Double check previous commits enabling SSM and PGAdmin access both work as expected.
