### PR TITLE
Set max_allocated_storage var and switch to updated Terraform db module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated database Terraform module to use the 'max_allocated_storage' param [#1312](https://github.com/PublicMapping/districtbuilder/pull/1312)
+
 ### Fixed
 
 ## [1.19.1]

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -75,14 +75,17 @@ resource "aws_db_parameter_group" "default" {
 }
 
 module "database" {
-  source = "github.com/azavea/terraform-aws-postgresql-rds?ref=3.0.0"
+  # TODO (#1316): go back to github.com/azavea/terraform-aws-postgresql-rds once it's updated
+  # (see https://github.com/azavea/terraform-aws-postgresql-rds/pull/48)
+  source = "github.com/KlaasH/terraform-aws-postgresql-rds?ref=max-allocated-storage"
 
   vpc_id                     = module.vpc.id
   allocated_storage          = var.rds_allocated_storage
+  max_allocated_storage      = var.rds_max_allocated_storage
   engine_version             = var.rds_engine_version
   instance_type              = var.rds_instance_type
   storage_type               = var.rds_storage_type
-  iops                       = var.rds_storage_type == "io1" ? var.rds_iops : null
+  iops                       = var.rds_iops
   database_identifier        = var.rds_database_identifier
   database_name              = var.rds_database_name
   database_username          = var.rds_database_username

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -58,6 +58,11 @@ variable "rds_allocated_storage" {
   type    = string
 }
 
+variable "rds_max_allocated_storage" {
+  default = 0
+  type    = string
+}
+
 variable "rds_engine_version" {
   default = "12.4"
   type    = string


### PR DESCRIPTION
## Overview

In the course of dealing with [issue #1307](https://github.com/PublicMapping/districtbuilder/issues/1307), I switched the database to using storage auto-scaling (and also to the `gp3` storage type).  But [the Terraform module we're using](https://github.com/azavea/terraform-aws-postgresql-rds) for the database config hasn't been updated in a while and doesn't support auto-scaling.  So I wasn't able to update the Terraform config then to match the changes I'd made in the console, but I left it at that.  Turns out, having the deployed state differ from the Terraform config in a way that the config can't even represent is a bad plan, and it bit us, in the form of [an attempt to run the Release](https://github.com/PublicMapping/districtbuilder/actions/runs/5293760757) action crashing and leaving the infrastructure in a somewhat broken in-between state.

So we need to update the Terraform config for the database to match how it is in production, that that's what this does.  It switches to [a fork of the module](https://github.com/KlaasH/terraform-aws-postgresql-rds/tree/max-allocated-storage) that has the `max_allocated_storage` parameter added.

I [opened a PR](https://github.com/azavea/terraform-aws-postgresql-rds/pull/48) on the module repo, but I'm not sure what the maintenance situation is for those modules these days, so I think it makes sense to just use the branch on my fork for now.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

### Demo

I made the same manual change to the staging database that I had made to production (changing to gp3 and turning on auto-scaling) then pushed a test branch to run [a test deploy to staging](https://github.com/PublicMapping/districtbuilder/actions/runs/5326258481/jobs/9648051707).  Per [the logs](https://github.com/PublicMapping/districtbuilder/actions/runs/5326258481/jobs/9648051707#step:6:194), it noticed that the database had been changed outside of Terraform, but didn't find any changes that needed to be applied to it.

## Testing Instructions

With this branch checked out, run the Terraform container:
```
DB_SETTINGS_BUCKET=districtbuilder-production-config-us-east-1 \
  DB_DEPLOYMENT_ENVIRONMENT=production \
  GIT_COMMIT=911fdcb \
  docker-compose -f docker-compose.ci.yml run --rm terraform
```
(that's the currently-deployed git commit, to avoid requiring that the app services get updated)

Inside that container, run `./scripts/infra plan`.  It will show some changes—I think that's a combination of the partial apply from the failed deploy and possibly some drift on the AWS side—but it shouldn't show any changes required for `resource "aws_db_instance" "postgresql"` (whereas if you check out `develop` and run it again, it will).

