### PR TITLE
Specify verbosity in parameter group and set to terse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Enabled SSM to EC2 Hosts [#1259](https://github.com/PublicMapping/districtbuilder/pull/1259)
 - Added support for client-side error-logging with Rollbar [#1264](https://github.com/PublicMapping/districtbuilder/pull/1264)
+- Specify verbosity in parameter group and set to terse. [#1273](https://github.com/PublicMapping/districtbuilder/pull/1273)
 
 ### Changed
 

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -58,6 +58,11 @@ resource "aws_db_parameter_group" "default" {
     value = var.rds_log_autovacuum_min_duration
   }
 
+ parameter {
+    name  = "log_error_verbosity"
+    value = "terse"
+  }
+
   tags = {
     Name        = "dbpgDatabaseServer"
     Project     = var.project
@@ -93,6 +98,7 @@ module "database" {
   storage_encrypted          = var.rds_storage_encrypted
   subnet_group               = aws_db_subnet_group.default.name
   parameter_group            = aws_db_parameter_group.default.name
+  cloudwatch_logs_exports    = null
 
   alarm_cpu_threshold                = var.rds_cpu_threshold_percent
   alarm_disk_queue_threshold         = var.rds_disk_queue_threshold

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -33,6 +33,7 @@ services:
       - GITHUB_SHA
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - DB_DEBUG=1
       - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-districtbuilder-staging-config-us-east-1}
       - DB_ROLLBAR_ACCESS_TOKEN


### PR DESCRIPTION
Verbosity can always be overridden in the live database.

Took two other actions:
 * Stopped copying logs to Cloudwatch - this has cost us a lot in the past (and is redundant to RDS logs)
 * Added AWS session key (how we are transitioning to do ops tasks).

### Checklist

- [ ] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible - these are small changes that may not need an entry.

### Notes

Tried plan on prod and it matches what has been working there.

## Testing Instructions

If no other PRs overwrite what's running in staging right now, both changed values (logs and verbosity) can be confirmed just looking at the DB config and parameter groups.

Closes #1265
