### PR TITLE
Make TopologyService refuse to load archived RegionConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated database Terraform module to use the 'max_allocated_storage' param [#1312](https://github.com/PublicMapping/districtbuilder/pull/1312)
+- Made TopologyService check 'archived' status and refuse to load archived layers [#1315](https://github.com/PublicMapping/districtbuilder/pull/1315)
 
 ### Fixed
 

--- a/src/server/src/districts/services/topology.service.ts
+++ b/src/server/src/districts/services/topology.service.ts
@@ -76,6 +76,10 @@ export class TopologyService {
     if (!this._layers) {
       return;
     }
+    if (regionConfig.archived) {
+      this.logger.error(`Tried to load archived RegionConfig ${regionConfig.id}`);
+      return undefined;
+    }
     if (!(regionConfig.s3URI in this._layers)) {
       // If we encounter a new layer (i.e. one added after the service has started),
       // then store the results in the `_layers` object.


### PR DESCRIPTION
## Overview

As described in issue #1314, some endpoint is causing an archived RegionConfig to get added to the layers list, and since it happens to be a broken layer that crashes when you try to load it, it's causing lots of problems.

Ideally we'd know where that request is coming from and fix it (like we did in #1241), but having a check in `TopologyService.get()` will solve the bigger part of the issue, and will be a good thing to have as a failsafe even if we do find the source.

### Checklist

- [x] Description of PR is in an appropriate section of `CHANGELOG.md` and grouped with similar changes, if possible

## Testing Instructions

Since I don't know where the bad call is coming from, the best I can come up with for how to test this would be to modify the code locally to trigger it.  E.g. manually archive a `region_config` instance, then hard-code its ID into one of the calls in `projects.controller.ts` (in either the `createOne` or `duplicateOne` methods), then do the corresponding operation and confirm that it produces the error message.

Closes #1314